### PR TITLE
Adding try catch around tag fetching to prevent deployment failures

### DIFF
--- a/scripts/postman/collection.js
+++ b/scripts/postman/collection.js
@@ -103,6 +103,11 @@ module.exports = class Collection {
       };
       this.folders.push(folder);
     });
+    // Creating a folder for endpoints without tags
+    this.folders.push({
+      name: 'Uncategorized',
+      item: [],
+    });
   }
 
   insertEndpoints() {
@@ -288,11 +293,16 @@ module.exports = class Collection {
    * Finds a folder instance for a given reference category ID
    */
   findFolder(endpoint) {
-    const currentTag = endpoint.tags[0];
-    // first find the folder name
-    const folderName = this.openapi.tags.filter((tag) => tag.name === currentTag)[0].name;
-    // return the first folder to match this name
-    return this.folders.filter((folder) => folder.name === folderName)[0].item;
+    try {
+      const currentTag = endpoint.tags[0];
+      // first find the folder name
+      const folderName = this.openapi.tags.filter((tag) => tag.name === currentTag)[0].name;
+      // return the first folder to match this name
+      return this.folders.filter((folder) => folder.name === folderName)[0].item;
+    } catch (e) {
+      console.error("Couldn't find folder for endpoint", e);
+      return 'Uncategorized';
+    }
   }
 
   pruneEmptyFolders() {


### PR DESCRIPTION
Adding try catch around tag fetching to prevent deployment failures.
[Deployment](https://github.com/intercom/Intercom-OpenAPI/actions/runs/4295667329/attempts/1) failed because  the Tag is [Ticket Type Attributes](https://github.com/intercom/intercom/blob/2930500569964f4f9556597187c694948e43fc51/app/lib/api/open_api/tags/ticket_type_attributes.rb#L8) but the spec is tagged as [TicketTypeAttributes](https://github.com/intercom/intercom/blob/aa4a2a553669314fe366e84c7c5f9e19d53b1ff2/spec/requests/api/v3/ticket_types/ticket_type_attributes_spec.rb#L7)  ( no spaces)

