### PR TITLE
Fixing no endpoint tag issue

### DIFF
--- a/scripts/postman/collection.js
+++ b/scripts/postman/collection.js
@@ -301,7 +301,7 @@ module.exports = class Collection {
       return this.folders.filter((folder) => folder.name === folderName)[0].item;
     } catch (e) {
       console.error("Couldn't find folder for endpoint", e);
-      return 'Uncategorized';
+      return this.folders.filter((folder) => folder.name === 'Uncategorized')[0].item;
     }
   }
 


### PR DESCRIPTION
[Deployment](https://github.com/intercom/Intercom-OpenAPI/actions/runs/4438375783/jobs/7789338021) of changes https://github.com/intercom/Intercom-OpenAPI/pull/64 to postman collection has failed. 

It failed because we couldn't find a 'tag' to place the endpoint into. 
This PR updates the catch to correctly handle this. 