### PR TITLE
Add attachment files to conversation reply 

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991268286'
+                    id: '991267540'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1709227259
+                      created_at: 1709286889
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991268287'
+                    id: '991267541'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 54795f10-2e16-4d26-8191-dc398b5ecb2b
+                    request_id: 754d9f8b-7907-40d3-a988-062057c6be9d
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8b54612f-b786-414f-89e1-07fd9b20b744
+                    request_id: 1c7c7e86-9cec-4fec-8bf6-82dc933e8f9e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: edeb6317-64d8-40a8-8d55-0e1b24e12405
+                    - id: 89183260-d8f2-428f-be9d-cd599d5703bc
                       performed_by:
                         type: admin
-                        id: '991268291'
+                        id: '991267545'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1709227265
+                      created_at: 1709286895
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: a0ed01e2-5812-48b3-9193-b800af91cf7c
+                    - id: c4df6dbf-2e80-421b-9824-50b904e35b59
                       performed_by:
                         type: admin
-                        id: '991268291'
+                        id: '991267545'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1709227265
+                      created_at: 1709286895
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a172cc31-bd28-4dd5-a06a-6add5ad89f38
+                    request_id: 3b814485-4fd2-44dc-bc15-69335f2762be
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991268293'
+                      id: '991267547'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f03eba4b-25f4-46dc-a298-68e51ccc05b5
+                    request_id: 5849d646-a7e1-4d4e-84bb-e42991f2a958
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991268295'
+                    id: '991267549'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: f281efca-c9c0-41a8-a019-094a224b99de
+                    request_id: a8fb93de-5694-411c-a553-9cb37a36a7b1
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 47b9bedd-6fcc-4f6a-9cd2-7e5c4640b3a0
+                    request_id: b752020c-fda2-45c4-95a6-1eb9d2857e75
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -379,30 +379,30 @@ paths:
                 successful:
                   value:
                     data:
-                    - id: 1
+                    - id: 49
                       type: content_import_source
-                      last_synced_at: 1709227268
+                      last_synced_at: 1709286898
                       status: active
                       url: https://support.example.com/us/1
                       sync_behavior: automatic
-                      created_at: 1709227268
-                      updated_at: 1709227268
-                    - id: 2
+                      created_at: 1709286898
+                      updated_at: 1709286898
+                    - id: 50
                       type: content_import_source
-                      last_synced_at: 1709227268
+                      last_synced_at: 1709286898
                       status: active
                       url: https://support.example.com/us/2
                       sync_behavior: automatic
-                      created_at: 1709227268
-                      updated_at: 1709227268
-                    - id: 3
+                      created_at: 1709286898
+                      updated_at: 1709286898
+                    - id: 51
                       type: content_import_source
-                      last_synced_at: 1709227268
+                      last_synced_at: 1709286898
                       status: active
                       url: https://support.example.com/us/3
                       sync_behavior: automatic
-                      created_at: 1709227268
-                      updated_at: 1709227268
+                      created_at: 1709286898
+                      updated_at: 1709286898
                     pages:
                       type: pages
                       page: 1
@@ -420,7 +420,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 24e37f58-599e-4217-a85b-62f49b0b32e1
+                    request_id: 6813f9ca-f5ff-4e84-98db-31a03f5141ba
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -446,14 +446,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 4
+                    id: 52
                     type: content_import_source
-                    last_synced_at: 1709227269
+                    last_synced_at: 1709286899
                     status: active
                     url: https://www.example.com
                     sync_behavior: api
-                    created_at: 1709227269
-                    updated_at: 1709227269
+                    created_at: 1709286899
+                    updated_at: 1709286899
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -464,7 +464,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ae33bfca-7b66-4877-b5a5-577e27464538
+                    request_id: d63a09cd-1efc-4722-9275-bff2ea563936
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -514,7 +514,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 97f99a0b-5afa-49b1-85a7-f41e5ae333d2
+                    request_id: e31a19fd-dad4-44a2-bf78-c847c47c8c01
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -538,14 +538,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 6
+                    id: 54
                     type: content_import_source
-                    last_synced_at: 1709227271
+                    last_synced_at: 1709286901
                     status: active
                     url: https://support.example.com/us/5
                     sync_behavior: api
-                    created_at: 1709227271
-                    updated_at: 1709227271
+                    created_at: 1709286901
+                    updated_at: 1709286901
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -556,7 +556,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9e254c94-8000-4d2e-84f5-18c935d14835
+                    request_id: ab0f09d1-d6c2-4621-af40-a6a3c6112e7b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -581,14 +581,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 7
+                    id: 55
                     type: content_import_source
-                    last_synced_at: 1709227271
+                    last_synced_at: 1709286902
                     status: active
                     url: https://www.example.com
                     sync_behavior: api
-                    created_at: 1709227271
-                    updated_at: 1709227272
+                    created_at: 1709286902
+                    updated_at: 1709286902
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -599,7 +599,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0e6321a1-fdc9-42bd-b8bb-55894f3394fd
+                    request_id: 0ea751d5-8dd1-43bf-b27b-d9e8fd269e90
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -637,42 +637,42 @@ paths:
                 successful:
                   value:
                     data:
-                    - id: '3'
+                    - id: '27'
                       type: external_page
                       title: My External Content
                       html: "<h1>Hello world</h1><p>This is external content</p>"
                       url: https://support.example.com/us/3
                       fin_availability: true
                       locale: en
-                      source_id: 10
+                      source_id: 58
                       external_id: '3'
-                      created_at: 1709227273
-                      updated_at: 1709227273
-                      last_ingested_at: 1709227273
-                    - id: '2'
+                      created_at: 1709286903
+                      updated_at: 1709286903
+                      last_ingested_at: 1709286903
+                    - id: '26'
                       type: external_page
                       title: My External Content
                       html: "<h1>Hello world</h1><p>This is external content</p>"
                       url: https://support.example.com/us/2
                       fin_availability: true
                       locale: en
-                      source_id: 9
+                      source_id: 57
                       external_id: '2'
-                      created_at: 1709227273
-                      updated_at: 1709227273
-                      last_ingested_at: 1709227273
-                    - id: '1'
+                      created_at: 1709286903
+                      updated_at: 1709286903
+                      last_ingested_at: 1709286903
+                    - id: '25'
                       type: external_page
                       title: My External Content
                       html: "<h1>Hello world</h1><p>This is external content</p>"
                       url: https://support.example.com/us/1
                       fin_availability: true
                       locale: en
-                      source_id: 8
+                      source_id: 56
                       external_id: '1'
-                      created_at: 1709227273
-                      updated_at: 1709227273
-                      last_ingested_at: 1709227273
+                      created_at: 1709286903
+                      updated_at: 1709286903
+                      last_ingested_at: 1709286903
                     pages:
                       type: pages
                       page: 1
@@ -690,7 +690,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4a7e1a55-b5cd-4c79-a294-9d08782363f3
+                    request_id: 78faddc5-9adc-46c9-84ed-1fa1f11d57e1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -717,18 +717,18 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '5'
+                    id: '29'
                     type: external_page
                     title: Test
                     html: "<html><body><h1>Test</h1></body></html>"
                     url: https://www.example.com
                     fin_availability: true
                     locale: en
-                    source_id: 12
+                    source_id: 60
                     external_id: abc1234
-                    created_at: 1709227274
-                    updated_at: 1709227274
-                    last_ingested_at: 1709227274
+                    created_at: 1709286904
+                    updated_at: 1709286905
+                    last_ingested_at: 1709286905
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -739,7 +739,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 23697940-cb60-4c8e-881a-549fa5277806
+                    request_id: 923e2966-fcb6-43a9-9804-8b823804b4a5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -757,7 +757,7 @@ paths:
                   external_id: abc1234
                   html: "<html><body><h1>Test</h1></body></html>"
                   locale: en
-                  source_id: 12
+                  source_id: 60
                   title: Test
                   url: https://www.example.com
   "/ai/external_pages/{id}":
@@ -788,18 +788,18 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '6'
+                    id: '30'
                     type: external_page
                     title: My External Content
                     html: "<h1>Hello world</h1><p>This is external content</p>"
                     url: https://support.example.com/us/5
                     fin_availability: true
                     locale: en
-                    source_id: 13
+                    source_id: 61
                     external_id: '4'
-                    created_at: 1709227275
-                    updated_at: 1709227275
-                    last_ingested_at: 1709227275
+                    created_at: 1709286905
+                    updated_at: 1709286905
+                    last_ingested_at: 1709286905
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -810,7 +810,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4e9fd4c0-b73b-445b-a30f-8c85171ac613
+                    request_id: 26d706dc-c955-4994-b893-a26710037b94
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -835,18 +835,18 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '7'
+                    id: '31'
                     type: external_page
                     title: My External Content
                     html: "<h1>Hello world</h1><p>This is external content</p>"
                     url: https://support.example.com/us/6
                     fin_availability: true
                     locale: en
-                    source_id: 14
+                    source_id: 62
                     external_id: '5'
-                    created_at: 1709227276
-                    updated_at: 1709227276
-                    last_ingested_at: 1709227276
+                    created_at: 1709286906
+                    updated_at: 1709286906
+                    last_ingested_at: 1709286906
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -857,7 +857,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ac2b7b20-ebd8-4738-8a3c-06f4a010b039
+                    request_id: 126906c4-02a9-4ba6-94d4-3193fe74076a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -883,18 +883,18 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '8'
+                    id: '32'
                     type: external_page
                     title: Test
                     html: "<html><body><h1>Test</h1></body></html>"
                     url: https://www.example.com
                     fin_availability: true
                     locale: en
-                    source_id: 15
+                    source_id: 63
                     external_id: '5678'
-                    created_at: 1709227277
-                    updated_at: 1709227277
-                    last_ingested_at: 1709227277
+                    created_at: 1709286907
+                    updated_at: 1709286907
+                    last_ingested_at: 1709286907
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -905,7 +905,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 69ec6002-11c5-45fe-a9f5-c3fe72c6f3c3
+                    request_id: 4fccc53c-4dec-4e2a-9460-5a248cf2172b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -923,7 +923,7 @@ paths:
                   external_id: '5678'
                   html: "<html><body><h1>Test</h1></body></html>"
                   locale: en
-                  source_id: 15
+                  source_id: 63
                   title: Test
                   url: https://www.example.com
   "/articles":
@@ -958,20 +958,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '76'
+                    - id: '74'
                       type: article
                       workspace_id: this_is_an_id64_that_should_be_at_least_4
-                      parent_id: 292
+                      parent_id: 229
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991268319
+                      author_id: 991267573
                       state: published
-                      created_at: 1709227277
-                      updated_at: 1709227277
-                      url: http://help-center.test/myapp-64/en/articles/76-this-is-the-article-title
+                      created_at: 1709286908
+                      updated_at: 1709286908
+                      url: http://help-center.test/myapp-64/en/articles/74-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -982,7 +982,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 84581b53-bb79-434e-ae63-d6832ae49ef4
+                    request_id: e4334ed4-fcc6-4a74-a6cf-359293f97f0b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1007,10 +1007,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '79'
+                    id: '77'
                     type: article
                     workspace_id: this_is_an_id68_that_should_be_at_least_4
-                    parent_id: 294
+                    parent_id: 231
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1024,11 +1024,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991268324
+                    author_id: 991267578
                     state: published
-                    created_at: 1709227280
-                    updated_at: 1709227280
-                    url: http://help-center.test/myapp-68/en/articles/79-thanks-for-everything
+                    created_at: 1709286910
+                    updated_at: 1709286910
+                    url: http://help-center.test/myapp-68/en/articles/77-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -1039,7 +1039,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 0b2faa66-03d2-4e6e-ab4e-e78cb2c6dd67
+                    request_id: ebb2caa5-062d-404b-bbcd-d85b6174fa4c
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -1054,7 +1054,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b043a5ca-d454-4175-ac17-f6688dd7d1b3
+                    request_id: 4afcfcbe-d615-4aaa-b50a-a6b173bc1f87
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1072,16 +1072,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991268324
+                  author_id: 991267578
                   state: published
-                  parent_id: 294
+                  parent_id: 231
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991268324
+                      author_id: 991267578
                       state: published
               bad_request:
                 summary: Bad Request
@@ -1118,10 +1118,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '82'
+                    id: '80'
                     type: article
                     workspace_id: this_is_an_id74_that_should_be_at_least_4
-                    parent_id: 297
+                    parent_id: 234
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1135,11 +1135,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991268329
+                    author_id: 991267583
                     state: published
-                    created_at: 1709227281
-                    updated_at: 1709227281
-                    url: http://help-center.test/myapp-74/en/articles/82-this-is-the-article-title
+                    created_at: 1709286912
+                    updated_at: 1709286912
+                    url: http://help-center.test/myapp-74/en/articles/80-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -1150,7 +1150,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: 694c4c87-5396-4a57-879d-e53f7a79536b
+                    request_id: 87183e02-4ca7-4159-afd2-6e24a71af1df
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1164,7 +1164,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3fcd8967-4d07-49b9-a9ff-3508ceee05e4
+                    request_id: 239c2a09-3151-4437-bda2-2f5815a98120
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1197,10 +1197,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '85'
+                    id: '83'
                     type: article
                     workspace_id: this_is_an_id80_that_should_be_at_least_4
-                    parent_id: 300
+                    parent_id: 237
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1214,11 +1214,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991268335
+                    author_id: 991267589
                     state: published
-                    created_at: 1709227283
-                    updated_at: 1709227284
-                    url: http://help-center.test/myapp-80/en/articles/85-christmas-is-here
+                    created_at: 1709286914
+                    updated_at: 1709286915
+                    url: http://help-center.test/myapp-80/en/articles/83-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -1229,7 +1229,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 6e8cd0df-88ee-4aae-bb06-e8c9e81f2d1c
+                    request_id: ca7350e0-8355-46d2-906c-8b8f1db67737
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1243,7 +1243,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5f465e7b-f583-4918-bf9f-85617c1daa52
+                    request_id: decf7c39-edb5-46a1-aed7-191873d37df0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1291,7 +1291,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '88'
+                    id: '86'
                     object: article
                     deleted: true
               schema:
@@ -1304,7 +1304,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 7e4df0b7-4538-4e2c-9e8d-6809a46e94d8
+                    request_id: 16971753-c593-419b-ada5-d4114f033596
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1318,7 +1318,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 012d0d8b-1a8f-4cfd-ad09-c4a3062e13e9
+                    request_id: 1c38e1c2-b29e-4a43-b6f2-56b152f2639a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1378,7 +1378,7 @@ paths:
                     total_count: 1
                     data:
                       articles:
-                      - id: '92'
+                      - id: '90'
                         type: article
                         workspace_id: this_is_an_id92_that_should_be_at_least_4
                         parent_id:
@@ -1387,10 +1387,10 @@ paths:
                         title: Title 1
                         description: ''
                         body: ''
-                        author_id: 991268348
+                        author_id: 991267602
                         state: draft
-                        created_at: 1709227288
-                        updated_at: 1709227288
+                        created_at: 1709286919
+                        updated_at: 1709286919
                         url:
                       highlights: []
                     pages:
@@ -1408,7 +1408,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 81117099-4e0f-4a9f-a7dc-c17d97edef30
+                    request_id: c7ad6e84-de4a-4b33-acf7-6e90e382114c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1439,27 +1439,27 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '308'
+                    - id: '245'
                       workspace_id: this_is_an_id96_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-96/collection-17
                       order: 17
-                      created_at: 1709227289
-                      updated_at: 1709227289
+                      created_at: 1709286921
+                      updated_at: 1709286921
                       description: english collection description
                       icon: bookmark
                       parent_id:
-                      help_center_id: 160
-                    - id: '309'
+                      help_center_id: 125
+                    - id: '246'
                       workspace_id: this_is_an_id96_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-96/section-1
                       order: 1
-                      created_at: 1709227289
-                      updated_at: 1709227289
+                      created_at: 1709286921
+                      updated_at: 1709286921
                       description:
                       icon: bookmark
-                      parent_id: '308'
+                      parent_id: '245'
                       help_center_id:
                     total_count: 2
                     pages:
@@ -1477,7 +1477,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bf8541ac-ea3d-4ad9-a65d-32663b98c838
+                    request_id: 474965fa-befa-4efc-91b7-475fa5bf8d4d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1502,17 +1502,17 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '314'
+                    id: '251'
                     workspace_id: this_is_an_id100_that_should_be_at_least_
                     name: Thanks for everything
                     url: http://help-center.test/myapp-100/
                     order: 1
-                    created_at: 1709227290
-                    updated_at: 1709227290
+                    created_at: 1709286922
+                    updated_at: 1709286922
                     description: ''
                     icon: book-bookmark
                     parent_id:
-                    help_center_id: 162
+                    help_center_id: 127
               schema:
                 "$ref": "#/components/schemas/collection"
         '400':
@@ -1523,7 +1523,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: '0689bf69-8f09-462e-b56e-827e5857d7da'
+                    request_id: 2aaf30f0-b7dd-4ee3-bacf-8802c0d1c70a
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -1537,7 +1537,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4f82b6c0-f50a-4889-85a1-900cdc26e14d
+                    request_id: 2ee64b07-2059-495c-a5c8-749cb1b0ef03
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1585,17 +1585,17 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '319'
+                    id: '256'
                     workspace_id: this_is_an_id106_that_should_be_at_least_
                     name: English collection title
                     url: http://help-center.test/myapp-106/collection-22
                     order: 22
-                    created_at: 1709227291
-                    updated_at: 1709227291
+                    created_at: 1709286923
+                    updated_at: 1709286923
                     description: english collection description
                     icon: bookmark
                     parent_id:
-                    help_center_id: 165
+                    help_center_id: 130
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1606,7 +1606,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 27ff18bb-59b4-4e6e-9f3d-606f4b5541ac
+                    request_id: db0df8bd-3ef7-4e37-a2b8-2e77c9401524
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1620,7 +1620,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a845013c-cc69-409c-b00e-3e2f90dadee0
+                    request_id: 46470afd-3330-47c0-9bdc-47ee7bc6614d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1653,17 +1653,17 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '325'
+                    id: '262'
                     workspace_id: this_is_an_id112_that_should_be_at_least_
                     name: Update collection name
                     url: http://help-center.test/myapp-112/collection-25
                     order: 25
-                    created_at: 1709227293
-                    updated_at: 1709227293
+                    created_at: 1709286925
+                    updated_at: 1709286925
                     description: english collection description
                     icon: folder
                     parent_id:
-                    help_center_id: 168
+                    help_center_id: 133
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1674,7 +1674,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: 341995f3-74c3-4eca-90da-95303f5f5d7c
+                    request_id: 10b55445-28dd-414b-8d52-e077ffbb749e
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1688,7 +1688,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 00f35cac-5152-4cb3-900b-43c13cda4c1f
+                    request_id: f46944cb-c294-4622-aaef-2ab3ab8cfbf3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1735,7 +1735,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '331'
+                    id: '268'
                     object: collection
                     deleted: true
               schema:
@@ -1748,7 +1748,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: 7224355e-c512-4368-9372-6883baac6401
+                    request_id: b7e44c82-9c68-4db3-bb4a-ee7e456c4eb9
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1762,7 +1762,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6db12af4-1c1d-46f5-8b46-8dd74b36624f
+                    request_id: ef86f961-4d06-4287-9f1c-906f33eed783
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1796,10 +1796,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '174'
+                    id: '139'
                     workspace_id: this_is_an_id124_that_should_be_at_least_
-                    created_at: 1709227296
-                    updated_at: 1709227296
+                    created_at: 1709286928
+                    updated_at: 1709286928
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1813,7 +1813,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 30e89201-f289-4c8a-a8c2-8cbefa8b505c
+                    request_id: cd4be5ed-5d0b-4116-9079-03d7d1a9b9ee
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1827,7 +1827,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6337f5eb-aa86-4f4a-8cd2-5ab0eabbd173
+                    request_id: 55afb1f6-b2de-4fee-ba12-6ab8bdccccc2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1865,7 +1865,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b7f64115-7860-4526-8803-a3bad2f1bc61
+                    request_id: bab90703-c7b7-4cb7-945b-6831bbab689e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1898,12 +1898,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 65e0bd246abd0181dac14ef4
+                    id: 65e1a616ba4d122e24b98797
                     app_id: this_is_an_id147_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1709227300
-                    updated_at: 1709227300
+                    created_at: 1709286934
+                    updated_at: 1709286934
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1940,7 +1940,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 45b26691-9a65-45ee-98d7-30ee91448cff
+                    request_id: e88b3260-1fa6-4263-8c7e-d1f8f1cbe04b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2038,12 +2038,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0bd266abd0181dac14efc
+                      id: 65e1a618ba4d122e24b9879f
                       app_id: this_is_an_id153_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709227302
-                      created_at: 1709227302
-                      updated_at: 1709227302
+                      remote_created_at: 1709286936
+                      created_at: 1709286936
+                      updated_at: 1709286936
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2072,7 +2072,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 5f856eca-5dc1-4f36-9714-f5a428306112
+                    request_id: e8d07e4a-a346-42cf-86a6-a6db30e1c6cb
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2086,7 +2086,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 75cbcec8-afb7-4b63-9f72-7b14ab543d98
+                    request_id: beb1ae54-8e6e-453f-9ea4-2ea936075b0d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2121,12 +2121,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0bd286abd0181dac14f07
+                    id: 65e1a61aba4d122e24b987aa
                     app_id: this_is_an_id159_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1709227304
-                    created_at: 1709227304
-                    updated_at: 1709227304
+                    remote_created_at: 1709286938
+                    created_at: 1709286938
+                    updated_at: 1709286938
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2148,7 +2148,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 8d7ce2c1-f996-412b-bb21-4ff0b356d39b
+                    request_id: 4c2636ed-0934-4b66-9d07-55ab4c3a9551
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2162,7 +2162,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 65856b5a-9729-4b62-b5a6-afb36ac54b66
+                    request_id: 5eeb001f-8a6d-4e4d-a11d-4a0b12450292
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2196,12 +2196,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0bd2a6abd0181dac14f11
+                    id: 65e1a61dba4d122e24b987b4
                     app_id: this_is_an_id165_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1709227306
-                    created_at: 1709227306
-                    updated_at: 1709227306
+                    remote_created_at: 1709286941
+                    created_at: 1709286941
+                    updated_at: 1709286941
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2223,7 +2223,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 83622035-b6f5-4968-b449-5f50ff59f625
+                    request_id: 82282427-ba89-4126-b6a5-84172a9d911e
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2237,7 +2237,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 45fb64be-650e-4aee-a7b6-8fe98c153315
+                    request_id: 548851a4-4284-4151-b9db-00709e12bd62
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2269,7 +2269,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 65e0bd2c6abd0181dac14f1b
+                    id: 65e1a61fba4d122e24b987be
                     object: company
                     deleted: true
               schema:
@@ -2282,7 +2282,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 7544c7f7-ffb5-4659-896e-20d90ff5ff7a
+                    request_id: 39792775-08e3-4677-b81b-81f2f024786f
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2296,7 +2296,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 58a5d151-5ecf-4a69-9bf5-531bcb33c2fb
+                    request_id: eb3e33d7-478f-4526-844f-17b5a4b35c1c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2348,7 +2348,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 5db8c0c6-25c9-42d1-9c74-8c34b4382a26
+                    request_id: 90ab08e2-3a21-4d18-b0df-55430020bb08
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2362,7 +2362,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 91a1467e-0dfe-4d4c-b6ff-67f51569caff
+                    request_id: 4d608894-468b-4ab5-98b3-901d0ef357c4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2407,7 +2407,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: b313b826-0d8b-4739-a840-894e3dd387ad
+                    request_id: 011a51f0-20d2-45c0-bbe9-500d7b9eb0a5
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2421,7 +2421,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 780b0a22-c230-42b5-a523-93fa4890504c
+                    request_id: a4e49255-84b7-4de4-a7a2-35a3e41d3a5b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2478,12 +2478,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0bd326abd0181dac14f37
+                      id: 65e1a625ba4d122e24b987da
                       app_id: this_is_an_id189_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709227314
-                      created_at: 1709227314
-                      updated_at: 1709227314
+                      remote_created_at: 1709286949
+                      created_at: 1709286949
+                      updated_at: 1709286949
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2512,7 +2512,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 66c37218-78bf-4d96-bb3f-9eab8ec3ae52
+                    request_id: 3a835c5c-92cc-49f4-a764-a1d4fc589532
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2564,12 +2564,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0bd336abd0181dac14f3d
+                      id: 65e1a627ba4d122e24b987e0
                       app_id: this_is_an_id193_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709227315
-                      created_at: 1709227315
-                      updated_at: 1709227315
+                      remote_created_at: 1709286951
+                      created_at: 1709286951
+                      updated_at: 1709286951
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2583,7 +2583,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: 242635b3-4b61-4db9-aba3-3380a04175ce
+                    scroll_param: 6f2165a3-aa41-4dc9-9699-0b9cddd89d07
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2594,7 +2594,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '089f2003-59da-4f21-8793-d6f5f2b2b7be'
+                    request_id: '0759edb0-3295-4aba-b2f7-d9d8e75d7e3e'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2629,12 +2629,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0bd356abd0181dac14f46
+                    id: 65e1a629ba4d122e24b987e9
                     app_id: this_is_an_id197_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1709227317
-                    created_at: 1709227317
-                    updated_at: 1709227317
+                    remote_created_at: 1709286953
+                    created_at: 1709286953
+                    updated_at: 1709286953
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2656,7 +2656,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 32cc5736-b69b-4827-879f-20e7ce2c9308
+                    request_id: e082613d-3f37-42bf-b4f9-baa36e9b666f
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2670,7 +2670,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: a8b64fbd-dece-4157-a087-0cfc8386920f
+                    request_id: 4efb5899-b9b6-4f3b-8330-f97931103f8a
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2684,7 +2684,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '007994dd-4656-4604-9068-68dbdc575850'
+                    request_id: d22e6138-5cb6-4e42-99f7-705f6a825e04
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2707,7 +2707,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 65e0bd356abd0181dac14f46
+                  id: 65e1a629ba4d122e24b987e9
               bad_request:
                 summary: Bad Request
                 value:
@@ -2746,13 +2746,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 65e0bd3b6abd0181dac14f67
+                      id: 65e1a62fba4d122e24b9880a
                       app_id: this_is_an_id213_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1709227323
-                      created_at: 1709227323
-                      updated_at: 1709227323
-                      last_request_at: 1709054523
+                      remote_created_at: 1709286959
+                      created_at: 1709286959
+                      updated_at: 1709286959
+                      last_request_at: 1709114159
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2781,7 +2781,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 8748c7e7-760a-494e-8a25-72c691aa2680
+                    request_id: 4aa657fb-bf8d-424b-b747-81791251d1b1
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2795,7 +2795,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3ba429c7-6536-4999-abd4-9c6fab2f9ff3
+                    request_id: 34ce2af3-8c45-49cf-a2dd-e2b73babc50a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2838,12 +2838,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0bd386abd0181dac14f56
+                    id: 65e1a62cba4d122e24b987f9
                     app_id: this_is_an_id205_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1709227320
-                    created_at: 1709227320
-                    updated_at: 1709227320
+                    remote_created_at: 1709286956
+                    created_at: 1709286956
+                    updated_at: 1709286956
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2865,14 +2865,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: ade089e6-3056-438f-b74e-137df59d5ff7
+                    request_id: c9bbe49b-e571-4c15-b20a-4f992f7ef727
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: d429b68d-0e46-44b4-94b0-64276c573182
+                    request_id: 34b058b7-7cec-49e3-8122-f9c5b87b538d
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2886,7 +2886,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c97e9f1f-a2e2-4005-acf0-22667769d577
+                    request_id: 772de109-1a4c-455a-bd8d-41eb39455413
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2922,42 +2922,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '55'
-                      created_at: 1708622525
+                      id: '39'
+                      created_at: 1708682162
                       contact:
                         type: contact
-                        id: 65e0bd3d6abd0181dac14f72
+                        id: 65e1a632ba4d122e24b98815
                       author:
                         type: admin
-                        id: '991268408'
+                        id: '991267662'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '54'
-                      created_at: 1708536125
+                      id: '38'
+                      created_at: 1708595762
                       contact:
                         type: contact
-                        id: 65e0bd3d6abd0181dac14f72
+                        id: 65e1a632ba4d122e24b98815
                       author:
                         type: admin
-                        id: '991268408'
+                        id: '991267662'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '53'
-                      created_at: 1708536125
+                      id: '37'
+                      created_at: 1708595762
                       contact:
                         type: contact
-                        id: 65e0bd3d6abd0181dac14f72
+                        id: 65e1a632ba4d122e24b98815
                       author:
                         type: admin
-                        id: '991268408'
+                        id: '991267662'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
@@ -2980,7 +2980,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 60ff1ad4-41ba-4c9f-85a4-3e3521138d97
+                    request_id: 414b4497-e067-4d76-be40-50cfe984daf1
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3014,14 +3014,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '60'
-                    created_at: 1709227327
+                    id: '44'
+                    created_at: 1709286964
                     contact:
                       type: contact
-                      id: 65e0bd3e6abd0181dac14f74
+                      id: 65e1a633ba4d122e24b98817
                     author:
                       type: admin
-                      id: '991268410'
+                      id: '991267664'
                       name: Ciaran124 Lee
                       email: admin124@email.com
                       away_mode_enabled: false
@@ -3037,14 +3037,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 1fc73d95-9054-4bcc-8ac8-8632d1933c4d
+                    request_id: 733b3d53-2a32-4ba5-b609-cef3ac302f91
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 5a9be556-2ce2-4b90-82f4-c552ed2de763
+                    request_id: 38f33aac-a246-4dd9-9ff0-854522ab7021
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3074,20 +3074,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 65e0bd3e6abd0181dac14f74
-                  admin_id: 991268410
+                  contact_id: 65e1a633ba4d122e24b98817
+                  admin_id: 991267664
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 65e0bd3f6abd0181dac14f75
+                  contact_id: 65e1a634ba4d122e24b98818
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991268412
+                  admin_id: 991267666
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -3120,10 +3120,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 65e0bd406abd0181dac14f77
+                      id: 65e1a635ba4d122e24b9881a
                       name: segment
-                      created_at: 1709227328
-                      updated_at: 1709227328
+                      created_at: 1709286965
+                      updated_at: 1709286965
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -3135,7 +3135,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 495aa406-126d-4e5e-a353-ac5aed8b9b46
+                    request_id: dba77c93-01c2-4944-98b0-3446a7791ded
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3149,7 +3149,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a0ccd30b-642b-4cb6-b6f2-ed7bcc06ff3b
+                    request_id: 98a9c158-1f21-44ea-b6e2-189ab7ff25a6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3193,7 +3193,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '185'
+                      id: '137'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -3207,7 +3207,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '187'
+                      id: '139'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -3230,7 +3230,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 02222b72-e2db-464f-b43b-da71c97d9800
+                    request_id: 9a66567c-9633-4d0b-8b4f-e803db72e6dd
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3244,7 +3244,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 60fc0a6f-28ad-4810-8dcb-bc5c1f44ae9b
+                    request_id: 23dbf80d-2c93-478b-bb18-d400626ed5bb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3285,7 +3285,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '200'
+                    id: '152'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3308,14 +3308,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 22de4d21-822c-43f3-9f49-ef6216410028
+                    request_id: 2d0d35be-10fc-43d3-b9ea-c8ecf9e6e55b
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 333af9dc-989c-404b-84df-1b21002b3957
+                    request_id: 4c6783c3-c8a3-4d2d-90c7-0fc16d45871a
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3329,7 +3329,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 19da2731-ded4-42b1-97ef-4fef08dbb59e
+                    request_id: dc1b3e70-b319-47d6-8e4e-7d567312695b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3357,12 +3357,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 200
+                  id: 152
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 204
+                  id: 156
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -3408,7 +3408,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '216'
+                    id: '168'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3431,14 +3431,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: c91569a3-427e-40b8-a097-2cde6a4ccff1
+                    request_id: 6bd5288c-e72f-4a6a-9ba6-239a5e4612e7
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 9d32059b-41fd-4eea-8800-526e14babe5a
+                    request_id: e938659e-0ce6-4e0b-9802-84126cd8e245
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3452,7 +3452,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 788c3c87-9744-49a4-a733-604ed0e85f5b
+                    request_id: 4caa1b58-d50d-4a01-9db5-ceb9e30f4519
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3490,7 +3490,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '170'
+                      id: '102'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -3502,7 +3502,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 87cf8d6d-08b3-4623-9e3a-afed4b99baa5
+                    request_id: 8795dc5b-3043-46bf-92f8-6adedad27349
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3516,7 +3516,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 81b2ec71-b5fa-4d53-b059-6a283af7736a
+                    request_id: d85e07d0-df98-4347-9dbe-ab3cb4d1a67d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3551,7 +3551,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '171'
+                    id: '103'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3563,14 +3563,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: bc82f03f-17a5-4cb2-85c6-43664accc132
+                    request_id: 6bac71a0-2142-47c9-b4ec-cd80a329ee62
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 92e1e4c2-6c3b-41d6-8602-22c0da5460dc
+                    request_id: 9951a02d-4e7b-47fc-bb1a-f8567073dbce
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3584,7 +3584,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 751cd910-30b7-4db7-b306-d06c43857b3b
+                    request_id: 9c482020-dd24-4a6d-b0a6-8cb54713731a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3607,11 +3607,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 171
+                  id: 103
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 172
+                  id: 104
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3653,7 +3653,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '174'
+                    id: '106'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3665,14 +3665,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: fce1e084-533d-4d7c-a9f4-6152e8d2f8e0
+                    request_id: 8e57e159-c888-4f5e-b541-1e9afb1e8817
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 2b4dbc0b-16cd-4b42-a958-d6cbff05aed8
+                    request_id: 72d29ac2-b6e8-4a51-be66-b1136c0b5222
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3686,7 +3686,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 45857bf6-c3cf-4552-8f3c-509d623970bc
+                    request_id: b9189fef-26d2-4e44-9d00-284e75b9b8ed
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3720,7 +3720,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0bd4d6abd0181dac14f8e
+                    id: 65e1a643ba4d122e24b98831
                     workspace_id: this_is_an_id279_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3736,9 +3736,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709227341
-                    updated_at: 1709227341
-                    signed_up_at: 1709227341
+                    created_at: 1709286979
+                    updated_at: 1709286979
+                    signed_up_at: 1709286979
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3772,31 +3772,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd4d6abd0181dac14f8e/tags"
+                      url: "/contacts/65e1a643ba4d122e24b98831/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd4d6abd0181dac14f8e/notes"
+                      url: "/contacts/65e1a643ba4d122e24b98831/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd4d6abd0181dac14f8e/companies"
+                      url: "/contacts/65e1a643ba4d122e24b98831/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd4d6abd0181dac14f8e/subscriptions"
+                      url: "/contacts/65e1a643ba4d122e24b98831/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd4d6abd0181dac14f8e/subscriptions"
+                      url: "/contacts/65e1a643ba4d122e24b98831/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3815,7 +3815,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 98b29696-f5f0-4c7f-b924-7cd544dc8fb2
+                    request_id: 73367ac4-954f-49b1-9b85-3e1d2272e5bf
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3860,7 +3860,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0bd4e6abd0181dac14f8f
+                    id: 65e1a644ba4d122e24b98832
                     workspace_id: this_is_an_id283_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3876,9 +3876,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709227342
-                    updated_at: 1709227342
-                    signed_up_at: 1709227342
+                    created_at: 1709286980
+                    updated_at: 1709286980
+                    signed_up_at: 1709286980
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3912,31 +3912,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd4e6abd0181dac14f8f/tags"
+                      url: "/contacts/65e1a644ba4d122e24b98832/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd4e6abd0181dac14f8f/notes"
+                      url: "/contacts/65e1a644ba4d122e24b98832/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd4e6abd0181dac14f8f/companies"
+                      url: "/contacts/65e1a644ba4d122e24b98832/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd4e6abd0181dac14f8f/subscriptions"
+                      url: "/contacts/65e1a644ba4d122e24b98832/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd4e6abd0181dac14f8f/subscriptions"
+                      url: "/contacts/65e1a644ba4d122e24b98832/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3955,7 +3955,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 749cf91c-b02c-43d8-bb67-f91017d2f462
+                    request_id: 8af7a22e-0693-4469-ae37-662cac531f01
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3986,7 +3986,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0bd4f6abd0181dac14f90
+                    id: 65e1a646ba4d122e24b98833
                     external_id: '70'
                     type: contact
                     deleted: true
@@ -4000,7 +4000,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d59d0ad1-9c33-44a8-9c73-9d8cbc316c8f
+                    request_id: fd58fdf2-d2c9-4a68-a5d8-c4473e5bbf7d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4028,7 +4028,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0bd506abd0181dac14f92
+                    id: 65e1a647ba4d122e24b98835
                     workspace_id: this_is_an_id291_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -4044,9 +4044,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709227344
-                    updated_at: 1709227345
-                    signed_up_at: 1709227344
+                    created_at: 1709286983
+                    updated_at: 1709286983
+                    signed_up_at: 1709286983
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -4080,31 +4080,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd506abd0181dac14f92/tags"
+                      url: "/contacts/65e1a647ba4d122e24b98835/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd506abd0181dac14f92/notes"
+                      url: "/contacts/65e1a647ba4d122e24b98835/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd506abd0181dac14f92/companies"
+                      url: "/contacts/65e1a647ba4d122e24b98835/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd506abd0181dac14f92/subscriptions"
+                      url: "/contacts/65e1a647ba4d122e24b98835/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd506abd0181dac14f92/subscriptions"
+                      url: "/contacts/65e1a647ba4d122e24b98835/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4123,7 +4123,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '09b4ab2a-8683-4229-92ec-d30e54fc53ba'
+                    request_id: 45d15256-0652-4138-822b-fa8ffae1fb49
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4138,8 +4138,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 65e0bd506abd0181dac14f91
-                  into: 65e0bd506abd0181dac14f92
+                  from: 65e1a647ba4d122e24b98834
+                  into: 65e1a647ba4d122e24b98835
   "/contacts/search":
     post:
       summary: Search contacts
@@ -4268,7 +4268,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c78080a2-a81d-4f4a-a1a1-20396efe7b73
+                    request_id: 6a9316bd-507a-4930-af31-49ecfb9bffaa
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4288,15 +4288,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: 65e0bd526abd0181dac14f95
+                      value: 65e1a649ba4d122e24b98838
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: 65e0bd526abd0181dac14f95
+                        value: 65e1a649ba4d122e24b98838
                       - field: id
                         operator: "="
-                        value: 65e0bd526abd0181dac14f95
+                        value: 65e1a649ba4d122e24b98838
   "/contacts":
     get:
       summary: List all contacts
@@ -4335,7 +4335,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 85c59b77-2c2f-4bd3-8f7d-7110e15e21a6
+                    request_id: 4ee7590b-351c-4b80-887b-ea449f6c01bd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4361,7 +4361,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0bd546abd0181dac14f97
+                    id: 65e1a64bba4d122e24b9883a
                     workspace_id: this_is_an_id303_that_should_be_at_least_
                     external_id:
                     role: user
@@ -4377,8 +4377,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709227348
-                    updated_at: 1709227348
+                    created_at: 1709286987
+                    updated_at: 1709286987
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -4413,31 +4413,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd546abd0181dac14f97/tags"
+                      url: "/contacts/65e1a64bba4d122e24b9883a/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd546abd0181dac14f97/notes"
+                      url: "/contacts/65e1a64bba4d122e24b9883a/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd546abd0181dac14f97/companies"
+                      url: "/contacts/65e1a64bba4d122e24b9883a/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd546abd0181dac14f97/subscriptions"
+                      url: "/contacts/65e1a64bba4d122e24b9883a/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bd546abd0181dac14f97/subscriptions"
+                      url: "/contacts/65e1a64bba4d122e24b9883a/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4456,7 +4456,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '0938dac2-a826-41c5-b835-4385978acd07'
+                    request_id: 81d22ca8-a812-4bb6-909b-c0d43c73061d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4500,7 +4500,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0bd556abd0181dac14f98
+                    id: 65e1a64cba4d122e24b9883b
                     external_id: '70'
                     type: contact
                     archived: true
@@ -4533,7 +4533,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0bd566abd0181dac14f99
+                    id: 65e1a64dba4d122e24b9883c
                     external_id: '70'
                     type: contact
                     archived: false
@@ -4569,7 +4569,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '176'
+                    id: '108'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4581,7 +4581,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: b1bf0cf7-9b6f-401a-b814-dd2f614ea528
+                    request_id: 54ef8339-b22c-4a9d-83ef-0c5f24ef1616
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4595,7 +4595,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5a001e63-af9b-4a13-bf39-fc91cd29fb54
+                    request_id: 1c95b5f3-3c52-441a-9fd0-6737de1e3a51
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4624,13 +4624,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 176
-                  admin_id: 991268443
+                  id: 108
+                  admin_id: 991267697
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 177
-                  admin_id: 991268445
+                  id: 109
+                  admin_id: 991267699
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4668,7 +4668,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '179'
+                    id: '111'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4680,14 +4680,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 7c4c8814-f512-4433-ac6c-b5d1d400bdb6
+                    request_id: 6ca7f00a-9247-46fa-ac01-0b0cb2cbe61b
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: ab9ac6e4-eb0c-4f43-8749-c6ead6476018
+                    request_id: 6efd71a9-cd97-429e-9ecc-6dcc4ce8841f
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4701,7 +4701,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b4602658-5dab-4a22-a85f-67f486a6da09
+                    request_id: 528903cc-ca8d-4c6b-a9fd-f82188a699ab
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4724,15 +4724,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991268447
+                  admin_id: 991267701
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991268449
+                  admin_id: 991267703
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991268450
+                  admin_id: 991267704
   "/conversations":
     get:
       summary: List all conversations
@@ -4779,20 +4779,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '576'
-                      created_at: 1709227358
-                      updated_at: 1709227358
+                      id: '314'
+                      created_at: 1709286999
+                      updated_at: 1709286999
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918397'
+                        id: '403918244'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991268453'
+                          id: '991267707'
                           name: Ciaran164 Lee
                           email: admin164@email.com
                         attachments: []
@@ -4802,7 +4802,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0bd5d6abd0181dac14f9d
+                          id: 65e1a656ba4d122e24b98840
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -4837,7 +4837,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 44c06ec3-3c92-40ef-9b79-652e5cb6f31b
+                    request_id: 0ec9b06f-246d-4ebd-bdaf-5569bfde23af
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4851,7 +4851,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 25708230-bf2c-42c7-8856-d19195225250
+                    request_id: 83e2ad29-1551-4f7f-a996-7159ad945230
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4887,11 +4887,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918407'
-                    created_at: 1709227380
+                    id: '403918254'
+                    created_at: 1709287033
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '601'
+                    conversation_id: '339'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -4902,7 +4902,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 5dd29a54-3788-4c77-9e30-ba47fab4d60c
+                    request_id: 0726a031-ec7e-4573-81f9-bd41d6d99c14
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -4916,7 +4916,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1de3427a-1749-40d6-996e-a3d4f70611bd
+                    request_id: 761f5e57-8642-4219-83df-ae9a1e6b0e8a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4930,7 +4930,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 7ac480f7-815d-407f-9106-13c2b4c54b69
+                    request_id: 6336bca6-33d2-4d0a-9eb3-e0d37aa42730
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4947,7 +4947,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65e0bd736abd0181dac14fb2
+                    id: 65e1a677ba4d122e24b98855
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -5005,20 +5005,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '605'
-                    created_at: 1709227385
-                    updated_at: 1709227385
+                    id: '343'
+                    created_at: 1709287041
+                    updated_at: 1709287041
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918411'
+                      id: '403918258'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268467'
+                        id: '991267721'
                         name: Ciaran171 Lee
                         email: admin171@email.com
                       attachments: []
@@ -5028,7 +5028,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bd796abd0181dac14fb6
+                        id: 65e1a681ba4d122e24b98859
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5067,7 +5067,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 913ef3fc-7668-4460-8555-d2b0905c5a4f
+                    request_id: ecd12640-16f4-451e-be6a-87f0c8451045
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5081,7 +5081,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 209f42c1-720f-4cf6-aeea-2182914ec24a
+                    request_id: b53615fb-1e34-4487-bbd7-690aaa01eb4a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5095,7 +5095,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 46241e0e-d317-4824-84f7-ea33b7380644
+                    request_id: 8e07bf2a-072d-4055-96b8-8ecd8fd48537
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5142,20 +5142,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '609'
-                    created_at: 1709227390
-                    updated_at: 1709227392
+                    id: '347'
+                    created_at: 1709287050
+                    updated_at: 1709287053
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918415'
+                      id: '403918262'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268475'
+                        id: '991267729'
                         name: Ciaran175 Lee
                         email: admin175@email.com
                       attachments: []
@@ -5165,7 +5165,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bd7e6abd0181dac14fba
+                        id: 65e1a689ba4d122e24b9885d
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5196,15 +5196,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '137'
+                        id: '94'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709227392
-                        updated_at: 1709227392
-                        notified_at: 1709227392
+                        created_at: 1709287052
+                        updated_at: 1709287052
+                        notified_at: 1709287052
                         assigned_to:
                         author:
-                          id: '991268476'
+                          id: '991267730'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id347_that_should_be_at_least_@intercom.io
@@ -5213,15 +5213,15 @@ paths:
                         redacted: false
                         metadata: {}
                       - type: conversation_part
-                        id: '138'
+                        id: '95'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709227392
-                        updated_at: 1709227392
-                        notified_at: 1709227392
+                        created_at: 1709287053
+                        updated_at: 1709287053
+                        notified_at: 1709287053
                         assigned_to:
                         author:
-                          id: '991268476'
+                          id: '991267730'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id347_that_should_be_at_least_@intercom.io
@@ -5240,7 +5240,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: e117a9f9-7ad0-4f98-b489-ad65e0003dac
+                    request_id: e3d35f2f-3a62-46a0-b81f-e36ce9226946
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5254,7 +5254,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3ade11da-20e4-4c18-b576-7036cef8b6a1
+                    request_id: f6e38ed0-8b19-4a69-9643-e8c1f1555f60
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5268,7 +5268,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: ca69ed06-f5dd-4ae1-90e7-1e53c3341b6e
+                    request_id: f38f9491-1514-40e3-8e56-a6cf4b1af420
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5319,7 +5319,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '613'
+                    id: '351'
                     object: conversation
                     deleted: true
               schema:
@@ -5332,7 +5332,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8cfceafa-f9eb-494b-972c-69903ce7439d
+                    request_id: c703d2c2-17c3-4c71-8163-01895a12b973
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5346,7 +5346,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: e3857d03-32d0-40a9-974c-faae1055193e
+                    request_id: 3264266c-cb4e-4db8-a61a-8f9c8999aeab
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5381,57 +5381,57 @@ paths:
 
         Most keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `"foorbar"`).
 
-        | Field                                     | Type                                                                                     |
-        | :---------------------------------------- | :--------------------------------------------------------------------------------------- |
-        | id                                        | String                                                                                   |
-        | created_at                                | Date (UNIX timestamp)                                                                    |
-        | updated_at                                | Date (UNIX timestamp)                                                                    |
-        | source.type                               | String<br>Accepted fields are `conversation`, `push`, `facebook`, `twitter` and `email`. |
-        | source.id                                 | String                                                                                   |
-        | source.delivered_as                       | String                                                                                   |
-        | source.subject                            | String                                                                                   |
-        | source.body                               | String                                                                                   |
-        | source.author.id                          | String                                                                                   |
-        | source.author.type                        | String                                                                                   |
-        | source.author.name                        | String                                                                                   |
-        | source.author.email                       | String                                                                                   |
-        | source.url                                | String                                                                                   |
-        | contact_ids                               | String                                                                                   |
-        | teammate_ids                              | String                                                                                   |
-        | admin_assignee_id                         | String                                                                                   |
-        | team_assignee_id                          | String                                                                                   |
-        | channel_initiated                         | String                                                                                   |
-        | open                                      | Boolean                                                                                  |
-        | read                                      | Boolean                                                                                  |
-        | state                                     | String                                                                                   |
-        | waiting_since                             | Date (UNIX timestamp)                                                                    |
-        | snoozed_until                             | Date (UNIX timestamp)                                                                    |
-        | tag_ids                                   | String                                                                                   |
-        | priority                                  | String                                                                                   |
-        | statistics.time_to_assignment             | Integer                                                                                  |
-        | statistics.time_to_admin_reply            | Integer                                                                                  |
-        | statistics.time_to_first_close            | Integer                                                                                  |
-        | statistics.time_to_last_close             | Integer                                                                                  |
-        | statistics.median_time_to_reply           | Integer                                                                                  |
-        | statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                    |
-        | statistics.first_assignment_at            | Date (UNIX timestamp)                                                                    |
-        | statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                    |
-        | statistics.first_close_at                 | Date (UNIX timestamp)                                                                    |
-        | statistics.last_assignment_at             | Date (UNIX timestamp)                                                                    |
-        | statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                    |
-        | statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                    |
-        | statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                    |
-        | statistics.last_close_at                  | Date (UNIX timestamp)                                                                    |
-        | statistics.last_closed_by_id              | String                                                                                   |
-        | statistics.count_reopens                  | Integer                                                                                  |
-        | statistics.count_assignments              | Integer                                                                                  |
-        | statistics.count_conversation_parts       | Integer                                                                                  |
-        | conversation_rating.requested_at          | Date (UNIX timestamp)                                                                    |
-        | conversation_rating.replied_at            | Date (UNIX timestamp)                                                                    |
-        | conversation_rating.score                 | Integer                                                                                  |
-        | conversation_rating.remark                | String                                                                                   |
-        | conversation_rating.contact_id            | String                                                                                   |
-        | conversation_rating.admin_d               | String                                                                                   |
+        | Field                                     | Type                                                                                                                                                   |
+        | :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
+        | id                                        | String                                                                                                                                                 |
+        | created_at                                | Date (UNIX timestamp)                                                                                                                                  |
+        | updated_at                                | Date (UNIX timestamp)                                                                                                                                  |
+        | source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |
+        | source.id                                 | String                                                                                                                                                 |
+        | source.delivered_as                       | String                                                                                                                                                 |
+        | source.subject                            | String                                                                                                                                                 |
+        | source.body                               | String                                                                                                                                                 |
+        | source.author.id                          | String                                                                                                                                                 |
+        | source.author.type                        | String                                                                                                                                                 |
+        | source.author.name                        | String                                                                                                                                                 |
+        | source.author.email                       | String                                                                                                                                                 |
+        | source.url                                | String                                                                                                                                                 |
+        | contact_ids                               | String                                                                                                                                                 |
+        | teammate_ids                              | String                                                                                                                                                 |
+        | admin_assignee_id                         | String                                                                                                                                                 |
+        | team_assignee_id                          | String                                                                                                                                                 |
+        | channel_initiated                         | String                                                                                                                                                 |
+        | open                                      | Boolean                                                                                                                                                |
+        | read                                      | Boolean                                                                                                                                                |
+        | state                                     | String                                                                                                                                                 |
+        | waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |
+        | snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |
+        | tag_ids                                   | String                                                                                                                                                 |
+        | priority                                  | String                                                                                                                                                 |
+        | statistics.time_to_assignment             | Integer                                                                                                                                                |
+        | statistics.time_to_admin_reply            | Integer                                                                                                                                                |
+        | statistics.time_to_first_close            | Integer                                                                                                                                                |
+        | statistics.time_to_last_close             | Integer                                                                                                                                                |
+        | statistics.median_time_to_reply           | Integer                                                                                                                                                |
+        | statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_closed_by_id              | String                                                                                                                                                 |
+        | statistics.count_reopens                  | Integer                                                                                                                                                |
+        | statistics.count_assignments              | Integer                                                                                                                                                |
+        | statistics.count_conversation_parts       | Integer                                                                                                                                                |
+        | conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |
+        | conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | conversation_rating.score                 | Integer                                                                                                                                                |
+        | conversation_rating.remark                | String                                                                                                                                                 |
+        | conversation_rating.contact_id            | String                                                                                                                                                 |
+        | conversation_rating.admin_d               | String                                                                                                                                                 |
 
         ### Accepted Operators
 
@@ -5466,20 +5466,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '616'
-                      created_at: 1709227402
-                      updated_at: 1709227402
+                      id: '354'
+                      created_at: 1709287069
+                      updated_at: 1709287069
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918422'
+                        id: '403918269'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991268505'
+                          id: '991267759'
                           name: Ciaran198 Lee
                           email: admin198@email.com
                         attachments: []
@@ -5489,7 +5489,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0bd8a6abd0181dac14fc1
+                          id: 65e1a69cba4d122e24b98864
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -5530,15 +5530,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '616'
+                      value: '354'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '616'
+                        value: '354'
                       - field: id
                         operator: "="
-                        value: '616'
+                        value: '354'
   "/conversations/{id}/reply":
     post:
       summary: Reply to a conversation
@@ -5569,20 +5569,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '624'
-                    created_at: 1709227408
-                    updated_at: 1709227409
-                    waiting_since: 1709227409
+                    id: '362'
+                    created_at: 1709287081
+                    updated_at: 1709287082
+                    waiting_since: 1709287082
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918425'
+                      id: '403918272'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268507'
+                        id: '991267761'
                         name: Ciaran199 Lee
                         email: admin199@email.com
                       attachments: []
@@ -5592,10 +5592,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bd906abd0181dac14fc8
+                        id: 65e1a6a8ba4d122e24b9886b
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709227409
+                      created_at: 1709287082
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5624,15 +5624,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '140'
+                        id: '97'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709227409
-                        updated_at: 1709227409
-                        notified_at: 1709227409
+                        created_at: 1709287082
+                        updated_at: 1709287082
+                        notified_at: 1709287082
                         assigned_to:
                         author:
-                          id: 65e0bd906abd0181dac14fc8
+                          id: 65e1a6a8ba4d122e24b9886b
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5644,20 +5644,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '625'
-                    created_at: 1709227410
-                    updated_at: 1709227411
+                    id: '363'
+                    created_at: 1709287084
+                    updated_at: 1709287085
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918426'
+                      id: '403918273'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268509'
+                        id: '991267763'
                         name: Ciaran200 Lee
                         email: admin200@email.com
                       attachments: []
@@ -5667,7 +5667,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bd926abd0181dac14fc9
+                        id: 65e1a6abba4d122e24b9886c
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5696,7 +5696,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '141'
+                        id: '98'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5711,12 +5711,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1709227411
-                        updated_at: 1709227411
-                        notified_at: 1709227411
+                        created_at: 1709287085
+                        updated_at: 1709287085
+                        notified_at: 1709287085
                         assigned_to:
                         author:
-                          id: '991268509'
+                          id: '991267763'
                           type: admin
                           name: Ciaran200 Lee
                           email: admin200@email.com
@@ -5728,20 +5728,20 @@ paths:
                 Admin quick_reply reply:
                   value:
                     type: conversation
-                    id: '626'
-                    created_at: 1709227412
-                    updated_at: 1709227414
+                    id: '364'
+                    created_at: 1709287086
+                    updated_at: 1709287088
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918427'
+                      id: '403918274'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268511'
+                        id: '991267765'
                         name: Ciaran201 Lee
                         email: admin201@email.com
                       attachments: []
@@ -5751,7 +5751,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bd946abd0181dac14fca
+                        id: 65e1a6aeba4d122e24b9886d
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5780,15 +5780,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '142'
+                        id: '99'
                         part_type: quick_reply
                         body:
-                        created_at: 1709227414
-                        updated_at: 1709227414
-                        notified_at: 1709227414
+                        created_at: 1709287088
+                        updated_at: 1709287088
+                        notified_at: 1709287088
                         assigned_to:
                         author:
-                          id: '991268511'
+                          id: '991267765'
                           type: admin
                           name: Ciaran201 Lee
                           email: admin201@email.com
@@ -5800,20 +5800,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '627'
-                    created_at: 1709227415
-                    updated_at: 1709227416
-                    waiting_since: 1709227416
+                    id: '365'
+                    created_at: 1709287089
+                    updated_at: 1709287091
+                    waiting_since: 1709287091
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918428'
+                      id: '403918275'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268513'
+                        id: '991267767'
                         name: Ciaran202 Lee
                         email: admin202@email.com
                       attachments: []
@@ -5823,10 +5823,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bd976abd0181dac14fcb
+                        id: 65e1a6b1ba4d122e24b9886e
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709227416
+                      created_at: 1709287091
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5855,15 +5855,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '143'
+                        id: '100'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709227416
-                        updated_at: 1709227416
-                        notified_at: 1709227416
+                        created_at: 1709287091
+                        updated_at: 1709287091
+                        notified_at: 1709287091
                         assigned_to:
                         author:
-                          id: 65e0bd976abd0181dac14fcb
+                          id: 65e1a6b1ba4d122e24b9886e
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5882,7 +5882,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 62ee924b-23d2-4820-90b0-26a76dcceb3f
+                    request_id: 58cb93f1-209b-478d-8b7a-50df74d07222
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5896,7 +5896,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d3b1c96e-ac4b-403c-a67b-704a59f17b98
+                    request_id: 78ee273f-da95-41de-96f5-2526a096dfc6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5910,7 +5910,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 33be37ef-d9c4-4739-9961-383a61a857e1
+                    request_id: 1f0ecce7-26a3-4199-b6d7-3c72e396b208
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5927,14 +5927,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bd906abd0181dac14fc8
+                  intercom_user_id: 65e1a6a8ba4d122e24b9886b
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991268509
+                  admin_id: 991267763
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -5944,25 +5944,25 @@ paths:
                 value:
                   message_type: quick_reply
                   type: admin
-                  admin_id: 991268511
+                  admin_id: 991267765
                   reply_options:
                   - text: 'Yes'
-                    uuid: 70988ad0-2073-4ccd-b7e7-dc854231388c
+                    uuid: afd7d67f-8bfb-4b26-8b52-5e12a4eb8f3c
                   - text: 'No'
-                    uuid: a7b04be0-5a8d-4798-8875-641732351aa5
+                    uuid: f3c2e798-c88d-4432-98f6-1f92dc379b5d
               user_last_conversation_reply:
                 summary: User last conversation reply
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bd976abd0181dac14fcb
+                  intercom_user_id: 65e1a6b1ba4d122e24b9886e
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bd996abd0181dac14fcc
+                  intercom_user_id: 65e1a6b4ba4d122e24b9886f
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -5997,20 +5997,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '631'
-                    created_at: 1709227421
-                    updated_at: 1709227422
+                    id: '369'
+                    created_at: 1709287099
+                    updated_at: 1709287101
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918432'
+                      id: '403918279'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268521'
+                        id: '991267775'
                         name: Ciaran206 Lee
                         email: admin206@email.com
                       attachments: []
@@ -6020,7 +6020,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bd9d6abd0181dac14fcf
+                        id: 65e1a6bbba4d122e24b98872
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6049,15 +6049,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '144'
+                        id: '101'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1709227422
-                        updated_at: 1709227422
-                        notified_at: 1709227422
+                        created_at: 1709287101
+                        updated_at: 1709287101
+                        notified_at: 1709287101
                         assigned_to:
                         author:
-                          id: '991268521'
+                          id: '991267775'
                           type: admin
                           name: Ciaran206 Lee
                           email: admin206@email.com
@@ -6069,20 +6069,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '632'
-                    created_at: 1709227423
-                    updated_at: 1709227425
+                    id: '370'
+                    created_at: 1709287102
+                    updated_at: 1709287103
                     waiting_since:
-                    snoozed_until: 1709231024
+                    snoozed_until: 1709290703
                     source:
                       type: conversation
-                      id: '403918433'
+                      id: '403918280'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268523'
+                        id: '991267777'
                         name: Ciaran207 Lee
                         email: admin207@email.com
                       attachments: []
@@ -6092,7 +6092,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bd9f6abd0181dac14fd0
+                        id: 65e1a6beba4d122e24b98873
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6121,15 +6121,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '145'
+                        id: '102'
                         part_type: snoozed
                         body:
-                        created_at: 1709227425
-                        updated_at: 1709227425
-                        notified_at: 1709227425
+                        created_at: 1709287103
+                        updated_at: 1709287103
+                        notified_at: 1709287103
                         assigned_to:
                         author:
-                          id: '991268523'
+                          id: '991267777'
                           type: admin
                           name: Ciaran207 Lee
                           email: admin207@email.com
@@ -6141,20 +6141,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '637'
-                    created_at: 1709227423
-                    updated_at: 1709227432
+                    id: '375'
+                    created_at: 1709287101
+                    updated_at: 1709287110
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918434'
+                      id: '403918281'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268525'
+                        id: '991267779'
                         name: Ciaran208 Lee
                         email: admin208@email.com
                       attachments: []
@@ -6164,7 +6164,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bda46abd0181dac14fd5
+                        id: 65e1a6c2ba4d122e24b98878
                         external_id: '74'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6193,15 +6193,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '147'
+                        id: '104'
                         part_type: open
                         body:
-                        created_at: 1709227432
-                        updated_at: 1709227432
-                        notified_at: 1709227432
+                        created_at: 1709287110
+                        updated_at: 1709287110
+                        notified_at: 1709287110
                         assigned_to:
                         author:
-                          id: '991268525'
+                          id: '991267779'
                           type: admin
                           name: Ciaran208 Lee
                           email: admin208@email.com
@@ -6213,20 +6213,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '641'
-                    created_at: 1709227433
-                    updated_at: 1709227434
+                    id: '379'
+                    created_at: 1709287111
+                    updated_at: 1709287111
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918437'
+                      id: '403918284'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268527'
+                        id: '991267781'
                         name: Ciaran209 Lee
                         email: admin209@email.com
                       attachments: []
@@ -6236,10 +6236,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bda96abd0181dac14fd8
+                        id: 65e1a6c6ba4d122e24b9887b
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991268527
+                    admin_assignee_id: 991267781
                     team_assignee_id:
                     open: true
                     state: open
@@ -6265,17 +6265,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '148'
+                        id: '105'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1709227434
-                        updated_at: 1709227434
-                        notified_at: 1709227434
+                        created_at: 1709287111
+                        updated_at: 1709287111
+                        notified_at: 1709287111
                         assigned_to:
                           type: admin
-                          id: '991268527'
+                          id: '991267781'
                         author:
-                          id: '991268527'
+                          id: '991267781'
                           type: admin
                           name: Ciaran209 Lee
                           email: admin209@email.com
@@ -6294,7 +6294,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 46fd661f-6b54-45d3-aebf-fbcf9eccb39d
+                    request_id: 9f7fe153-d5eb-4055-abdc-b9b0736ef4de
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6308,7 +6308,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bd416d2c-574b-4ebc-8c21-111d363d7a48
+                    request_id: 0b2b3c10-3608-48a3-80e7-8e041d78d180
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6322,7 +6322,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 21b90c06-7724-4f41-bd2b-9c53222f2597
+                    request_id: aee0baa2-238a-4d30-a4d2-65969b953bb0
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6343,32 +6343,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991268521
+                  admin_id: 991267775
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991268523
-                  snoozed_until: 1709231024
+                  admin_id: 991267777
+                  snoozed_until: 1709290703
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991268525
+                  admin_id: 991267779
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991268527
-                  assignee_id: 991268527
+                  admin_id: 991267781
+                  assignee_id: 991267781
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991268529
+                  admin_id: 991267783
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -6399,20 +6399,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '645'
-                    created_at: 1709227438
-                    updated_at: 1709227439
+                    id: '383'
+                    created_at: 1709287116
+                    updated_at: 1709287117
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918441'
+                      id: '403918288'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268535'
+                        id: '991267789'
                         name: Ciaran213 Lee
                         email: admin213@email.com
                       attachments: []
@@ -6422,7 +6422,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bdae6abd0181dac14fdc
+                        id: 65e1a6ccba4d122e24b9887f
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6451,17 +6451,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '149'
+                        id: '106'
                         part_type: default_assignment
                         body:
-                        created_at: 1709227439
-                        updated_at: 1709227439
-                        notified_at: 1709227439
+                        created_at: 1709287117
+                        updated_at: 1709287117
+                        notified_at: 1709287117
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991268536'
+                          id: '991267790'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id391_that_should_be_at_least_@intercom.io
@@ -6480,7 +6480,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 3da967d9-a0ef-4178-b7a0-5f837225e337
+                    request_id: 5fa9dfc7-8234-49ec-bf31-8b09c2e65746
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6494,7 +6494,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c0db66fc-d3a4-409d-8efa-e10449ee7d2b
+                    request_id: 6cfb4cae-c2d9-40be-9d23-04b98f95c1dd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6508,7 +6508,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 8646f6a7-6c9b-4622-bea9-652201a1da94
+                    request_id: 1c1ee4e5-888f-49be-b96c-4eaff29288fb
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6549,7 +6549,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65e0bdb46abd0181dac14fe0
+                      id: 65e1a6d4ba4d122e24b98883
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6560,7 +6560,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: e81ca21f-a6ff-47e7-8c13-98c7583d1e6c
+                    request_id: d5c406e3-db0c-47e5-b6b3-b4cc55a00e45
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6574,7 +6574,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 360fc1af-79b0-4ddb-ac0a-6d6e73ff7665
+                    request_id: 5028a207-e009-49c4-8a86-536a11c998ee
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6588,7 +6588,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 1721d82e-0645-4d68-881d-586cf4ab4aaf
+                    request_id: a681299a-6e91-4083-8901-5cac4c092fff
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6603,15 +6603,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991268543
+                  admin_id: 991267797
                   customer:
-                    intercom_user_id: 65e0bdb46abd0181dac14fe0
+                    intercom_user_id: 65e1a6d4ba4d122e24b98883
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991268545
+                  admin_id: 991267799
                   customer:
-                    intercom_user_id: 65e0bdb66abd0181dac14fe1
+                    intercom_user_id: 65e1a6d6ba4d122e24b98884
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -6654,7 +6654,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65e0bdbf6abd0181dac14feb
+                      id: 65e1a6e3ba4d122e24b9888e
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6665,14 +6665,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 97f94ded-b09e-434f-a545-c6f65711988d
+                    request_id: bc873eb2-90f7-48bd-83ff-f844bdb3b7f0
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 1489b334-3119-4a91-a6a3-f85c512085d1
+                    request_id: 2b0f042f-4afb-4fb2-ba06-261e32d52809
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -6686,7 +6686,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: 12569ad2-c9e3-40cf-873a-9e3530ed51f3
+                    request_id: 95b9e89e-3ce8-49a0-89c1-ea49a9ed0ad7
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -6700,7 +6700,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2aee5344-f4d2-418d-873d-155a39fe25d4
+                    request_id: bd38cd31-11ea-409a-b1cb-146793f59989
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6714,7 +6714,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 6b03886e-7613-45c9-8d50-98a54f1f7476
+                    request_id: '019091ba-2409-4dc0-82fd-59ed1070240f'
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6729,27 +6729,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991268551
+                  admin_id: 991267805
                   customer:
-                    intercom_user_id: 65e0bdb96abd0181dac14fe4
+                    intercom_user_id: 65e1a6ddba4d122e24b98887
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991268553
+                  admin_id: 991267807
                   customer:
-                    intercom_user_id: 65e0bdc06abd0181dac14fec
+                    intercom_user_id: 65e1a6e4ba4d122e24b9888f
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991268555
+                  admin_id: 991267809
                   customer:
-                    intercom_user_id: 65e0bdc76abd0181dac14ff3
+                    intercom_user_id: 65e1a6efba4d122e24b98896
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991268557
+                  admin_id: 991267811
                   customer:
-                    intercom_user_id: 65e0bdce6abd0181dac14ffa
+                    intercom_user_id: 65e1a6fbba4d122e24b9889d
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6777,20 +6777,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '701'
-                    created_at: 1709227492
-                    updated_at: 1709227494
-                    waiting_since: 1709227493
+                    id: '439'
+                    created_at: 1709287198
+                    updated_at: 1709287200
+                    waiting_since: 1709287199
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918467'
+                      id: '403918314'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268563'
+                        id: '991267817'
                         name: Ciaran227 Lee
                         email: admin227@email.com
                       attachments: []
@@ -6800,10 +6800,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bde46abd0181dac1500f
+                        id: 65e1a71eba4d122e24b988b2
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709227493
+                      created_at: 1709287199
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6832,15 +6832,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '157'
+                        id: '114'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1709227493
-                        updated_at: 1709227494
-                        notified_at: 1709227493
+                        created_at: 1709287199
+                        updated_at: 1709287200
+                        notified_at: 1709287199
                         assigned_to:
                         author:
-                          id: 65e0bde46abd0181dac1500f
+                          id: 65e1a71eba4d122e24b988b2
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6859,7 +6859,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: c0edb36c-cb13-42b7-906f-265c1acbb8b0
+                    request_id: 6c6b391f-17ad-49a3-b97e-055b1561a28b
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -6873,7 +6873,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3773efb8-1a2e-4828-96d8-fd48e7ef9988
+                    request_id: 0feb2aa6-5faa-4db5-a820-12d133a1951c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6889,8 +6889,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 701
-                  conversation_part_id: 157
+                  conversation_id: 439
+                  conversation_part_id: 114
               not_found:
                 summary: Not found
                 value:
@@ -6925,20 +6925,20 @@ paths:
                 successful:
                   value:
                     type: ticket
-                    id: '704'
-                    ticket_id: '24'
+                    id: '442'
+                    ticket_id: '35'
                     ticket_attributes: {}
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '108'
+                      id: '73'
                       name: my-ticket-type-1
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id425_that_should_be_at_least_
                       archived: false
-                      created_at: 1709227500
-                      updated_at: 1709227500
+                      created_at: 1709287209
+                      updated_at: 1709287209
                       is_internal: false
                       ticket_type_attributes:
                         type: list
@@ -6948,37 +6948,37 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bde96abd0181dac15012
+                        id: 65e1a726ba4d122e24b988b5
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709227497
-                    updated_at: 1709227500
+                    created_at: 1709287206
+                    updated_at: 1709287209
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '159'
+                        id: '116'
                         part_type: comment
                         body: "<p>Comment for message</p>"
-                        created_at: 1709227497
-                        updated_at: 1709227497
+                        created_at: 1709287206
+                        updated_at: 1709287206
                         author:
-                          id: 65e0bde96abd0181dac15012
+                          id: 65e1a726ba4d122e24b988b5
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '160'
+                        id: '117'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709227500
-                        updated_at: 1709227500
+                        created_at: 1709287209
+                        updated_at: 1709287209
                         author:
-                          id: '991268573'
+                          id: '991267827'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id425_that_should_be_at_least_@intercom.io
@@ -7003,7 +7003,7 @@ paths:
                 Bad request:
                   value:
                     type: error.list
-                    request_id: be98374f-dcf5-46c0-ac8b-92087b66003a
+                    request_id: d0531957-2477-4303-bf83-9d07b70dba74
                     errors:
                     - code: parameter_invalid
                       message: Ticket type is not a customer ticket type
@@ -7018,11 +7018,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  ticket_type_id: '108'
+                  ticket_type_id: '73'
               bad_request:
                 summary: Bad request
                 value:
-                  ticket_type_id: '109'
+                  ticket_type_id: '74'
   "/custom_object_instances/{custom_object_type_identifier}":
     parameters:
     - name: custom_object_type_identifier
@@ -7051,14 +7051,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '1'
+                    id: '11'
                     type: object_type_identifier_1
                     custom_attributes: {}
                     external_id: '123'
                     external_created_at: 1392036272
                     external_updated_at: 1392036272
-                    created_at: 1709227504
-                    updated_at: 1709227504
+                    created_at: 1709287215
+                    updated_at: 1709287215
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7069,7 +7069,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4fae9acc-de4e-4c14-bb37-3cbf35f258c3
+                    request_id: 0f146cb0-485f-4cba-b276-a9df5944ac44
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7129,14 +7129,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '3'
+                    id: '13'
                     type: object_type_identifier_4
                     custom_attributes: {}
                     external_id: '123'
                     external_created_at:
                     external_updated_at:
-                    created_at: 1709227506
-                    updated_at: 1709227506
+                    created_at: 1709287216
+                    updated_at: 1709287216
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7147,7 +7147,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f1a6e58a-5ef5-4525-a642-57ac73c819d3
+                    request_id: 457d3105-358d-4756-b95a-73d06a07fabd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7187,14 +7187,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '4'
+                    id: '14'
                     type: object_type_identifier_6
                     custom_attributes: {}
                     external_id: '123'
                     external_created_at:
                     external_updated_at:
-                    created_at: 1709227506
-                    updated_at: 1709227506
+                    created_at: 1709287217
+                    updated_at: 1709287217
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7205,7 +7205,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 19027344-b407-4221-bfad-ace66fe02384
+                    request_id: a2b546a5-2d77-4396-8c64-db5fe56bb2f3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7236,7 +7236,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '5'
+                    id: '15'
                     object: object_type_identifier_8
                     deleted: true
               schema:
@@ -7249,7 +7249,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5ec30eb9-37be-4386-af29-f9422a98bd3f
+                    request_id: 840e395c-a4b3-4649-b1b2-3dc1e2c7b86b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7435,7 +7435,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 66
+                    - id: 35
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -7448,9 +7448,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991268590'
-                      created_at: 1709227508
-                      updated_at: 1709227508
+                      admin_id: '991267844'
+                      created_at: 1709287219
+                      updated_at: 1709287219
                       model: company
                     - type: data_attribute
                       name: id
@@ -7522,7 +7522,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4c512e09-e1a6-4a1d-8eeb-e4a5cfd6fa98
+                    request_id: c74ab17d-57b6-4587-b7ad-b2d28be5c1c3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7547,7 +7547,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 69
+                    id: 38
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -7558,9 +7558,9 @@ paths:
                     messenger_writable: false
                     custom: true
                     archived: false
-                    admin_id: '991268592'
-                    created_at: 1709227509
-                    updated_at: 1709227509
+                    admin_id: '991267846'
+                    created_at: 1709287220
+                    updated_at: 1709287220
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -7572,7 +7572,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: 70f655d4-09ad-43d5-bbcd-0c6f7ee965b0
+                    request_id: fe837b9a-274b-45ff-955a-7565cf0277fa
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -7580,7 +7580,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: 57d5bd8b-1054-4f2d-9039-cb8a4edbd9fe
+                    request_id: af435573-9587-48dd-9083-d798207ec5a2
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -7588,7 +7588,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: 34ca565e-dd6b-46fd-9db1-db438a772cf1
+                    request_id: 2785d900-f7d5-4342-a6e4-623f33c8a521
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -7596,14 +7596,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: 503b9800-97b8-4733-9b10-8e1f90f5c530
+                    request_id: fd1062b7-8473-4b8f-9e1a-a188aa23c555
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: d86de746-2d01-4d3b-8bcf-0191f2e02720
+                    request_id: 87c628dd-6495-485c-bd04-f59e545fe0d7
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -7618,7 +7618,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7ca0fdf9-5b80-4bea-adeb-437e57ca3743
+                    request_id: 122b1704-d672-4b18-a247-9066c3700ed1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7697,7 +7697,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 76
+                    id: 45
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -7712,9 +7712,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991268599'
-                    created_at: 1709227513
-                    updated_at: 1709227513
+                    admin_id: '991267853'
+                    created_at: 1709287223
+                    updated_at: 1709287223
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -7726,7 +7726,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: e0b19ae4-26ee-49f0-adda-8f2181794669
+                    request_id: e664ffc1-82f0-4691-83ca-3523f667cd27
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -7740,7 +7740,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: ca222eb9-4834-425e-84b5-0b9c18732160
+                    request_id: 92b5f017-a181-4413-8cf1-070bc305e543
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -7754,7 +7754,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: 45a6dd4e-a17a-4ddd-a312-9ca7e54e5b3a
+                    request_id: c6bcb79c-51c2-4db3-b8ac-913d43750d4e
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -7769,7 +7769,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e00fba61-d13b-4256-b524-6512e903bd52
+                    request_id: a749a964-8a53-42da-b4e5-1844c6579215
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7874,7 +7874,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 60c3c221-b223-40e2-a9e9-1a4e9fbda004
+                    request_id: 1de99a5d-f331-4f5e-9df4-f9806ea362a9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7961,7 +7961,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 65e0bdfd6abd0181dac15018
+                    intercom_user_id: 65e1a73bba4d122e24b988bb
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -7973,7 +7973,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b98ed429-a7dd-4d67-a7a9-2a1d90fd1bd2
+                    request_id: f7b11971-cb6b-4214-8255-99671eb6ac21
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8004,7 +8004,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0e97670a-c94d-4519-82d4-0a6dd223ca9f
+                    request_id: 79d44874-4764-45fd-b322-6b439826f022
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8048,7 +8048,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: l6utcvon3s6kyk64
+                    job_identifier: 5cipvo9e7a1onprm
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -8063,8 +8063,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1709209520
-                  created_at_before: 1709227520
+                  created_at_after: 1709269229
+                  created_at_before: 1709287229
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -8098,7 +8098,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: mn6k0skjojst06me
+                    job_identifier: d9wmxtozpplnb7k2
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -8130,7 +8130,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: l8p9t5l1h95cfpin
+                    job_identifier: xd866j88e4f17tfi
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -8191,30 +8191,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918472'
-                    created_at: 1709227522
+                    id: '403918319'
+                    created_at: 1709287232
                     body: heyy
                     message_type: inapp
-                    conversation_id: '706'
+                    conversation_id: '444'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918473'
-                    created_at: 1709227523
+                    id: '403918320'
+                    created_at: 1709287233
                     body: heyy
                     message_type: inapp
-                    conversation_id: '707'
+                    conversation_id: '445'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '25'
-                    created_at: 1709227525
+                    id: '15'
+                    created_at: 1709287235
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991268622'
+                      id: '991267876'
                       name: Ciaran279 Lee
                       email: admin279@email.com
                       away_mode_enabled: false
@@ -8229,14 +8229,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: 39feb561-faad-4f8e-a22f-eabbe0883eaf
+                    request_id: 42c294af-c94e-46f5-bd6a-3a46219cbb97
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: 2fb2d043-9631-40ac-9508-b3fc2c53f109
+                    request_id: dd58ab52-4246-4092-af90-45186414387b
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -8250,7 +8250,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: fda2a426-353e-4e7d-898d-59f8d5ca771c
+                    request_id: 5a74206c-3a5d-44a4-9130-5aebbf12267b
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -8264,7 +8264,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5ea84b3e-d6f9-4806-be6c-bee4f9b6d130
+                    request_id: f25e58df-951e-4866-9ef0-3f063f24f24c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8278,7 +8278,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 302f7ff2-f9d6-4e6e-83d4-2d3a1b99e0e2
+                    request_id: 7f02973c-c451-465f-a676-7aaff1eaa24c
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -8295,7 +8295,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65e0be026abd0181dac1501d
+                    id: 65e1a740ba4d122e24b988c0
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -8303,7 +8303,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 65e0be036abd0181dac1501e
+                    id: 65e1a741ba4d122e24b988c1
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -8311,10 +8311,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268622'
+                    id: '991267876'
                   to:
                     type: user
-                    id: 65e0be046abd0181dac1501f
+                    id: 65e1a742ba4d122e24b988c2
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -8322,10 +8322,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268624'
+                    id: '991267878'
                   to:
                     type: user
-                    id: 65e0be056abd0181dac15020
+                    id: 65e1a743ba4d122e24b988c3
                   message_type: inapp
                   body:
                   subject: heyy
@@ -8334,7 +8334,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268625'
+                    id: '991267879'
                   to:
                     type: user
                     user_id: '70'
@@ -8345,10 +8345,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268626'
+                    id: '991267880'
                   to:
                     type: user
-                    id: 65e0be066abd0181dac15022
+                    id: 65e1a744ba4d122e24b988c5
                   message_type: email
                   body:
                   subject: heyy
@@ -8379,12 +8379,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '57'
+                    - id: '29'
                       type: news-item
                       workspace_id: this_is_an_id515_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991268631
+                      sender_id: 991267885
                       state: draft
                       labels: []
                       cover_image_url:
@@ -8394,15 +8394,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709227528
-                      updated_at: 1709227528
+                      created_at: 1709287238
+                      updated_at: 1709287238
                       newsfeed_assignments: []
-                    - id: '58'
+                    - id: '30'
                       type: news-item
                       workspace_id: this_is_an_id515_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991268633
+                      sender_id: 991267887
                       state: draft
                       labels: []
                       cover_image_url:
@@ -8412,8 +8412,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709227528
-                      updated_at: 1709227528
+                      created_at: 1709287238
+                      updated_at: 1709287238
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -8426,7 +8426,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8b7d531b-3345-4885-9f92-6643d9bd81e4
+                    request_id: 2ed86a19-1a17-4b94-8361-18b69a2d3707
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8451,12 +8451,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '61'
+                    id: '33'
                     type: news-item
                     workspace_id: this_is_an_id519_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991268640
+                    sender_id: 991267894
                     state: live
                     labels:
                     - New
@@ -8467,10 +8467,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1709227530
-                    updated_at: 1709227530
+                    created_at: 1709287240
+                    updated_at: 1709287240
                     newsfeed_assignments:
-                    - newsfeed_id: 103
+                    - newsfeed_id: 53
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -8482,7 +8482,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 678c9b5a-37f9-4227-a080-d48c42c182a7
+                    request_id: 7eeb2bd6-d68a-4085-af22-3d40eb015439
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8503,14 +8503,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991268640
+                  sender_id: 991267894
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 103
+                  - newsfeed_id: 53
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -8539,12 +8539,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '62'
+                    id: '34'
                     type: news-item
                     workspace_id: this_is_an_id523_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991268643
+                    sender_id: 991267897
                     state: live
                     labels: []
                     cover_image_url:
@@ -8554,11 +8554,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1709227531
-                    updated_at: 1709227531
+                    created_at: 1709287241
+                    updated_at: 1709287241
                     newsfeed_assignments:
-                    - newsfeed_id: 105
-                      published_at: 1709227531
+                    - newsfeed_id: 55
+                      published_at: 1709287241
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -8569,7 +8569,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 5b3530af-e03e-4b4e-9096-dc7c2b7c7475
+                    request_id: 96f3214e-1859-4288-ac9d-e9b4d2d669fc
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8583,7 +8583,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8badf7a4-31b3-4098-8bd5-1561536435c6
+                    request_id: 26cf0e69-884a-4c12-93b5-939c03f7835d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8614,12 +8614,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '65'
+                    id: '37'
                     type: news-item
                     workspace_id: this_is_an_id529_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991268651
+                    sender_id: 991267905
                     state: live
                     labels: []
                     cover_image_url:
@@ -8627,8 +8627,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1709227532
-                    updated_at: 1709227533
+                    created_at: 1709287243
+                    updated_at: 1709287243
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -8640,7 +8640,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 5e36a61e-34da-406d-ac2a-cd7d1a803e0e
+                    request_id: f01ef503-e30b-47cf-9a55-75a09241db9d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8654,7 +8654,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bcf06938-ed48-4bee-a8f0-b4112421030b
+                    request_id: e18f1080-b04d-40b3-864f-80c558391bb2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8671,7 +8671,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991268651
+                  sender_id: 991267905
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -8680,7 +8680,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991268654
+                  sender_id: 991267908
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -8710,7 +8710,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '68'
+                    id: '40'
                     object: news-item
                     deleted: true
               schema:
@@ -8723,7 +8723,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 894409a1-50ed-443a-bdc3-cc12b20ab680
+                    request_id: 2645e679-b8d6-42c2-a031-02ff5c948a2a
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8737,7 +8737,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9a48c278-8b6d-4683-b950-cf0726224435
+                    request_id: 847c5f0c-1c5f-4b37-94f6-7158d02680c3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8790,7 +8790,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7d3c9ca9-d7d5-415d-960c-3622590a9e90
+                    request_id: 1c0c0f33-e091-43eb-bc69-39e33eb9413f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8823,16 +8823,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '118'
+                    - id: '68'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709227538
-                      updated_at: 1709227538
-                    - id: '119'
+                      created_at: 1709287248
+                      updated_at: 1709287248
+                    - id: '69'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709227538
-                      updated_at: 1709227538
+                      created_at: 1709287248
+                      updated_at: 1709287248
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -8844,7 +8844,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 695a8e56-b83c-49b1-93a6-77bc34f7ebc1
+                    request_id: 588b8384-c6f1-461e-8fdb-9768da4a6c82
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8878,11 +8878,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '122'
+                    id: '72'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1709227538
-                    updated_at: 1709227538
+                    created_at: 1709287249
+                    updated_at: 1709287249
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -8893,7 +8893,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5d03d0a7-669f-49cf-95e6-84b8bcb44123
+                    request_id: 6f8baeb6-72d1-4004-8b2a-8d63e1dbe039
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8927,14 +8927,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '63'
-                    created_at: 1708536339
+                    id: '47'
+                    created_at: 1708596050
                     contact:
                       type: contact
-                      id: 65e0be136abd0181dac15025
+                      id: 65e1a752ba4d122e24b988c8
                     author:
                       type: admin
-                      id: '991268670'
+                      id: '991267924'
                       name: Ciaran326 Lee
                       email: admin326@email.com
                       away_mode_enabled: false
@@ -8950,7 +8950,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: ab298099-1d96-4570-affc-34210a313212
+                    request_id: 4756dff2-224f-47aa-8144-9efccbe0f6eb
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8964,7 +8964,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 00ba6a8c-efba-45e6-8c47-cddcd1a722a6
+                    request_id: 2d0b68cd-f6e5-42ba-bd14-ac0e040d7e25
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9000,16 +9000,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 65e0be156abd0181dac15028
+                      id: 65e1a754ba4d122e24b988cb
                       name: John segment
-                      created_at: 1709227541
-                      updated_at: 1709227541
+                      created_at: 1709287252
+                      updated_at: 1709287252
                       person_type: user
                     - type: segment
-                      id: 65e0be156abd0181dac15029
+                      id: 65e1a754ba4d122e24b988cc
                       name: Jane segment
-                      created_at: 1709227541
-                      updated_at: 1709227541
+                      created_at: 1709287252
+                      updated_at: 1709287252
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -9021,7 +9021,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 144674bc-8e04-4e16-8a2f-2fd129366699
+                    request_id: ad248267-4422-43bf-a19a-cc4b89b4993b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9055,10 +9055,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 65e0be166abd0181dac1502c
+                    id: 65e1a755ba4d122e24b988cf
                     name: John segment
-                    created_at: 1709227542
-                    updated_at: 1709227542
+                    created_at: 1709287253
+                    updated_at: 1709287253
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -9070,7 +9070,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: 66a03d15-5922-4f85-85d4-581e6fe15029
+                    request_id: bb5531ef-31c8-4663-aee1-22941812cb72
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9084,7 +9084,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7c2d75bc-9e7b-433c-baec-8553d8923deb
+                    request_id: 4c5b4724-452a-4895-88b4-bd12fcb0354f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9114,7 +9114,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '229'
+                      id: '181'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -9137,7 +9137,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fd7b22ee-0b65-4407-988b-5eecac5e0139
+                    request_id: 0e2418ea-1332-4ebb-8646-a057962cb69a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9167,7 +9167,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/fb68eebc-ddd4-430e-b3f7-287bb388d7bf
+                    url: http://via.intercom.io/msgr/8050272c-d0d3-4078-820a-34e590013d8f
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -9200,7 +9200,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '083b682e-1657-4a62-b9f4-322adfeae5fd'
+                    request_id: 1390c356-3c49-47a4-ac84-4392f1aac756
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9263,7 +9263,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '192'
+                      id: '124'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -9275,7 +9275,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 39bd135a-f677-4ecc-9f24-528d1565fe1f
+                    request_id: ccee2feb-f972-4282-a36f-f8531d52a62f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9314,7 +9314,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '195'
+                    id: '127'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9326,7 +9326,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: 5cd7b647-7e2f-4169-ba61-8c8541ec2ad5
+                    request_id: 4353caed-ed5d-4788-aa04-48120c813e06
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -9340,14 +9340,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: 040c319f-bdd8-423e-8cd4-6e787202ad5f
+                    request_id: c3b24f5c-4998-40c1-86d0-176e5e7837a6
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: 68b00384-fc9b-4af1-bfea-eb4f60c6b14e
+                    request_id: 3f261d15-f16e-4666-82e8-56954d768bb7
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -9361,7 +9361,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ddb970dd-a463-4675-8977-a3f1aaf869b1
+                    request_id: d51c80c0-390c-4cad-ab39-0950b6e0ac72
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9427,7 +9427,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '203'
+                    id: '135'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9439,7 +9439,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: c0a49163-7dde-4af4-b629-3024f318b516
+                    request_id: 7391b97b-327b-45cb-81c0-03ee63d62bea
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9453,7 +9453,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b7fef1f5-0877-4842-afc7-24c371c88070
+                    request_id: 98c6b555-e8bb-4db9-91f7-444d92dbf3f5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9489,7 +9489,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 2b431786-898a-450d-81d1-6f18d9fcefc8
+                    request_id: 197efe89-e109-4370-ad64-0d5fdc6636c8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9503,7 +9503,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: 49561cea-8bb6-4b7f-9005-072659563869
+                    request_id: aacb79a4-2a45-478e-a91b-69952eb8c56d
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -9518,7 +9518,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 93d5ee54-8e35-40a0-ac2f-b2e8747b303f
+                    request_id: 79c576fa-4044-417f-902b-262cf3f976ce
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9556,7 +9556,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b92bd16f-3633-46f0-b6da-7074b6ea24ee
+                    request_id: ad3f88c9-77bb-46a1-a606-33d67eb5e931
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9591,7 +9591,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991268708'
+                    id: '991267962'
                     name: team 1
                     admin_ids: []
               schema:
@@ -9604,7 +9604,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: 901cb30c-5af6-477c-b654-058c925abce3
+                    request_id: ccf0f00d-e36b-4cbc-894f-d871977183bf
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -9618,7 +9618,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 39b43da3-8f71-4795-ae98-47dadbafa9dc
+                    request_id: 6889fe71-c089-47f9-998c-2a33741296ec
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9651,7 +9651,7 @@ paths:
                 Ticket Type Attribute created:
                   value:
                     type: ticket_type_attribute
-                    id: '322'
+                    id: '196'
                     workspace_id: this_is_an_id621_that_should_be_at_least_
                     name: Attribute Title
                     description: Attribute Description
@@ -9664,10 +9664,10 @@ paths:
                     visible_on_create: true
                     visible_to_contacts: true
                     default: false
-                    ticket_type_id: 110
+                    ticket_type_id: 75
                     archived: false
-                    created_at: 1709227560
-                    updated_at: 1709227560
+                    created_at: 1709287272
+                    updated_at: 1709287272
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -9678,7 +9678,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 38fbdd5e-3561-44f6-9a7e-e83e380fb0f8
+                    request_id: 7c47ecc1-c66e-4221-913f-2ba67b5c199c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9731,7 +9731,7 @@ paths:
                 Ticket Type Attribute updated:
                   value:
                     type: ticket_type_attribute
-                    id: '327'
+                    id: '201'
                     workspace_id: this_is_an_id625_that_should_be_at_least_
                     name: name
                     description: New Attribute Description
@@ -9742,10 +9742,10 @@ paths:
                     visible_on_create: false
                     visible_to_contacts: false
                     default: false
-                    ticket_type_id: 112
+                    ticket_type_id: 77
                     archived: false
-                    created_at: 1709227561
-                    updated_at: 1709227561
+                    created_at: 1709287273
+                    updated_at: 1709287273
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -9756,7 +9756,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dc4d6571-91c5-4a5c-b8ac-94eab339d855
+                    request_id: 00e72481-5c01-40c3-9403-28533e57f7e0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9795,20 +9795,20 @@ paths:
                     type: list
                     data:
                     - type: ticket_type
-                      id: '114'
+                      id: '79'
                       name: Bug Report
                       description: Bug Report Template
                       icon: "\U0001F39F️"
                       workspace_id: this_is_an_id629_that_should_be_at_least_
                       archived: false
-                      created_at: 1709227562
-                      updated_at: 1709227562
+                      created_at: 1709287274
+                      updated_at: 1709287274
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '330'
+                          id: '204'
                           workspace_id: this_is_an_id629_that_should_be_at_least_
                           name: _default_title_
                           description: ''
@@ -9821,12 +9821,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 114
+                          ticket_type_id: 79
                           archived: false
-                          created_at: 1709227562
-                          updated_at: 1709227562
+                          created_at: 1709287274
+                          updated_at: 1709287274
                         - type: ticket_type_attribute
-                          id: '332'
+                          id: '206'
                           workspace_id: this_is_an_id629_that_should_be_at_least_
                           name: name
                           description: description
@@ -9838,12 +9838,12 @@ paths:
                           visible_on_create: false
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 114
+                          ticket_type_id: 79
                           archived: false
-                          created_at: 1709227562
-                          updated_at: 1709227562
+                          created_at: 1709287274
+                          updated_at: 1709287274
                         - type: ticket_type_attribute
-                          id: '331'
+                          id: '205'
                           workspace_id: this_is_an_id629_that_should_be_at_least_
                           name: _default_description_
                           description: ''
@@ -9856,10 +9856,10 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 114
+                          ticket_type_id: 79
                           archived: false
-                          created_at: 1709227562
-                          updated_at: 1709227562
+                          created_at: 1709287274
+                          updated_at: 1709287274
                       category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type_list"
@@ -9871,7 +9871,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 56035eff-972a-4ae6-9357-f7422eb26110
+                    request_id: 0bf52318-469a-4659-92fc-80f5aae04998
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9900,20 +9900,20 @@ paths:
                 Ticket type created:
                   value:
                     type: ticket_type
-                    id: '117'
+                    id: '82'
                     name: Customer Issue
                     description: Customer Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id633_that_should_be_at_least_
                     archived: false
-                    created_at: 1709227563
-                    updated_at: 1709227563
+                    created_at: 1709287275
+                    updated_at: 1709287275
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '339'
+                        id: '213'
                         workspace_id: this_is_an_id633_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -9926,12 +9926,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 117
+                        ticket_type_id: 82
                         archived: false
-                        created_at: 1709227563
-                        updated_at: 1709227563
+                        created_at: 1709287275
+                        updated_at: 1709287275
                       - type: ticket_type_attribute
-                        id: '340'
+                        id: '214'
                         workspace_id: this_is_an_id633_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -9944,10 +9944,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 117
+                        ticket_type_id: 82
                         archived: false
-                        created_at: 1709227563
-                        updated_at: 1709227563
+                        created_at: 1709287275
+                        updated_at: 1709287275
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -9959,7 +9959,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ecf3ddb6-d105-4c92-ad99-cea3e05bcb4c
+                    request_id: 0cf46dd3-f8dc-433a-95f8-34e6ef47d731
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10005,20 +10005,20 @@ paths:
                 Ticket type found:
                   value:
                     type: ticket_type
-                    id: '119'
+                    id: '84'
                     name: Bug Report
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id637_that_should_be_at_least_
                     archived: false
-                    created_at: 1709227564
-                    updated_at: 1709227564
+                    created_at: 1709287276
+                    updated_at: 1709287276
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '344'
+                        id: '218'
                         workspace_id: this_is_an_id637_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -10031,12 +10031,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 119
+                        ticket_type_id: 84
                         archived: false
-                        created_at: 1709227564
-                        updated_at: 1709227564
+                        created_at: 1709287276
+                        updated_at: 1709287276
                       - type: ticket_type_attribute
-                        id: '346'
+                        id: '220'
                         workspace_id: this_is_an_id637_that_should_be_at_least_
                         name: name
                         description: description
@@ -10048,12 +10048,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 119
+                        ticket_type_id: 84
                         archived: false
-                        created_at: 1709227564
-                        updated_at: 1709227564
+                        created_at: 1709287276
+                        updated_at: 1709287276
                       - type: ticket_type_attribute
-                        id: '345'
+                        id: '219'
                         workspace_id: this_is_an_id637_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -10066,10 +10066,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 119
+                        ticket_type_id: 84
                         archived: false
-                        created_at: 1709227564
-                        updated_at: 1709227564
+                        created_at: 1709287276
+                        updated_at: 1709287276
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -10081,7 +10081,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cc7abf41-6b93-43be-ae29-97fd72b290b1
+                    request_id: cb622325-6d77-4321-b60c-951059d423f9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10114,20 +10114,20 @@ paths:
                 Ticket type updated:
                   value:
                     type: ticket_type
-                    id: '121'
+                    id: '86'
                     name: Bug Report 2
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id641_that_should_be_at_least_
                     archived: false
-                    created_at: 1709227565
-                    updated_at: 1709227565
+                    created_at: 1709287277
+                    updated_at: 1709287278
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '350'
+                        id: '224'
                         workspace_id: this_is_an_id641_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -10140,12 +10140,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 121
+                        ticket_type_id: 86
                         archived: false
-                        created_at: 1709227565
-                        updated_at: 1709227565
+                        created_at: 1709287277
+                        updated_at: 1709287277
                       - type: ticket_type_attribute
-                        id: '352'
+                        id: '226'
                         workspace_id: this_is_an_id641_that_should_be_at_least_
                         name: name
                         description: description
@@ -10157,12 +10157,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 121
+                        ticket_type_id: 86
                         archived: false
-                        created_at: 1709227565
-                        updated_at: 1709227565
+                        created_at: 1709287278
+                        updated_at: 1709287278
                       - type: ticket_type_attribute
-                        id: '351'
+                        id: '225'
                         workspace_id: this_is_an_id641_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -10175,10 +10175,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 121
+                        ticket_type_id: 86
                         archived: false
-                        created_at: 1709227565
-                        updated_at: 1709227565
+                        created_at: 1709287278
+                        updated_at: 1709287278
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -10190,7 +10190,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c56634a7-edd2-4115-b316-0b6d2e064055
+                    request_id: d11fff50-487a-4700-ac01-a8f1e7e283c4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10236,13 +10236,13 @@ paths:
                 User reply:
                   value:
                     type: ticket_part
-                    id: '163'
+                    id: '120'
                     part_type: comment
                     body: "<p>Thanks again :)</p>"
-                    created_at: 1709227568
-                    updated_at: 1709227568
+                    created_at: 1709287281
+                    updated_at: 1709287281
                     author:
-                      id: 65e0be2f6abd0181dac1504f
+                      id: 65e1a770ba4d122e24b988f2
                       type: user
                       name:
                       email: user30@email.com
@@ -10251,7 +10251,7 @@ paths:
                 Admin note reply:
                   value:
                     type: ticket_part
-                    id: '165'
+                    id: '122'
                     part_type: note
                     body: |-
                       <h2>An Unordered HTML List</h2>
@@ -10266,10 +10266,10 @@ paths:
                       <li>Tea</li>
                       <li>Milk</li>
                       </ol>
-                    created_at: 1709227570
-                    updated_at: 1709227570
+                    created_at: 1709287285
+                    updated_at: 1709287285
                     author:
-                      id: '991268735'
+                      id: '991267989'
                       type: admin
                       name: Ciaran385 Lee
                       email: admin385@email.com
@@ -10278,12 +10278,12 @@ paths:
                 Admin quick_reply reply:
                   value:
                     type: ticket_part
-                    id: '167'
+                    id: '124'
                     part_type: quick_reply
-                    created_at: 1709227573
-                    updated_at: 1709227573
+                    created_at: 1709287288
+                    updated_at: 1709287288
                     author:
-                      id: '991268740'
+                      id: '991267994'
                       type: admin
                       name: Ciaran389 Lee
                       email: admin389@email.com
@@ -10299,7 +10299,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: ba42ac82-044b-47ef-a7a4-50ae1f86443f
+                    request_id: 157367be-e058-4d54-83f9-13185566c114
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -10313,7 +10313,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b9dbfb7f-28d9-4b02-b6b2-c9592ed8f656
+                    request_id: 75bd622a-ac99-48cf-babd-211fff7417db
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10330,14 +10330,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0be2f6abd0181dac1504f
+                  intercom_user_id: 65e1a770ba4d122e24b988f2
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991268735
+                  admin_id: 991267989
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -10347,18 +10347,18 @@ paths:
                 value:
                   message_type: quick_reply
                   type: admin
-                  admin_id: 991268740
+                  admin_id: 991267994
                   reply_options:
                   - text: 'Yes'
-                    uuid: 7c62a524-65c0-4e3f-a2a6-62fd1ebab674
+                    uuid: d7a4d536-b9be-4667-87be-2b5c3142b263
                   - text: 'No'
-                    uuid: b158b19a-d87a-4d13-835f-73d2d854910e
+                    uuid: 041f9cc9-8bfe-4177-87fb-4f9c34611228
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0be366abd0181dac15052
+                  intercom_user_id: 65e1a779ba4d122e24b988f5
                   body: Thanks again :)
   "/tickets/{ticket_id}/tags":
     post:
@@ -10390,7 +10390,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '211'
+                    id: '143'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -10402,7 +10402,7 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: 285d793f-8f0f-43a2-9780-d74d0aad4141
+                    request_id: 52261e2b-364d-4078-80f4-c8683a580b11
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
@@ -10416,7 +10416,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '04615268-ef02-4704-88ce-09305d222ef3'
+                    request_id: 500191ad-9b8f-4fc1-bd97-7799b7abfdd9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10445,13 +10445,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 211
-                  admin_id: 991268750
+                  id: 143
+                  admin_id: 991268004
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  id: 212
-                  admin_id: 991268753
+                  id: 144
+                  admin_id: 991268007
   "/tickets/{ticket_id}/tags/{id}":
     delete:
       summary: Remove tag from a ticket
@@ -10489,7 +10489,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '214'
+                    id: '146'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -10501,14 +10501,14 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: 2494e815-8f3d-4def-83e9-5e95d44ea94e
+                    request_id: dbf24ad5-0812-4c34-852c-2ac7fbc8916b
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 851f364a-389e-4165-9d09-176d2a9930c9
+                    request_id: ec6c3e6d-69c2-4b0f-9375-8a3c0952d807
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -10522,7 +10522,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f91cde7d-68dc-4496-8f07-1c3331af7049
+                    request_id: 1fbb6ef2-71c7-4e0c-989d-5cf99e5d8b76
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10545,15 +10545,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991268759
+                  admin_id: 991268013
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  admin_id: 991268762
+                  admin_id: 991268016
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991268765
+                  admin_id: 991268019
   "/tickets":
     post:
       summary: Create a ticket
@@ -10575,28 +10575,28 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '719'
-                    ticket_id: '35'
+                    id: '457'
+                    ticket_id: '46'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '135'
+                      id: '100'
                       name: my-ticket-type-15
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id669_that_should_be_at_least_
                       archived: false
-                      created_at: 1709227586
-                      updated_at: 1709227586
+                      created_at: 1709287308
+                      updated_at: 1709287308
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '364'
+                          id: '238'
                           workspace_id: this_is_an_id669_that_should_be_at_least_
                           name: title
                           description: ola
@@ -10608,12 +10608,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 135
+                          ticket_type_id: 100
                           archived: false
-                          created_at: 1709227586
-                          updated_at: 1709227586
+                          created_at: 1709287308
+                          updated_at: 1709287308
                         - type: ticket_type_attribute
-                          id: '365'
+                          id: '239'
                           workspace_id: this_is_an_id669_that_should_be_at_least_
                           name: description
                           description: ola
@@ -10625,33 +10625,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 135
+                          ticket_type_id: 100
                           archived: false
-                          created_at: 1709227587
-                          updated_at: 1709227587
+                          created_at: 1709287308
+                          updated_at: 1709287308
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0be436abd0181dac1505a
+                        id: 65e1a78cba4d122e24b988fd
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709227587
-                    updated_at: 1709227587
+                    created_at: 1709287309
+                    updated_at: 1709287309
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '168'
+                        id: '125'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709227587
-                        updated_at: 1709227587
+                        created_at: 1709287309
+                        updated_at: 1709287309
                         author:
-                          id: '991268777'
+                          id: '991268031'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id669_that_should_be_at_least_@intercom.io
@@ -10676,7 +10676,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4a4bd392-66f5-4a3c-a9b1-c6d89ff62362
+                    request_id: dd8f33d6-3043-424c-a341-54649c90a6dd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10691,9 +10691,9 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  ticket_type_id: 135
+                  ticket_type_id: 100
                   contacts:
-                  - id: 65e0be436abd0181dac1505a
+                  - id: 65e1a78cba4d122e24b988fd
                   ticket_attributes:
                     title: example
                     description: there is a problem
@@ -10724,28 +10724,28 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '720'
-                    ticket_id: '36'
+                    id: '458'
+                    ticket_id: '47'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: in_progress
                     ticket_type:
                       type: ticket_type
-                      id: '137'
+                      id: '102'
                       name: my-ticket-type-17
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id673_that_should_be_at_least_
                       archived: false
-                      created_at: 1709227589
-                      updated_at: 1709227589
+                      created_at: 1709287310
+                      updated_at: 1709287310
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '369'
+                          id: '243'
                           workspace_id: this_is_an_id673_that_should_be_at_least_
                           name: title
                           description: ola
@@ -10757,12 +10757,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 137
+                          ticket_type_id: 102
                           archived: false
-                          created_at: 1709227589
-                          updated_at: 1709227589
+                          created_at: 1709287311
+                          updated_at: 1709287311
                         - type: ticket_type_attribute
-                          id: '370'
+                          id: '244'
                           workspace_id: this_is_an_id673_that_should_be_at_least_
                           name: description
                           description: ola
@@ -10774,98 +10774,98 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 137
+                          ticket_type_id: 102
                           archived: false
-                          created_at: 1709227589
-                          updated_at: 1709227589
+                          created_at: 1709287311
+                          updated_at: 1709287311
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0be456abd0181dac1505b
-                        external_id: df39deff-f249-4449-b4cb-673dd9be8a4d
-                    admin_assignee_id: '991268791'
+                        id: 65e1a78fba4d122e24b988fe
+                        external_id: 14591f94-bf38-4517-95b3-776e6b74ec11
+                    admin_assignee_id: '991268045'
                     team_assignee_id: '0'
-                    created_at: 1709227589
-                    updated_at: 1709227592
+                    created_at: 1709287311
+                    updated_at: 1709287315
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '169'
+                        id: '126'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709227590
-                        updated_at: 1709227590
+                        created_at: 1709287312
+                        updated_at: 1709287312
                         author:
-                          id: '991268789'
+                          id: '991268043'
                           type: admin
                           name: Ciaran429 Lee
                           email: admin429@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '170'
+                        id: '127'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709227591
-                        updated_at: 1709227591
+                        created_at: 1709287314
+                        updated_at: 1709287314
                         author:
-                          id: '991268790'
+                          id: '991268044'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id673_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '171'
+                        id: '128'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709227591
-                        updated_at: 1709227591
+                        created_at: 1709287314
+                        updated_at: 1709287314
                         author:
-                          id: '991268790'
+                          id: '991268044'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id673_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '172'
+                        id: '129'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: in_progress
                         previous_ticket_state: submitted
-                        created_at: 1709227591
-                        updated_at: 1709227591
+                        created_at: 1709287314
+                        updated_at: 1709287314
                         author:
-                          id: '991268790'
+                          id: '991268044'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id673_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '173'
+                        id: '130'
                         part_type: assignment
-                        created_at: 1709227591
-                        updated_at: 1709227591
+                        created_at: 1709287314
+                        updated_at: 1709287314
                         assigned_to:
                           type: admin
-                          id: '991268791'
+                          id: '991268045'
                         author:
-                          id: '991268789'
+                          id: '991268043'
                           type: admin
                           name: Ciaran429 Lee
                           email: admin429@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '174'
+                        id: '131'
                         part_type: snoozed
-                        created_at: 1709227592
-                        updated_at: 1709227592
+                        created_at: 1709287315
+                        updated_at: 1709287315
                         author:
-                          id: '991268790'
+                          id: '991268044'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id673_that_should_be_at_least_@intercom.io
@@ -10873,7 +10873,7 @@ paths:
                         redacted: false
                       total_count: 6
                     open: true
-                    snoozed_until: 1709312400
+                    snoozed_until: 1709398800
                     linked_objects:
                       type: list
                       data: []
@@ -10891,14 +10891,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 89174ebe-8645-4da3-b905-365118a661fc
+                    request_id: ceb02dca-b654-464f-9339-dfa11c8ff74d
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
                 Assignee not found:
                   value:
                     type: error.list
-                    request_id: 82897bf7-81b5-42e9-a2b5-2174aad14478
+                    request_id: 06d6a32c-52b5-4717-9031-c78b16916e13
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
@@ -10910,7 +10910,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c55fb7e2-086c-4af4-a055-dfe6acfbce94
+                    request_id: 9fa6d8fe-da41-4d17-b626-5cb3da08d356
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10930,8 +10930,8 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991268789'
-                    assignee_id: '991268791'
+                    admin_id: '991268043'
+                    assignee_id: '991268045'
                   open: true
                   snoozed_until: 1673609604
               admin_not_found:
@@ -10943,7 +10943,7 @@ paths:
                   state: in_progress
                   assignment:
                     admin_id: '123'
-                    assignee_id: '991268799'
+                    assignee_id: '991268053'
               assignee_not_found:
                 summary: Assignee not found
                 value:
@@ -10952,7 +10952,7 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991268805'
+                    admin_id: '991268059'
                     assignee_id: '456'
     get:
       summary: Retrieve a ticket
@@ -10980,28 +10980,28 @@ paths:
                 Ticket found:
                   value:
                     type: ticket
-                    id: '723'
-                    ticket_id: '39'
+                    id: '461'
+                    ticket_id: '50'
                     ticket_attributes:
                       title: attribute_value
                       description:
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '141'
+                      id: '106'
                       name: my-ticket-type-21
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id681_that_should_be_at_least_
                       archived: false
-                      created_at: 1709227597
-                      updated_at: 1709227597
+                      created_at: 1709287322
+                      updated_at: 1709287322
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '380'
+                          id: '254'
                           workspace_id: this_is_an_id681_that_should_be_at_least_
                           name: title
                           description: ola
@@ -11013,12 +11013,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 141
+                          ticket_type_id: 106
                           archived: false
-                          created_at: 1709227597
-                          updated_at: 1709227597
+                          created_at: 1709287322
+                          updated_at: 1709287322
                         - type: ticket_type_attribute
-                          id: '381'
+                          id: '255'
                           workspace_id: this_is_an_id681_that_should_be_at_least_
                           name: description
                           description: ola
@@ -11030,33 +11030,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 141
+                          ticket_type_id: 106
                           archived: false
-                          created_at: 1709227597
-                          updated_at: 1709227597
+                          created_at: 1709287322
+                          updated_at: 1709287322
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0be4d6abd0181dac1505e
-                        external_id: 3bf85af7-4d13-46d8-9305-32afc85940ae
+                        id: 65e1a79bba4d122e24b98901
+                        external_id: 49ee0694-a1f0-45b3-b4a7-66366c4a44fd
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709227598
-                    updated_at: 1709227598
+                    created_at: 1709287323
+                    updated_at: 1709287323
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '177'
+                        id: '134'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709227598
-                        updated_at: 1709227598
+                        created_at: 1709287323
+                        updated_at: 1709287323
                         author:
-                          id: '991268818'
+                          id: '991268072'
                           type: admin
                           name: Ciaran455 Lee
                           email: admin455@email.com
@@ -11081,7 +11081,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a85f0d0d-356d-412c-8115-b74fff1d52de
+                    request_id: 35bb0d3b-6603-4d2b-bceb-70dda9faed54
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11167,28 +11167,28 @@ paths:
                     total_count: 1
                     tickets:
                     - type: ticket
-                      id: '724'
-                      ticket_id: '40'
+                      id: '462'
+                      ticket_id: '51'
                       ticket_attributes:
                         title: attribute_value
                         description:
                       ticket_state: submitted
                       ticket_type:
                         type: ticket_type
-                        id: '143'
+                        id: '108'
                         name: my-ticket-type-23
                         description: my ticket type description is awesome.
                         icon: "\U0001F981"
                         workspace_id: this_is_an_id685_that_should_be_at_least_
                         archived: false
-                        created_at: 1709227599
-                        updated_at: 1709227599
+                        created_at: 1709287326
+                        updated_at: 1709287326
                         is_internal: false
                         ticket_type_attributes:
                           type: list
                           data:
                           - type: ticket_type_attribute
-                            id: '385'
+                            id: '259'
                             workspace_id: this_is_an_id685_that_should_be_at_least_
                             name: title
                             description: ola
@@ -11200,12 +11200,12 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 143
+                            ticket_type_id: 108
                             archived: false
-                            created_at: 1709227600
-                            updated_at: 1709227600
+                            created_at: 1709287326
+                            updated_at: 1709287326
                           - type: ticket_type_attribute
-                            id: '386'
+                            id: '260'
                             workspace_id: this_is_an_id685_that_should_be_at_least_
                             name: description
                             description: ola
@@ -11217,33 +11217,33 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 143
+                            ticket_type_id: 108
                             archived: false
-                            created_at: 1709227600
-                            updated_at: 1709227600
+                            created_at: 1709287326
+                            updated_at: 1709287326
                         category: Back-office
                       contacts:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0be506abd0181dac1505f
-                          external_id: 91a518b5-8bd2-4b9f-85b4-4355059f3da1
+                          id: 65e1a79fba4d122e24b98902
+                          external_id: b9acf8e4-b640-488e-a28f-33a69a5cc2fe
                       admin_assignee_id: '0'
                       team_assignee_id: '0'
-                      created_at: 1709227600
-                      updated_at: 1709227600
+                      created_at: 1709287327
+                      updated_at: 1709287328
                       ticket_parts:
                         type: ticket_part.list
                         ticket_parts:
                         - type: ticket_part
-                          id: '178'
+                          id: '135'
                           part_type: ticket_state_updated_by_admin
                           ticket_state: submitted
                           previous_ticket_state: submitted
-                          created_at: 1709227600
-                          updated_at: 1709227600
+                          created_at: 1709287328
+                          updated_at: 1709287328
                           author:
-                            id: '991268831'
+                            id: '991268085'
                             type: admin
                             name: Ciaran467 Lee
                             email: admin467@email.com
@@ -11274,15 +11274,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '724'
+                      value: '462'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '724'
+                        value: '462'
                       - field: id
                         operator: "="
-                        value: '724'
+                        value: '462'
   "/visitors":
     put:
       summary: Update a visitor
@@ -11309,26 +11309,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0be526abd0181dac15062
+                    id: 65e1a7a2ba4d122e24b98905
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Cyan Rhino
+                    pseudonym: Indigo Mug
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/cyan-rhino.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/indigo-mug.png
                     app_id: this_is_an_id689_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709227602
-                    remote_created_at: 1709227602
-                    signed_up_at: 1709227602
-                    updated_at: 1709227603
+                    created_at: 1709287330
+                    remote_created_at: 1709287330
+                    signed_up_at: 1709287330
+                    updated_at: 1709287331
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -11361,7 +11361,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 77cb6760-4e67-449c-ba50-09ee30264f49
+                    request_id: 9ea9fdb4-3805-45ef-9afc-12efecea94ef
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -11375,7 +11375,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 25236b69-f2bd-4bc6-aed5-efac7043034e
+                    request_id: c8effeaf-c364-4aeb-a8a9-95fe3207ff2c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11390,7 +11390,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 65e0be526abd0181dac15062
+                  id: 65e1a7a2ba4d122e24b98905
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -11423,7 +11423,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0be546abd0181dac15068
+                    id: 65e1a7a4ba4d122e24b9890b
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -11439,10 +11439,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709227604
-                    remote_created_at: 1709227604
-                    signed_up_at: 1709227604
-                    updated_at: 1709227604
+                    created_at: 1709287332
+                    remote_created_at: 1709287332
+                    signed_up_at: 1709287332
+                    updated_at: 1709287332
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -11475,7 +11475,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: e000120c-8039-4698-b482-d6db4cd323d7
+                    request_id: d7747e79-f9e2-47a9-a5f3-eff7438cd2a3
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -11489,7 +11489,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d7bc39a1-c111-4e73-a4ad-ee5f1435347c
+                    request_id: e811c640-1435-4c7a-a76f-6fc62f534d10
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11523,7 +11523,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0be556abd0181dac1506e
+                    id: 65e1a7a6ba4d122e24b98911
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -11539,10 +11539,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709227605
-                    remote_created_at: 1709227605
-                    signed_up_at: 1709227605
-                    updated_at: 1709227605
+                    created_at: 1709287334
+                    remote_created_at: 1709287334
+                    signed_up_at: 1709287334
+                    updated_at: 1709287334
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -11575,7 +11575,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: 726551fa-cbb8-4ded-8083-0d6e607f9a6c
+                    request_id: e5b611e9-7468-4d75-b946-ba37ccc6e451
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -11589,7 +11589,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b2eb50d0-699c-482b-b6ba-5d0d46d00255
+                    request_id: '086e2aee-051b-4dbf-9645-290dcbc345d7'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11622,7 +11622,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0be576abd0181dac15074
+                    id: 65e1a7a7ba4d122e24b98917
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -11638,10 +11638,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709227607
-                    remote_created_at: 1709227607
-                    signed_up_at: 1709227607
-                    updated_at: 1709227607
+                    created_at: 1709287336
+                    remote_created_at: 1709287335
+                    signed_up_at: 1709287335
+                    updated_at: 1709287336
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -11674,7 +11674,7 @@ paths:
                 Visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 8f42d00b-4153-4a0f-adee-91bba99a278b
+                    request_id: 4314bcf7-6556-479c-984a-8b4227663553
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -11688,7 +11688,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ef8f8037-045b-4ccd-b06b-483c404f727d
+                    request_id: 48deb8cf-eded-4168-9859-a6b71775a1a4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11719,7 +11719,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0be596abd0181dac1507b
+                    id: 65e1a7aaba4d122e24b9891e
                     workspace_id: this_is_an_id713_that_should_be_at_least_
                     external_id:
                     role: user
@@ -11735,9 +11735,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709227609
-                    updated_at: 1709227609
-                    signed_up_at: 1709227609
+                    created_at: 1709287338
+                    updated_at: 1709287338
+                    signed_up_at: 1709287337
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -11771,31 +11771,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0be596abd0181dac1507b/tags"
+                      url: "/contacts/65e1a7aaba4d122e24b9891e/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0be596abd0181dac1507b/notes"
+                      url: "/contacts/65e1a7aaba4d122e24b9891e/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0be596abd0181dac1507b/companies"
+                      url: "/contacts/65e1a7aaba4d122e24b9891e/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0be596abd0181dac1507b/subscriptions"
+                      url: "/contacts/65e1a7aaba4d122e24b9891e/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0be596abd0181dac1507b/subscriptions"
+                      url: "/contacts/65e1a7aaba4d122e24b9891e/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -11814,7 +11814,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 860672f5-a2dc-4beb-8e98-4ccb244f43b5
+                    request_id: 675a4ceb-c14c-4f45-909a-b43021dc10cc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -14333,7 +14333,8 @@ components:
       properties:
         type:
           type: string
-          description: This includes conversation, push, facebook, twitter and email.
+          description: This includes conversation, email, facebook, instagram, phone_call,
+            phone_switch, push, sms, twitter and whatsapp.
           example: conversation
         id:
           type: string

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991266214'
+                    id: '991268286'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1709049451
+                      created_at: 1709227259
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991266215'
+                    id: '991268287'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 66e44634-37d1-41bd-8232-5c9e1f93b1ab
+                    request_id: 54795f10-2e16-4d26-8191-dc398b5ecb2b
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ef54ab3a-c802-47d4-b400-4c8f19392ef4
+                    request_id: 8b54612f-b786-414f-89e1-07fd9b20b744
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: 7bb48d89-2ee0-43e2-a8dc-7255ed9345c4
+                    - id: edeb6317-64d8-40a8-8d55-0e1b24e12405
                       performed_by:
                         type: admin
-                        id: '991266219'
+                        id: '991268291'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1709049457
+                      created_at: 1709227265
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: 5397d05a-f87a-4596-999e-5fdd713d50ed
+                    - id: a0ed01e2-5812-48b3-9193-b800af91cf7c
                       performed_by:
                         type: admin
-                        id: '991266219'
+                        id: '991268291'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1709049457
+                      created_at: 1709227265
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a0a4becd-c5c0-4105-b1da-0c7c0a94286a
+                    request_id: a172cc31-bd28-4dd5-a06a-6add5ad89f38
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991266221'
+                      id: '991268293'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ab54ccec-6303-4a87-8229-5c510714a0ca
+                    request_id: f03eba4b-25f4-46dc-a298-68e51ccc05b5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991266223'
+                    id: '991268295'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: fbffa47a-5b19-45fc-96f0-9fbd336bb6bf
+                    request_id: f281efca-c9c0-41a8-a019-094a224b99de
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f1f120e2-5751-40be-b4b4-d151ff41c82a
+                    request_id: 47b9bedd-6fcc-4f6a-9cd2-7e5c4640b3a0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -381,28 +381,28 @@ paths:
                     data:
                     - id: 1
                       type: content_import_source
-                      last_synced_at: 1709049461
+                      last_synced_at: 1709227268
                       status: active
                       url: https://support.example.com/us/1
                       sync_behavior: automatic
-                      created_at: 1709049461
-                      updated_at: 1709049461
+                      created_at: 1709227268
+                      updated_at: 1709227268
                     - id: 2
                       type: content_import_source
-                      last_synced_at: 1709049461
+                      last_synced_at: 1709227268
                       status: active
                       url: https://support.example.com/us/2
                       sync_behavior: automatic
-                      created_at: 1709049461
-                      updated_at: 1709049461
+                      created_at: 1709227268
+                      updated_at: 1709227268
                     - id: 3
                       type: content_import_source
-                      last_synced_at: 1709049461
+                      last_synced_at: 1709227268
                       status: active
                       url: https://support.example.com/us/3
                       sync_behavior: automatic
-                      created_at: 1709049461
-                      updated_at: 1709049461
+                      created_at: 1709227268
+                      updated_at: 1709227268
                     pages:
                       type: pages
                       page: 1
@@ -420,7 +420,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bb2f0bf4-7dd9-4447-88d4-94fc4b0e83a3
+                    request_id: 24e37f58-599e-4217-a85b-62f49b0b32e1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -448,12 +448,12 @@ paths:
                   value:
                     id: 4
                     type: content_import_source
-                    last_synced_at: 1709049462
+                    last_synced_at: 1709227269
                     status: active
                     url: https://www.example.com
                     sync_behavior: api
-                    created_at: 1709049462
-                    updated_at: 1709049462
+                    created_at: 1709227269
+                    updated_at: 1709227269
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -464,7 +464,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9dbc5c58-b969-43ed-872f-4c2b4c0e4598
+                    request_id: ae33bfca-7b66-4877-b5a5-577e27464538
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -514,7 +514,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3664eb2c-e978-4467-970b-0901854296ee
+                    request_id: 97f99a0b-5afa-49b1-85a7-f41e5ae333d2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -540,12 +540,12 @@ paths:
                   value:
                     id: 6
                     type: content_import_source
-                    last_synced_at: 1709049464
+                    last_synced_at: 1709227271
                     status: active
                     url: https://support.example.com/us/5
                     sync_behavior: api
-                    created_at: 1709049464
-                    updated_at: 1709049464
+                    created_at: 1709227271
+                    updated_at: 1709227271
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -556,7 +556,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 056c017c-d185-4167-9d60-35f0331559c5
+                    request_id: 9e254c94-8000-4d2e-84f5-18c935d14835
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -583,12 +583,12 @@ paths:
                   value:
                     id: 7
                     type: content_import_source
-                    last_synced_at: 1709049465
+                    last_synced_at: 1709227271
                     status: active
                     url: https://www.example.com
                     sync_behavior: api
-                    created_at: 1709049465
-                    updated_at: 1709049465
+                    created_at: 1709227271
+                    updated_at: 1709227272
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -599,7 +599,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 533bce98-3101-4398-b0b5-2eafac8bbc91
+                    request_id: 0e6321a1-fdc9-42bd-b8bb-55894f3394fd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -646,9 +646,9 @@ paths:
                       locale: en
                       source_id: 10
                       external_id: '3'
-                      created_at: 1709049466
-                      updated_at: 1709049466
-                      last_ingested_at: 1709049466
+                      created_at: 1709227273
+                      updated_at: 1709227273
+                      last_ingested_at: 1709227273
                     - id: '2'
                       type: external_page
                       title: My External Content
@@ -658,9 +658,9 @@ paths:
                       locale: en
                       source_id: 9
                       external_id: '2'
-                      created_at: 1709049466
-                      updated_at: 1709049466
-                      last_ingested_at: 1709049466
+                      created_at: 1709227273
+                      updated_at: 1709227273
+                      last_ingested_at: 1709227273
                     - id: '1'
                       type: external_page
                       title: My External Content
@@ -670,9 +670,9 @@ paths:
                       locale: en
                       source_id: 8
                       external_id: '1'
-                      created_at: 1709049466
-                      updated_at: 1709049466
-                      last_ingested_at: 1709049466
+                      created_at: 1709227273
+                      updated_at: 1709227273
+                      last_ingested_at: 1709227273
                     pages:
                       type: pages
                       page: 1
@@ -690,7 +690,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7c2ae6b8-823f-4676-89df-d7e1a378d8be
+                    request_id: 4a7e1a55-b5cd-4c79-a294-9d08782363f3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -726,9 +726,9 @@ paths:
                     locale: en
                     source_id: 12
                     external_id: abc1234
-                    created_at: 1709049467
-                    updated_at: 1709049467
-                    last_ingested_at: 1709049467
+                    created_at: 1709227274
+                    updated_at: 1709227274
+                    last_ingested_at: 1709227274
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -739,7 +739,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a9e5509a-98d5-4d0f-a797-a8e1a30ff292
+                    request_id: 23697940-cb60-4c8e-881a-549fa5277806
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -797,9 +797,9 @@ paths:
                     locale: en
                     source_id: 13
                     external_id: '4'
-                    created_at: 1709049468
-                    updated_at: 1709049468
-                    last_ingested_at: 1709049468
+                    created_at: 1709227275
+                    updated_at: 1709227275
+                    last_ingested_at: 1709227275
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -810,7 +810,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 51a4d819-e7d4-4988-97bc-3dcfe7bbe568
+                    request_id: 4e9fd4c0-b73b-445b-a30f-8c85171ac613
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -844,9 +844,9 @@ paths:
                     locale: en
                     source_id: 14
                     external_id: '5'
-                    created_at: 1709049469
-                    updated_at: 1709049469
-                    last_ingested_at: 1709049469
+                    created_at: 1709227276
+                    updated_at: 1709227276
+                    last_ingested_at: 1709227276
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -857,7 +857,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 18b9dbf2-e514-457f-9042-ec6c573dd9cd
+                    request_id: ac2b7b20-ebd8-4738-8a3c-06f4a010b039
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -892,9 +892,9 @@ paths:
                     locale: en
                     source_id: 15
                     external_id: '5678'
-                    created_at: 1709049470
-                    updated_at: 1709049470
-                    last_ingested_at: 1709049470
+                    created_at: 1709227277
+                    updated_at: 1709227277
+                    last_ingested_at: 1709227277
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -905,7 +905,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 93193bc6-863e-404f-8392-5e85ee29fef4
+                    request_id: 69ec6002-11c5-45fe-a9f5-c3fe72c6f3c3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -958,20 +958,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '1'
+                    - id: '76'
                       type: article
                       workspace_id: this_is_an_id64_that_should_be_at_least_4
-                      parent_id: 1
+                      parent_id: 292
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991266247
+                      author_id: 991268319
                       state: published
-                      created_at: 1709049471
-                      updated_at: 1709049471
-                      url: http://help-center.test/myapp-64/en/articles/1-this-is-the-article-title
+                      created_at: 1709227277
+                      updated_at: 1709227277
+                      url: http://help-center.test/myapp-64/en/articles/76-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -982,7 +982,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 81c75a2f-4e33-43d1-b9c4-560bbe8eeb4a
+                    request_id: 84581b53-bb79-434e-ae63-d6832ae49ef4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1007,10 +1007,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '4'
+                    id: '79'
                     type: article
                     workspace_id: this_is_an_id68_that_should_be_at_least_4
-                    parent_id: 3
+                    parent_id: 294
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1024,11 +1024,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991266252
+                    author_id: 991268324
                     state: published
-                    created_at: 1709049474
-                    updated_at: 1709049474
-                    url: http://help-center.test/myapp-68/en/articles/4-thanks-for-everything
+                    created_at: 1709227280
+                    updated_at: 1709227280
+                    url: http://help-center.test/myapp-68/en/articles/79-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -1039,7 +1039,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 31cd7b56-b715-4aa3-a7d4-c69049a20a95
+                    request_id: 0b2faa66-03d2-4e6e-ab4e-e78cb2c6dd67
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -1054,7 +1054,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c173c8b9-afee-4f2e-8ddb-3285c2c49dcd
+                    request_id: b043a5ca-d454-4175-ac17-f6688dd7d1b3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1072,16 +1072,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991266252
+                  author_id: 991268324
                   state: published
-                  parent_id: 3
+                  parent_id: 294
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991266252
+                      author_id: 991268324
                       state: published
               bad_request:
                 summary: Bad Request
@@ -1118,10 +1118,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '7'
+                    id: '82'
                     type: article
                     workspace_id: this_is_an_id74_that_should_be_at_least_4
-                    parent_id: 6
+                    parent_id: 297
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1135,11 +1135,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991266257
+                    author_id: 991268329
                     state: published
-                    created_at: 1709049476
-                    updated_at: 1709049476
-                    url: http://help-center.test/myapp-74/en/articles/7-this-is-the-article-title
+                    created_at: 1709227281
+                    updated_at: 1709227281
+                    url: http://help-center.test/myapp-74/en/articles/82-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -1150,7 +1150,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: f53a9859-8f84-4557-a6da-ec91b500cb4d
+                    request_id: 694c4c87-5396-4a57-879d-e53f7a79536b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1164,7 +1164,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2e26da61-b5c3-49eb-9729-37029763d138
+                    request_id: 3fcd8967-4d07-49b9-a9ff-3508ceee05e4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1197,10 +1197,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '10'
+                    id: '85'
                     type: article
                     workspace_id: this_is_an_id80_that_should_be_at_least_4
-                    parent_id: 9
+                    parent_id: 300
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1214,11 +1214,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991266263
+                    author_id: 991268335
                     state: published
-                    created_at: 1709049478
-                    updated_at: 1709049478
-                    url: http://help-center.test/myapp-80/en/articles/10-christmas-is-here
+                    created_at: 1709227283
+                    updated_at: 1709227284
+                    url: http://help-center.test/myapp-80/en/articles/85-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -1229,7 +1229,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 9683d20a-50fc-4d4f-b701-02acd0cbf285
+                    request_id: 6e8cd0df-88ee-4aae-bb06-e8c9e81f2d1c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1243,7 +1243,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cbbdeaf9-145e-4810-809e-b4690e93d03c
+                    request_id: 5f465e7b-f583-4918-bf9f-85617c1daa52
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1291,7 +1291,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '13'
+                    id: '88'
                     object: article
                     deleted: true
               schema:
@@ -1304,7 +1304,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 1002d6b1-85c7-461e-acb8-feaaa4775f92
+                    request_id: 7e4df0b7-4538-4e2c-9e8d-6809a46e94d8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1318,7 +1318,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c05d815b-8184-44d2-b30a-e01835b1f19a
+                    request_id: 012d0d8b-1a8f-4cfd-ad09-c4a3062e13e9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1378,7 +1378,7 @@ paths:
                     total_count: 1
                     data:
                       articles:
-                      - id: '17'
+                      - id: '92'
                         type: article
                         workspace_id: this_is_an_id92_that_should_be_at_least_4
                         parent_id:
@@ -1387,10 +1387,10 @@ paths:
                         title: Title 1
                         description: ''
                         body: ''
-                        author_id: 991266276
+                        author_id: 991268348
                         state: draft
-                        created_at: 1709049483
-                        updated_at: 1709049483
+                        created_at: 1709227288
+                        updated_at: 1709227288
                         url:
                       highlights: []
                     pages:
@@ -1408,7 +1408,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 571658b2-a29a-4613-84da-b11ab67cfb94
+                    request_id: 81117099-4e0f-4a9f-a7dc-c17d97edef30
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1439,27 +1439,27 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '17'
+                    - id: '308'
                       workspace_id: this_is_an_id96_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-96/collection-17
                       order: 17
-                      created_at: 1709049484
-                      updated_at: 1709049484
+                      created_at: 1709227289
+                      updated_at: 1709227289
                       description: english collection description
                       icon: bookmark
                       parent_id:
-                      help_center_id: 17
-                    - id: '18'
+                      help_center_id: 160
+                    - id: '309'
                       workspace_id: this_is_an_id96_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-96/section-1
                       order: 1
-                      created_at: 1709049484
-                      updated_at: 1709049484
+                      created_at: 1709227289
+                      updated_at: 1709227289
                       description:
                       icon: bookmark
-                      parent_id: '17'
+                      parent_id: '308'
                       help_center_id:
                     total_count: 2
                     pages:
@@ -1477,7 +1477,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 13cab1a2-4095-4f54-ab98-738a903dd81d
+                    request_id: bf8541ac-ea3d-4ad9-a65d-32663b98c838
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1502,17 +1502,17 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '23'
+                    id: '314'
                     workspace_id: this_is_an_id100_that_should_be_at_least_
                     name: Thanks for everything
                     url: http://help-center.test/myapp-100/
                     order: 1
-                    created_at: 1709049486
-                    updated_at: 1709049486
+                    created_at: 1709227290
+                    updated_at: 1709227290
                     description: ''
                     icon: book-bookmark
                     parent_id:
-                    help_center_id: 19
+                    help_center_id: 162
               schema:
                 "$ref": "#/components/schemas/collection"
         '400':
@@ -1523,7 +1523,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 2a698237-df69-4e3a-967f-d5e0a664138d
+                    request_id: '0689bf69-8f09-462e-b56e-827e5857d7da'
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -1537,7 +1537,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f458e4bd-730f-434f-a1d2-025c774565d3
+                    request_id: 4f82b6c0-f50a-4889-85a1-900cdc26e14d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1585,17 +1585,17 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '28'
+                    id: '319'
                     workspace_id: this_is_an_id106_that_should_be_at_least_
                     name: English collection title
                     url: http://help-center.test/myapp-106/collection-22
                     order: 22
-                    created_at: 1709049487
-                    updated_at: 1709049487
+                    created_at: 1709227291
+                    updated_at: 1709227291
                     description: english collection description
                     icon: bookmark
                     parent_id:
-                    help_center_id: 22
+                    help_center_id: 165
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1606,7 +1606,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: e32fbe36-bf67-4880-b153-ea66eda0377a
+                    request_id: 27ff18bb-59b4-4e6e-9f3d-606f4b5541ac
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1620,7 +1620,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b149269d-5cc3-4b3d-90ab-c27e0b21906a
+                    request_id: a845013c-cc69-409c-b00e-3e2f90dadee0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1653,17 +1653,17 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '34'
+                    id: '325'
                     workspace_id: this_is_an_id112_that_should_be_at_least_
                     name: Update collection name
                     url: http://help-center.test/myapp-112/collection-25
                     order: 25
-                    created_at: 1709049488
-                    updated_at: 1709049489
+                    created_at: 1709227293
+                    updated_at: 1709227293
                     description: english collection description
                     icon: folder
                     parent_id:
-                    help_center_id: 25
+                    help_center_id: 168
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1674,7 +1674,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: 708d7651-671a-441b-a3a2-a97b9b99829e
+                    request_id: 341995f3-74c3-4eca-90da-95303f5f5d7c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1688,7 +1688,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d62eb725-1bdb-4eb5-95ee-21e5ce50a5de
+                    request_id: 00f35cac-5152-4cb3-900b-43c13cda4c1f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1735,7 +1735,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '40'
+                    id: '331'
                     object: collection
                     deleted: true
               schema:
@@ -1748,7 +1748,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: 0b726a04-9b5d-415f-9301-5d41f3574fcf
+                    request_id: 7224355e-c512-4368-9372-6883baac6401
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1762,7 +1762,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5321fe82-d9f6-447f-8f85-f90d16db161d
+                    request_id: 6db12af4-1c1d-46f5-8b46-8dd74b36624f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1796,10 +1796,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '31'
+                    id: '174'
                     workspace_id: this_is_an_id124_that_should_be_at_least_
-                    created_at: 1709049492
-                    updated_at: 1709049492
+                    created_at: 1709227296
+                    updated_at: 1709227296
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1813,7 +1813,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 995b4a1a-2a77-4bb4-b5c0-44fed1100ecd
+                    request_id: 30e89201-f289-4c8a-a8c2-8cbefa8b505c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1827,7 +1827,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1b06b887-68c6-40d6-bf0b-8f418d4b2b14
+                    request_id: 6337f5eb-aa86-4f4a-8cd2-5ab0eabbd173
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1865,7 +1865,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cad579f6-a7d8-4534-b90b-1a1168c7f1ee
+                    request_id: b7f64115-7860-4526-8803-a3bad2f1bc61
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1898,12 +1898,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 65de0699ba4d127f97961c64
+                    id: 65e0bd246abd0181dac14ef4
                     app_id: this_is_an_id147_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1709049497
-                    updated_at: 1709049497
+                    created_at: 1709227300
+                    updated_at: 1709227300
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1940,7 +1940,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 859055fa-31e1-44cb-a407-0225d7a0e61f
+                    request_id: 45b26691-9a65-45ee-98d7-30ee91448cff
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2038,12 +2038,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de069bba4d127f97961c6c
+                      id: 65e0bd266abd0181dac14efc
                       app_id: this_is_an_id153_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709049499
-                      created_at: 1709049499
-                      updated_at: 1709049499
+                      remote_created_at: 1709227302
+                      created_at: 1709227302
+                      updated_at: 1709227302
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2072,7 +2072,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 97bb479b-0654-40ae-a1db-a892969313b5
+                    request_id: 5f856eca-5dc1-4f36-9714-f5a428306112
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2086,7 +2086,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 057fae23-9403-4f2d-bb3a-6c302fd56d1a
+                    request_id: 75cbcec8-afb7-4b63-9f72-7b14ab543d98
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2121,12 +2121,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de069dba4d127f97961c77
+                    id: 65e0bd286abd0181dac14f07
                     app_id: this_is_an_id159_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1709049501
-                    created_at: 1709049501
-                    updated_at: 1709049501
+                    remote_created_at: 1709227304
+                    created_at: 1709227304
+                    updated_at: 1709227304
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2148,7 +2148,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 811a348f-c16c-4058-b9fc-c57f1bdcda7f
+                    request_id: 8d7ce2c1-f996-412b-bb21-4ff0b356d39b
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2162,7 +2162,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 46ff6a09-0ec4-4cd1-9a5a-febee6213112
+                    request_id: 65856b5a-9729-4b62-b5a6-afb36ac54b66
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2196,12 +2196,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de069fba4d127f97961c81
+                    id: 65e0bd2a6abd0181dac14f11
                     app_id: this_is_an_id165_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1709049503
-                    created_at: 1709049503
-                    updated_at: 1709049503
+                    remote_created_at: 1709227306
+                    created_at: 1709227306
+                    updated_at: 1709227306
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2223,7 +2223,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: ceb6ee38-e0f9-4294-bbf6-decc732745d5
+                    request_id: 83622035-b6f5-4968-b449-5f50ff59f625
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2237,7 +2237,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3b8a226c-9752-4906-a476-4c29c4024508
+                    request_id: 45fb64be-650e-4aee-a7b6-8fe98c153315
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2269,7 +2269,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 65de06a2ba4d127f97961c8b
+                    id: 65e0bd2c6abd0181dac14f1b
                     object: company
                     deleted: true
               schema:
@@ -2282,7 +2282,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: e0a181f7-22e3-4fc5-b120-b700ea7bb00e
+                    request_id: 7544c7f7-ffb5-4659-896e-20d90ff5ff7a
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2296,7 +2296,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1baf5eff-d765-4fd6-9083-4cbb7f55e6ca
+                    request_id: 58a5d151-5ecf-4a69-9bf5-531bcb33c2fb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2348,7 +2348,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 9e857756-0c29-4376-a014-7d9545ab62a0
+                    request_id: 5db8c0c6-25c9-42d1-9c74-8c34b4382a26
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2362,7 +2362,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 914c6efa-d224-478e-a869-e9edfc37c1a3
+                    request_id: 91a1467e-0dfe-4d4c-b6ff-67f51569caff
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2407,7 +2407,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: a752c7de-103a-4f88-b602-9aa33a7c6fec
+                    request_id: b313b826-0d8b-4739-a840-894e3dd387ad
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2421,7 +2421,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9df7c540-d87d-411f-8ef3-48ac9ba9ceaf
+                    request_id: 780b0a22-c230-42b5-a523-93fa4890504c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2478,12 +2478,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de06a8ba4d127f97961ca7
+                      id: 65e0bd326abd0181dac14f37
                       app_id: this_is_an_id189_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709049512
-                      created_at: 1709049512
-                      updated_at: 1709049512
+                      remote_created_at: 1709227314
+                      created_at: 1709227314
+                      updated_at: 1709227314
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2512,7 +2512,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d5aff5cb-a708-4cb2-a7ae-522b01f30a10
+                    request_id: 66c37218-78bf-4d96-bb3f-9eab8ec3ae52
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2564,12 +2564,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de06a9ba4d127f97961cad
+                      id: 65e0bd336abd0181dac14f3d
                       app_id: this_is_an_id193_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709049513
-                      created_at: 1709049513
-                      updated_at: 1709049513
+                      remote_created_at: 1709227315
+                      created_at: 1709227315
+                      updated_at: 1709227315
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2583,7 +2583,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: f8bfff41-12d1-4f8e-8b5e-8463292da4d3
+                    scroll_param: 242635b3-4b61-4db9-aba3-3380a04175ce
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2594,7 +2594,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fffb102b-ab77-4f89-8e17-f4aab019b030
+                    request_id: '089f2003-59da-4f21-8793-d6f5f2b2b7be'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2629,12 +2629,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de06abba4d127f97961cb6
+                    id: 65e0bd356abd0181dac14f46
                     app_id: this_is_an_id197_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1709049515
-                    created_at: 1709049515
-                    updated_at: 1709049515
+                    remote_created_at: 1709227317
+                    created_at: 1709227317
+                    updated_at: 1709227317
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2656,7 +2656,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: e919fe31-8278-48d3-8457-8cec71058993
+                    request_id: 32cc5736-b69b-4827-879f-20e7ce2c9308
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2670,7 +2670,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 9153af57-1132-4e9b-8205-fbdb3210e9c1
+                    request_id: a8b64fbd-dece-4157-a087-0cfc8386920f
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2684,7 +2684,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a04b39cf-6e2f-4c37-a5d6-869ce8cbcadf
+                    request_id: '007994dd-4656-4604-9068-68dbdc575850'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2707,7 +2707,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 65de06abba4d127f97961cb6
+                  id: 65e0bd356abd0181dac14f46
               bad_request:
                 summary: Bad Request
                 value:
@@ -2746,13 +2746,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 65de06b1ba4d127f97961cd7
+                      id: 65e0bd3b6abd0181dac14f67
                       app_id: this_is_an_id213_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1709049521
-                      created_at: 1709049521
-                      updated_at: 1709049521
-                      last_request_at: 1708876721
+                      remote_created_at: 1709227323
+                      created_at: 1709227323
+                      updated_at: 1709227323
+                      last_request_at: 1709054523
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2781,7 +2781,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 7d13966a-93b9-4bf7-8507-f2f02b76b9e4
+                    request_id: 8748c7e7-760a-494e-8a25-72c691aa2680
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2795,7 +2795,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 46d34721-a541-4f62-af38-230d46bc305d
+                    request_id: 3ba429c7-6536-4999-abd4-9c6fab2f9ff3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2838,12 +2838,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de06aeba4d127f97961cc6
+                    id: 65e0bd386abd0181dac14f56
                     app_id: this_is_an_id205_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1709049518
-                    created_at: 1709049518
-                    updated_at: 1709049519
+                    remote_created_at: 1709227320
+                    created_at: 1709227320
+                    updated_at: 1709227320
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2865,14 +2865,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 37846f62-2c18-4132-92be-fe87db952bfe
+                    request_id: ade089e6-3056-438f-b74e-137df59d5ff7
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: c88ee014-6794-4e83-b2f6-81876d70ef54
+                    request_id: d429b68d-0e46-44b4-94b0-64276c573182
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2886,7 +2886,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4b61adb7-ba7b-4e84-bd73-6159b21ffade
+                    request_id: c97e9f1f-a2e2-4005-acf0-22667769d577
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2922,42 +2922,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '3'
-                      created_at: 1708444724
+                      id: '55'
+                      created_at: 1708622525
                       contact:
                         type: contact
-                        id: 65de06b4ba4d127f97961ce2
+                        id: 65e0bd3d6abd0181dac14f72
                       author:
                         type: admin
-                        id: '991266336'
+                        id: '991268408'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '2'
-                      created_at: 1708358324
+                      id: '54'
+                      created_at: 1708536125
                       contact:
                         type: contact
-                        id: 65de06b4ba4d127f97961ce2
+                        id: 65e0bd3d6abd0181dac14f72
                       author:
                         type: admin
-                        id: '991266336'
+                        id: '991268408'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '1'
-                      created_at: 1708358324
+                      id: '53'
+                      created_at: 1708536125
                       contact:
                         type: contact
-                        id: 65de06b4ba4d127f97961ce2
+                        id: 65e0bd3d6abd0181dac14f72
                       author:
                         type: admin
-                        id: '991266336'
+                        id: '991268408'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
@@ -2980,7 +2980,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 8a0538a7-e7a5-4ef3-b021-5463baac9ecb
+                    request_id: 60ff1ad4-41ba-4c9f-85a4-3e3521138d97
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3014,14 +3014,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '8'
-                    created_at: 1709049525
+                    id: '60'
+                    created_at: 1709227327
                     contact:
                       type: contact
-                      id: 65de06b5ba4d127f97961ce4
+                      id: 65e0bd3e6abd0181dac14f74
                     author:
                       type: admin
-                      id: '991266338'
+                      id: '991268410'
                       name: Ciaran124 Lee
                       email: admin124@email.com
                       away_mode_enabled: false
@@ -3037,14 +3037,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 400eaaab-a417-4ce4-85c1-1c54a2d121da
+                    request_id: 1fc73d95-9054-4bcc-8ac8-8632d1933c4d
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 0b7a5a44-8ed3-4dcc-8813-6f0c1d0b5084
+                    request_id: 5a9be556-2ce2-4b90-82f4-c552ed2de763
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3074,20 +3074,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 65de06b5ba4d127f97961ce4
-                  admin_id: 991266338
+                  contact_id: 65e0bd3e6abd0181dac14f74
+                  admin_id: 991268410
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 65de06b6ba4d127f97961ce5
+                  contact_id: 65e0bd3f6abd0181dac14f75
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991266340
+                  admin_id: 991268412
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -3120,10 +3120,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 65de06b7ba4d127f97961ce7
+                      id: 65e0bd406abd0181dac14f77
                       name: segment
-                      created_at: 1709049527
-                      updated_at: 1709049527
+                      created_at: 1709227328
+                      updated_at: 1709227328
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -3135,7 +3135,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 8da29582-3ffa-49e6-a0e0-fbd4c8d158a6
+                    request_id: 495aa406-126d-4e5e-a353-ac5aed8b9b46
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3149,7 +3149,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ae4ee872-3373-47e9-863d-09392d64c179
+                    request_id: a0ccd30b-642b-4cb6-b6f2-ed7bcc06ff3b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3193,7 +3193,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '1'
+                      id: '185'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -3207,7 +3207,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '3'
+                      id: '187'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -3230,7 +3230,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 390b38af-f9de-4211-8fbb-6e405080b531
+                    request_id: 02222b72-e2db-464f-b43b-da71c97d9800
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3244,7 +3244,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 73dcd1c5-6f70-4680-915a-430855d6dac0
+                    request_id: 60fc0a6f-28ad-4810-8dcb-bc5c1f44ae9b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3285,7 +3285,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '16'
+                    id: '200'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3308,14 +3308,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 8692541f-7f5c-4d60-ba44-708e3e86920b
+                    request_id: 22de4d21-822c-43f3-9f49-ef6216410028
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 7bbc8537-bb57-4299-b5b3-f1668e98b7c2
+                    request_id: 333af9dc-989c-404b-84df-1b21002b3957
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3329,7 +3329,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: adda81e4-37b6-450f-9b0e-725912b4bd93
+                    request_id: 19da2731-ded4-42b1-97ef-4fef08dbb59e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3357,12 +3357,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 16
+                  id: 200
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 20
+                  id: 204
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -3408,7 +3408,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '32'
+                    id: '216'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3431,14 +3431,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 16e1ff29-9d54-4ba6-ae69-02429d87f017
+                    request_id: c91569a3-427e-40b8-a097-2cde6a4ccff1
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 38ce92c4-2320-424f-bf68-37e0a015bc62
+                    request_id: 9d32059b-41fd-4eea-8800-526e14babe5a
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3452,7 +3452,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 452ab871-4a3d-4243-88b5-16efa63b2f36
+                    request_id: 788c3c87-9744-49a4-a733-604ed0e85f5b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3490,7 +3490,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '1'
+                      id: '170'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -3502,7 +3502,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 0ed3cf5e-c18d-41d0-a6c4-811aac47492e
+                    request_id: 87cf8d6d-08b3-4623-9e3a-afed4b99baa5
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3516,7 +3516,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 152fe04a-15bf-4582-9939-1dffafacbe4f
+                    request_id: 81b2ec71-b5fa-4d53-b059-6a283af7736a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3551,7 +3551,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '2'
+                    id: '171'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3563,14 +3563,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 40668b58-a140-46c3-9d78-e8a5f07e5286
+                    request_id: bc82f03f-17a5-4cb2-85c6-43664accc132
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: f9a78a7a-a387-44c5-ba51-e41de242e036
+                    request_id: 92e1e4c2-6c3b-41d6-8602-22c0da5460dc
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3584,7 +3584,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c5547d70-cb8b-46b1-82ca-6375decef80c
+                    request_id: 751cd910-30b7-4db7-b306-d06c43857b3b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3607,11 +3607,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 2
+                  id: 171
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 3
+                  id: 172
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3653,7 +3653,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '5'
+                    id: '174'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3665,14 +3665,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 216aa87c-66b9-45fd-8081-5ac5403bf3ac
+                    request_id: fce1e084-533d-4d7c-a9f4-6152e8d2f8e0
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: d84297be-4145-4541-b459-446be9b71997
+                    request_id: 2b4dbc0b-16cd-4b42-a958-d6cbff05aed8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3686,7 +3686,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9b169336-0635-49da-9420-0674e7b404cd
+                    request_id: 45857bf6-c3cf-4552-8f3c-509d623970bc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3720,7 +3720,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de06c6ba4d127f97961cfe
+                    id: 65e0bd4d6abd0181dac14f8e
                     workspace_id: this_is_an_id279_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3736,9 +3736,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709049542
-                    updated_at: 1709049542
-                    signed_up_at: 1709049542
+                    created_at: 1709227341
+                    updated_at: 1709227341
+                    signed_up_at: 1709227341
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3772,31 +3772,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de06c6ba4d127f97961cfe/tags"
+                      url: "/contacts/65e0bd4d6abd0181dac14f8e/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de06c6ba4d127f97961cfe/notes"
+                      url: "/contacts/65e0bd4d6abd0181dac14f8e/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de06c6ba4d127f97961cfe/companies"
+                      url: "/contacts/65e0bd4d6abd0181dac14f8e/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de06c6ba4d127f97961cfe/subscriptions"
+                      url: "/contacts/65e0bd4d6abd0181dac14f8e/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de06c6ba4d127f97961cfe/subscriptions"
+                      url: "/contacts/65e0bd4d6abd0181dac14f8e/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3815,7 +3815,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0273df91-20b9-49df-be7b-44c90be797df
+                    request_id: 98b29696-f5f0-4c7f-b924-7cd544dc8fb2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3860,7 +3860,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de06c7ba4d127f97961cff
+                    id: 65e0bd4e6abd0181dac14f8f
                     workspace_id: this_is_an_id283_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3876,9 +3876,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709049543
-                    updated_at: 1709049543
-                    signed_up_at: 1709049543
+                    created_at: 1709227342
+                    updated_at: 1709227342
+                    signed_up_at: 1709227342
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3912,31 +3912,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de06c7ba4d127f97961cff/tags"
+                      url: "/contacts/65e0bd4e6abd0181dac14f8f/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de06c7ba4d127f97961cff/notes"
+                      url: "/contacts/65e0bd4e6abd0181dac14f8f/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de06c7ba4d127f97961cff/companies"
+                      url: "/contacts/65e0bd4e6abd0181dac14f8f/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de06c7ba4d127f97961cff/subscriptions"
+                      url: "/contacts/65e0bd4e6abd0181dac14f8f/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de06c7ba4d127f97961cff/subscriptions"
+                      url: "/contacts/65e0bd4e6abd0181dac14f8f/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3955,7 +3955,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2113cbc6-97f9-4b13-97bb-959262fe29cf
+                    request_id: 749cf91c-b02c-43d8-bb67-f91017d2f462
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3986,7 +3986,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de06c8ba4d127f97961d00
+                    id: 65e0bd4f6abd0181dac14f90
                     external_id: '70'
                     type: contact
                     deleted: true
@@ -4000,7 +4000,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 06a0db58-5b72-4c69-a4c6-4912e1a1b317
+                    request_id: d59d0ad1-9c33-44a8-9c73-9d8cbc316c8f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4028,7 +4028,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de06caba4d127f97961d02
+                    id: 65e0bd506abd0181dac14f92
                     workspace_id: this_is_an_id291_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -4044,9 +4044,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709049546
-                    updated_at: 1709049546
-                    signed_up_at: 1709049546
+                    created_at: 1709227344
+                    updated_at: 1709227345
+                    signed_up_at: 1709227344
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -4080,31 +4080,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de06caba4d127f97961d02/tags"
+                      url: "/contacts/65e0bd506abd0181dac14f92/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de06caba4d127f97961d02/notes"
+                      url: "/contacts/65e0bd506abd0181dac14f92/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de06caba4d127f97961d02/companies"
+                      url: "/contacts/65e0bd506abd0181dac14f92/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de06caba4d127f97961d02/subscriptions"
+                      url: "/contacts/65e0bd506abd0181dac14f92/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de06caba4d127f97961d02/subscriptions"
+                      url: "/contacts/65e0bd506abd0181dac14f92/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4123,7 +4123,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e02d4033-8e8c-4c1c-bd12-8d038d535931
+                    request_id: '09b4ab2a-8683-4229-92ec-d30e54fc53ba'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4138,8 +4138,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 65de06caba4d127f97961d01
-                  into: 65de06caba4d127f97961d02
+                  from: 65e0bd506abd0181dac14f91
+                  into: 65e0bd506abd0181dac14f92
   "/contacts/search":
     post:
       summary: Search contacts
@@ -4268,7 +4268,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f23a73f8-8718-4c78-846a-8c8c0ba82f59
+                    request_id: c78080a2-a81d-4f4a-a1a1-20396efe7b73
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4288,15 +4288,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: 65de06cbba4d127f97961d05
+                      value: 65e0bd526abd0181dac14f95
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: 65de06cbba4d127f97961d05
+                        value: 65e0bd526abd0181dac14f95
                       - field: id
                         operator: "="
-                        value: 65de06cbba4d127f97961d05
+                        value: 65e0bd526abd0181dac14f95
   "/contacts":
     get:
       summary: List all contacts
@@ -4335,7 +4335,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 490cc6d1-ff74-47f5-a147-4f880bca8514
+                    request_id: 85c59b77-2c2f-4bd3-8f7d-7110e15e21a6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4361,7 +4361,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de06ceba4d127f97961d07
+                    id: 65e0bd546abd0181dac14f97
                     workspace_id: this_is_an_id303_that_should_be_at_least_
                     external_id:
                     role: user
@@ -4377,8 +4377,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709049550
-                    updated_at: 1709049550
+                    created_at: 1709227348
+                    updated_at: 1709227348
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -4413,31 +4413,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de06ceba4d127f97961d07/tags"
+                      url: "/contacts/65e0bd546abd0181dac14f97/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de06ceba4d127f97961d07/notes"
+                      url: "/contacts/65e0bd546abd0181dac14f97/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de06ceba4d127f97961d07/companies"
+                      url: "/contacts/65e0bd546abd0181dac14f97/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de06ceba4d127f97961d07/subscriptions"
+                      url: "/contacts/65e0bd546abd0181dac14f97/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de06ceba4d127f97961d07/subscriptions"
+                      url: "/contacts/65e0bd546abd0181dac14f97/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4456,7 +4456,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0e09ada6-4848-4751-b663-88e2c1441906
+                    request_id: '0938dac2-a826-41c5-b835-4385978acd07'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4500,7 +4500,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de06cfba4d127f97961d08
+                    id: 65e0bd556abd0181dac14f98
                     external_id: '70'
                     type: contact
                     archived: true
@@ -4533,7 +4533,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de06d0ba4d127f97961d09
+                    id: 65e0bd566abd0181dac14f99
                     external_id: '70'
                     type: contact
                     archived: false
@@ -4569,7 +4569,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '7'
+                    id: '176'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4581,7 +4581,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 43422184-1c28-444d-8f04-4409aaf84aa2
+                    request_id: b1bf0cf7-9b6f-401a-b814-dd2f614ea528
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4595,7 +4595,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c977d61a-2cc5-400f-93ca-470c3c1fad93
+                    request_id: 5a001e63-af9b-4a13-bf39-fc91cd29fb54
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4624,13 +4624,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 7
-                  admin_id: 991266371
+                  id: 176
+                  admin_id: 991268443
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 8
-                  admin_id: 991266373
+                  id: 177
+                  admin_id: 991268445
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4668,7 +4668,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '10'
+                    id: '179'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4680,14 +4680,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 528e4c0b-9b54-49e6-ba41-39e1c57d387e
+                    request_id: 7c4c8814-f512-4433-ac6c-b5d1d400bdb6
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: ee6231c5-869f-4118-8c32-f783a336fc4b
+                    request_id: ab9ac6e4-eb0c-4f43-8749-c6ead6476018
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4701,7 +4701,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c8deaf94-f91d-4043-95da-87b647b19c4f
+                    request_id: b4602658-5dab-4a22-a85f-67f486a6da09
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4724,15 +4724,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991266375
+                  admin_id: 991268447
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991266377
+                  admin_id: 991268449
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991266378
+                  admin_id: 991268450
   "/conversations":
     get:
       summary: List all conversations
@@ -4779,20 +4779,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '5'
-                      created_at: 1709049560
-                      updated_at: 1709049560
+                      id: '576'
+                      created_at: 1709227358
+                      updated_at: 1709227358
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918065'
+                        id: '403918397'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991266381'
+                          id: '991268453'
                           name: Ciaran164 Lee
                           email: admin164@email.com
                         attachments: []
@@ -4802,7 +4802,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de06d8ba4d127f97961d0d
+                          id: 65e0bd5d6abd0181dac14f9d
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -4837,7 +4837,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 19d65508-6b56-4cd6-b9d6-eede8c6d2bcc
+                    request_id: 44c06ec3-3c92-40ef-9b79-652e5cb6f31b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4851,7 +4851,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: fcc949ab-e4f1-4310-99c8-0fd1d088be6b
+                    request_id: 25708230-bf2c-42c7-8856-d19195225250
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4867,13 +4867,17 @@ paths:
       tags:
       - Conversations
       operationId: createConversation
-      description: "You can create a conversation that has been initiated by a contact
-        (ie. user or lead).\nThe conversation can be an in-app message only.\n\n>
-        \U0001F4D8 Sending for visitors\n>\n> You can also send a message from a visitor
-        by specifying their `user_id` or `id` value in the `from` field, along with
-        a `type` field value of `contact`.\n> This visitor will be automatically converted
-        to a contact with a lead role once the conversation is created.\n\nThis will
-        return the Message model that has been created.\n\n"
+      description: |+
+        You can create a conversation that has been initiated by a contact (ie. user or lead).
+        The conversation can be an in-app message only.
+
+        {% admonition type="info" name="Sending for visitors" %}
+        You can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.
+        This visitor will be automatically converted to a contact with a lead role once the conversation is created.
+        {% /admonition %}
+
+        This will return the Message model that has been created.
+
       responses:
         '200':
           description: conversation created
@@ -4883,11 +4887,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918075'
-                    created_at: 1709049587
+                    id: '403918407'
+                    created_at: 1709227380
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '30'
+                    conversation_id: '601'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -4898,7 +4902,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 5a0aa3fd-f36a-46ba-9d75-e06176551233
+                    request_id: 5dd29a54-3788-4c77-9e30-ba47fab4d60c
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -4912,7 +4916,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 94c17d1f-bc20-45a2-9a6a-c73b528ca1c1
+                    request_id: 1de3427a-1749-40d6-996e-a3d4f70611bd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4926,7 +4930,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 2ce0555a-a4dd-4451-9817-8fa95655b857
+                    request_id: 7ac480f7-815d-407f-9106-13c2b4c54b69
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4943,7 +4947,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65de06f2ba4d127f97961d22
+                    id: 65e0bd736abd0181dac14fb2
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -4977,15 +4981,21 @@ paths:
       tags:
       - Conversations
       operationId: retrieveConversation
-      description: "\nYou can fetch the details of a single conversation.\n\nThis
-        will return a single Conversation model with all its conversation parts.\n\n>
-        \U0001F6A7 Hard limit of 500 parts\n>\n> The maximum number of conversation
-        parts that can be returned via the API is 500. If you have more than that
-        we will return the 500 most recent conversation parts.\n\n> \U0001F4D8 Bot
-        name in conversation parts\n>\n> For conversation parts generated by a bot,
-        bot name will depend on the following:\n- Customers that never turned on AI
-        answers will have `operator` as the bot name\n- Customers that have turned
-        on AI answers at some point will have `fin` as the bot name\n"
+      description: |2
+
+        You can fetch the details of a single conversation.
+
+        This will return a single Conversation model with all its conversation parts.
+
+        {% admonition type="warning" name="Hard limit of 500 parts" %}
+        The maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.
+        {% /admonition %}
+
+        ### Bot Name in Conversation Parts
+
+        For conversation parts generated by a bot, bot name will depend on the following:
+        - Customers that never turned on AI answers will have `operator` as the bot name
+        - Customers that have turned on AI answers at some point will have `fin` as the bot name
       responses:
         '200':
           description: conversation found
@@ -4995,20 +5005,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '34'
-                    created_at: 1709049592
-                    updated_at: 1709049592
+                    id: '605'
+                    created_at: 1709227385
+                    updated_at: 1709227385
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918079'
+                      id: '403918411'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266395'
+                        id: '991268467'
                         name: Ciaran171 Lee
                         email: admin171@email.com
                       attachments: []
@@ -5018,7 +5028,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de06f8ba4d127f97961d26
+                        id: 65e0bd796abd0181dac14fb6
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5057,7 +5067,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: e6d0933a-e7ad-40e5-9f2b-9a57b1b42ff9
+                    request_id: 913ef3fc-7668-4460-8555-d2b0905c5a4f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5071,7 +5081,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9bdf5e4b-f176-4bc0-868e-3adc2d69630c
+                    request_id: 209f42c1-720f-4cf6-aeea-2182914ec24a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5085,7 +5095,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: a440b44e-1f59-4ca0-9a23-7e032316e9b7
+                    request_id: 46241e0e-d317-4824-84f7-ea33b7380644
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5115,10 +5125,14 @@ paths:
       tags:
       - Conversations
       operationId: updateConversation
-      description: "\nYou can update an existing conversation.\n\n> \U0001F4D8\n>\n>
-        If you want to update a conversation with either a reply (or actions such
-        as assign, unassign, open, close or snooze) then take a look at their own
-        sections respectively as they currently require different endpoints and parameters.\n\n"
+      description: |2+
+
+        You can update an existing conversation.
+
+        {% admonition type="info" name="Replying and other actions" %}
+        If you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.
+        {% /admonition %}
+
       responses:
         '200':
           description: conversation found
@@ -5128,20 +5142,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '38'
-                    created_at: 1709049599
-                    updated_at: 1709049600
+                    id: '609'
+                    created_at: 1709227390
+                    updated_at: 1709227392
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918083'
+                      id: '403918415'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266403'
+                        id: '991268475'
                         name: Ciaran175 Lee
                         email: admin175@email.com
                       attachments: []
@@ -5151,7 +5165,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de06ffba4d127f97961d2a
+                        id: 65e0bd7e6abd0181dac14fba
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5182,15 +5196,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '4'
+                        id: '137'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709049600
-                        updated_at: 1709049600
-                        notified_at: 1709049600
+                        created_at: 1709227392
+                        updated_at: 1709227392
+                        notified_at: 1709227392
                         assigned_to:
                         author:
-                          id: '991266404'
+                          id: '991268476'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id347_that_should_be_at_least_@intercom.io
@@ -5199,15 +5213,15 @@ paths:
                         redacted: false
                         metadata: {}
                       - type: conversation_part
-                        id: '5'
+                        id: '138'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709049600
-                        updated_at: 1709049600
-                        notified_at: 1709049600
+                        created_at: 1709227392
+                        updated_at: 1709227392
+                        notified_at: 1709227392
                         assigned_to:
                         author:
-                          id: '991266404'
+                          id: '991268476'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id347_that_should_be_at_least_@intercom.io
@@ -5226,7 +5240,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: a7d9f793-2f20-4f02-8511-04005152ce98
+                    request_id: e117a9f9-7ad0-4f98-b489-ad65e0003dac
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5240,7 +5254,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 592fd7cc-d395-4d41-ad92-c7d92e5df2c5
+                    request_id: 3ade11da-20e4-4c18-b576-7036cef8b6a1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5254,7 +5268,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 969bed9d-8f5c-4a36-b928-c606366ca86f
+                    request_id: ca69ed06-f5dd-4ae1-90e7-1e53c3341b6e
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5305,7 +5319,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '42'
+                    id: '613'
                     object: conversation
                     deleted: true
               schema:
@@ -5318,7 +5332,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2c7e082e-15de-4b2b-a6d0-7d62f131818e
+                    request_id: 8cfceafa-f9eb-494b-972c-69903ce7439d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5332,7 +5346,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 442dae71-6dd3-4ee6-aba3-341e6cb22af8
+                    request_id: e3857d03-32d0-40a9-974c-faae1055193e
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5452,20 +5466,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '45'
-                      created_at: 1709049611
-                      updated_at: 1709049611
+                      id: '616'
+                      created_at: 1709227402
+                      updated_at: 1709227402
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918090'
+                        id: '403918422'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991266433'
+                          id: '991268505'
                           name: Ciaran198 Lee
                           email: admin198@email.com
                         attachments: []
@@ -5475,7 +5489,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de070bba4d127f97961d31
+                          id: 65e0bd8a6abd0181dac14fc1
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -5516,15 +5530,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '45'
+                      value: '616'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '45'
+                        value: '616'
                       - field: id
                         operator: "="
-                        value: '45'
+                        value: '616'
   "/conversations/{id}/reply":
     post:
       summary: Reply to a conversation
@@ -5536,19 +5550,11 @@ paths:
       - name: id
         in: path
         required: true
+        description: The Intercom provisioned identifier for the conversation or the
+          string "last" to reply to the last part of the conversation
+        example: 123 or "last"
         schema:
-          oneOf:
-          - title: Conversation ID
-            type: string
-            description: The id of the conversation to target.
-            example: '123'
-          - title: The most recent conversation
-            type: string
-            enum:
-            - last
-            description: You can also reply to the most recent conversation on a workspace
-              by specifying `last` as the string.
-            example: last
+          type: string
       tags:
       - Conversations
       operationId: replyConversation
@@ -5563,20 +5569,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '53'
-                    created_at: 1709049620
-                    updated_at: 1709049621
-                    waiting_since: 1709049621
+                    id: '624'
+                    created_at: 1709227408
+                    updated_at: 1709227409
+                    waiting_since: 1709227409
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918093'
+                      id: '403918425'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266435'
+                        id: '991268507'
                         name: Ciaran199 Lee
                         email: admin199@email.com
                       attachments: []
@@ -5586,10 +5592,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0714ba4d127f97961d38
+                        id: 65e0bd906abd0181dac14fc8
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709049621
+                      created_at: 1709227409
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5618,15 +5624,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '7'
+                        id: '140'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709049621
-                        updated_at: 1709049621
-                        notified_at: 1709049621
+                        created_at: 1709227409
+                        updated_at: 1709227409
+                        notified_at: 1709227409
                         assigned_to:
                         author:
-                          id: 65de0714ba4d127f97961d38
+                          id: 65e0bd906abd0181dac14fc8
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5638,20 +5644,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '54'
-                    created_at: 1709049622
-                    updated_at: 1709049623
+                    id: '625'
+                    created_at: 1709227410
+                    updated_at: 1709227411
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918094'
+                      id: '403918426'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266437'
+                        id: '991268509'
                         name: Ciaran200 Lee
                         email: admin200@email.com
                       attachments: []
@@ -5661,7 +5667,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0716ba4d127f97961d39
+                        id: 65e0bd926abd0181dac14fc9
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5690,7 +5696,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '8'
+                        id: '141'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5705,12 +5711,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1709049623
-                        updated_at: 1709049623
-                        notified_at: 1709049623
+                        created_at: 1709227411
+                        updated_at: 1709227411
+                        notified_at: 1709227411
                         assigned_to:
                         author:
-                          id: '991266437'
+                          id: '991268509'
                           type: admin
                           name: Ciaran200 Lee
                           email: admin200@email.com
@@ -5722,20 +5728,20 @@ paths:
                 Admin quick_reply reply:
                   value:
                     type: conversation
-                    id: '55'
-                    created_at: 1709049624
-                    updated_at: 1709049626
+                    id: '626'
+                    created_at: 1709227412
+                    updated_at: 1709227414
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918095'
+                      id: '403918427'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266439'
+                        id: '991268511'
                         name: Ciaran201 Lee
                         email: admin201@email.com
                       attachments: []
@@ -5745,7 +5751,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0718ba4d127f97961d3a
+                        id: 65e0bd946abd0181dac14fca
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5774,15 +5780,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '9'
+                        id: '142'
                         part_type: quick_reply
                         body:
-                        created_at: 1709049626
-                        updated_at: 1709049626
-                        notified_at: 1709049626
+                        created_at: 1709227414
+                        updated_at: 1709227414
+                        notified_at: 1709227414
                         assigned_to:
                         author:
-                          id: '991266439'
+                          id: '991268511'
                           type: admin
                           name: Ciaran201 Lee
                           email: admin201@email.com
@@ -5794,20 +5800,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '56'
-                    created_at: 1709049627
-                    updated_at: 1709049628
-                    waiting_since: 1709049628
+                    id: '627'
+                    created_at: 1709227415
+                    updated_at: 1709227416
+                    waiting_since: 1709227416
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918096'
+                      id: '403918428'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266441'
+                        id: '991268513'
                         name: Ciaran202 Lee
                         email: admin202@email.com
                       attachments: []
@@ -5817,10 +5823,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de071aba4d127f97961d3b
+                        id: 65e0bd976abd0181dac14fcb
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709049628
+                      created_at: 1709227416
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5849,15 +5855,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '10'
+                        id: '143'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709049628
-                        updated_at: 1709049628
-                        notified_at: 1709049628
+                        created_at: 1709227416
+                        updated_at: 1709227416
+                        notified_at: 1709227416
                         assigned_to:
                         author:
-                          id: 65de071aba4d127f97961d3b
+                          id: 65e0bd976abd0181dac14fcb
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5876,7 +5882,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 7d910882-2288-450d-a069-ef8b5856fe98
+                    request_id: 62ee924b-23d2-4820-90b0-26a76dcceb3f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5890,7 +5896,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 41b143f0-a86e-4851-b857-602025ef39e1
+                    request_id: d3b1c96e-ac4b-403c-a67b-704a59f17b98
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5904,7 +5910,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 4a90325b-73b3-419d-a29e-fad176216926
+                    request_id: 33be37ef-d9c4-4739-9961-383a61a857e1
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5921,14 +5927,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0714ba4d127f97961d38
+                  intercom_user_id: 65e0bd906abd0181dac14fc8
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991266437
+                  admin_id: 991268509
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -5938,25 +5944,25 @@ paths:
                 value:
                   message_type: quick_reply
                   type: admin
-                  admin_id: 991266439
+                  admin_id: 991268511
                   reply_options:
                   - text: 'Yes'
-                    uuid: 44d39f40-8769-47ca-a709-48b239f3ae07
+                    uuid: 70988ad0-2073-4ccd-b7e7-dc854231388c
                   - text: 'No'
-                    uuid: 0152cb89-cffc-471c-a577-38c625cd7868
+                    uuid: a7b04be0-5a8d-4798-8875-641732351aa5
               user_last_conversation_reply:
                 summary: User last conversation reply
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de071aba4d127f97961d3b
+                  intercom_user_id: 65e0bd976abd0181dac14fcb
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de071dba4d127f97961d3c
+                  intercom_user_id: 65e0bd996abd0181dac14fcc
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -5977,10 +5983,11 @@ paths:
       - Conversations
       operationId: manageConversation
       description: |
-        You can close a conversation.
-        You can snooze a conversation to reopen on a future date.
-        You can open a conversation which is `snoozed` or `closed`.
-        You can assign a conversation to an admin and/or team.
+        For managing conversations you can:
+        - Close a conversation
+        - Snooze a conversation to reopen on a future date
+        - Open a conversation which is `snoozed` or `closed`
+        - Assign a conversation to an admin and/or team.
       responses:
         '200':
           description: Assign a conversation
@@ -5990,20 +5997,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '60'
-                    created_at: 1709049634
-                    updated_at: 1709049635
+                    id: '631'
+                    created_at: 1709227421
+                    updated_at: 1709227422
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918100'
+                      id: '403918432'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266449'
+                        id: '991268521'
                         name: Ciaran206 Lee
                         email: admin206@email.com
                       attachments: []
@@ -6013,7 +6020,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0722ba4d127f97961d3f
+                        id: 65e0bd9d6abd0181dac14fcf
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6042,15 +6049,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '11'
+                        id: '144'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1709049635
-                        updated_at: 1709049635
-                        notified_at: 1709049635
+                        created_at: 1709227422
+                        updated_at: 1709227422
+                        notified_at: 1709227422
                         assigned_to:
                         author:
-                          id: '991266449'
+                          id: '991268521'
                           type: admin
                           name: Ciaran206 Lee
                           email: admin206@email.com
@@ -6062,20 +6069,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '61'
-                    created_at: 1709049636
-                    updated_at: 1709049637
+                    id: '632'
+                    created_at: 1709227423
+                    updated_at: 1709227425
                     waiting_since:
-                    snoozed_until: 1709053236
+                    snoozed_until: 1709231024
                     source:
                       type: conversation
-                      id: '403918101'
+                      id: '403918433'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266451'
+                        id: '991268523'
                         name: Ciaran207 Lee
                         email: admin207@email.com
                       attachments: []
@@ -6085,7 +6092,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0724ba4d127f97961d40
+                        id: 65e0bd9f6abd0181dac14fd0
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6114,15 +6121,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '12'
+                        id: '145'
                         part_type: snoozed
                         body:
-                        created_at: 1709049637
-                        updated_at: 1709049637
-                        notified_at: 1709049637
+                        created_at: 1709227425
+                        updated_at: 1709227425
+                        notified_at: 1709227425
                         assigned_to:
                         author:
-                          id: '991266451'
+                          id: '991268523'
                           type: admin
                           name: Ciaran207 Lee
                           email: admin207@email.com
@@ -6134,20 +6141,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '66'
-                    created_at: 1709049635
-                    updated_at: 1709049646
+                    id: '637'
+                    created_at: 1709227423
+                    updated_at: 1709227432
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918102'
+                      id: '403918434'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266453'
+                        id: '991268525'
                         name: Ciaran208 Lee
                         email: admin208@email.com
                       attachments: []
@@ -6157,7 +6164,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0729ba4d127f97961d45
+                        id: 65e0bda46abd0181dac14fd5
                         external_id: '74'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6186,15 +6193,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '14'
+                        id: '147'
                         part_type: open
                         body:
-                        created_at: 1709049646
-                        updated_at: 1709049646
-                        notified_at: 1709049646
+                        created_at: 1709227432
+                        updated_at: 1709227432
+                        notified_at: 1709227432
                         assigned_to:
                         author:
-                          id: '991266453'
+                          id: '991268525'
                           type: admin
                           name: Ciaran208 Lee
                           email: admin208@email.com
@@ -6206,20 +6213,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '70'
-                    created_at: 1709049647
-                    updated_at: 1709049648
+                    id: '641'
+                    created_at: 1709227433
+                    updated_at: 1709227434
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918105'
+                      id: '403918437'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266455'
+                        id: '991268527'
                         name: Ciaran209 Lee
                         email: admin209@email.com
                       attachments: []
@@ -6229,10 +6236,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de072fba4d127f97961d48
+                        id: 65e0bda96abd0181dac14fd8
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991266455
+                    admin_assignee_id: 991268527
                     team_assignee_id:
                     open: true
                     state: open
@@ -6258,17 +6265,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '15'
+                        id: '148'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1709049648
-                        updated_at: 1709049648
-                        notified_at: 1709049648
+                        created_at: 1709227434
+                        updated_at: 1709227434
+                        notified_at: 1709227434
                         assigned_to:
                           type: admin
-                          id: '991266455'
+                          id: '991268527'
                         author:
-                          id: '991266455'
+                          id: '991268527'
                           type: admin
                           name: Ciaran209 Lee
                           email: admin209@email.com
@@ -6287,7 +6294,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 5561c414-4665-43ed-b589-1412c46f25df
+                    request_id: 46fd661f-6b54-45d3-aebf-fbcf9eccb39d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6301,7 +6308,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2ae3eaec-2f20-4d4a-a5c7-1333c9b816a1
+                    request_id: bd416d2c-574b-4ebc-8c21-111d363d7a48
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6315,7 +6322,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: adc6b341-bc21-493d-b108-beac71078ca4
+                    request_id: 21b90c06-7724-4f41-bd2b-9c53222f2597
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6336,32 +6343,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991266449
+                  admin_id: 991268521
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991266451
-                  snoozed_until: 1709053236
+                  admin_id: 991268523
+                  snoozed_until: 1709231024
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991266453
+                  admin_id: 991268525
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991266455
-                  assignee_id: 991266455
+                  admin_id: 991268527
+                  assignee_id: 991268527
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991266457
+                  admin_id: 991268529
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -6392,20 +6399,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '74'
-                    created_at: 1709049654
-                    updated_at: 1709049654
+                    id: '645'
+                    created_at: 1709227438
+                    updated_at: 1709227439
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918109'
+                      id: '403918441'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266463'
+                        id: '991268535'
                         name: Ciaran213 Lee
                         email: admin213@email.com
                       attachments: []
@@ -6415,7 +6422,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0735ba4d127f97961d4c
+                        id: 65e0bdae6abd0181dac14fdc
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6444,17 +6451,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '16'
+                        id: '149'
                         part_type: default_assignment
                         body:
-                        created_at: 1709049655
-                        updated_at: 1709049655
-                        notified_at: 1709049655
+                        created_at: 1709227439
+                        updated_at: 1709227439
+                        notified_at: 1709227439
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991266464'
+                          id: '991268536'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id391_that_should_be_at_least_@intercom.io
@@ -6473,7 +6480,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: d483d2f4-76b8-45d4-990f-7f3982b780b2
+                    request_id: 3da967d9-a0ef-4178-b7a0-5f837225e337
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6487,7 +6494,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8bdfd22c-2fd4-42a1-94ad-632a84fbf94e
+                    request_id: c0db66fc-d3a4-409d-8efa-e10449ee7d2b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6501,7 +6508,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: b2133743-4b0f-410a-a969-cc1edada40f5
+                    request_id: 8646f6a7-6c9b-4622-bea9-652201a1da94
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6525,11 +6532,13 @@ paths:
       tags:
       - Conversations
       operationId: attachContactToConversation
-      description: "You can add participants who are contacts to a conversation, on
-        behalf of either another contact or an admin.\n\n> \U0001F6A7 Note about contacts
-        without an email\n>\n> If you add a contact via the email parameter and there
-        is no user/lead found on that workspace with he given email, then we will
-        create a new contact with `role` set to `lead`.\n\n"
+      description: |+
+        You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.
+
+        {% admonition type="attention" name="Contacts without an email" %}
+        If you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.
+        {% /admonition %}
+
       responses:
         '200':
           description: Attach a contact to a conversation
@@ -6540,7 +6549,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65de073bba4d127f97961d50
+                      id: 65e0bdb46abd0181dac14fe0
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6551,7 +6560,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 4b5c22dc-5cd3-48fc-9f77-b12dcea3852e
+                    request_id: e81ca21f-a6ff-47e7-8c13-98c7583d1e6c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6565,7 +6574,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4243c719-e540-4669-bd37-dd1d2b15fc8a
+                    request_id: 360fc1af-79b0-4ddb-ac0a-6d6e73ff7665
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6579,7 +6588,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 37e2db14-89bb-4a8a-b35b-9424801af115
+                    request_id: 1721d82e-0645-4d68-881d-586cf4ab4aaf
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6594,15 +6603,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991266471
+                  admin_id: 991268543
                   customer:
-                    intercom_user_id: 65de073bba4d127f97961d50
+                    intercom_user_id: 65e0bdb46abd0181dac14fe0
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991266473
+                  admin_id: 991268545
                   customer:
-                    intercom_user_id: 65de073dba4d127f97961d51
+                    intercom_user_id: 65e0bdb66abd0181dac14fe1
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -6628,11 +6637,13 @@ paths:
       tags:
       - Conversations
       operationId: detachContactFromConversation
-      description: "You can add participants who are contacts to a conversation, on
-        behalf of either another contact or an admin.\n\n> \U0001F6A7 Note about contacts
-        without an email\n>\n> If you add a contact via the email parameter and there
-        is no user/lead found on that workspace with he given email, then we will
-        create a new contact with `role` set to `lead`.\n\n"
+      description: |+
+        You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.
+
+        {% admonition type="attention" name="Contacts without an email" %}
+        If you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.
+        {% /admonition %}
+
       responses:
         '200':
           description: Detach a contact from a group conversation
@@ -6643,7 +6654,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65de0748ba4d127f97961d5b
+                      id: 65e0bdbf6abd0181dac14feb
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6654,14 +6665,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 4b4bd806-90c8-4e5b-a3b9-1c4407640cbd
+                    request_id: 97f94ded-b09e-434f-a545-c6f65711988d
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 3752f814-2b07-4933-b1de-456e4930a793
+                    request_id: 1489b334-3119-4a91-a6a3-f85c512085d1
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -6675,7 +6686,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: a9429e6a-3346-478e-8dda-535aff558f1c
+                    request_id: 12569ad2-c9e3-40cf-873a-9e3530ed51f3
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -6689,7 +6700,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 87c5d13d-fbf2-42eb-a076-189a1070a3c6
+                    request_id: 2aee5344-f4d2-418d-873d-155a39fe25d4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6703,7 +6714,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 7bffd447-a021-4837-8161-2fe7db7a1b5b
+                    request_id: 6b03886e-7613-45c9-8d50-98a54f1f7476
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6718,27 +6729,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991266479
+                  admin_id: 991268551
                   customer:
-                    intercom_user_id: 65de0741ba4d127f97961d54
+                    intercom_user_id: 65e0bdb96abd0181dac14fe4
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991266481
+                  admin_id: 991268553
                   customer:
-                    intercom_user_id: 65de0749ba4d127f97961d5c
+                    intercom_user_id: 65e0bdc06abd0181dac14fec
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991266483
+                  admin_id: 991268555
                   customer:
-                    intercom_user_id: 65de0750ba4d127f97961d63
+                    intercom_user_id: 65e0bdc76abd0181dac14ff3
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991266485
+                  admin_id: 991268557
                   customer:
-                    intercom_user_id: 65de0757ba4d127f97961d6a
+                    intercom_user_id: 65e0bdce6abd0181dac14ffa
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6750,12 +6761,13 @@ paths:
       tags:
       - Conversations
       operationId: redactConversation
-      description: "You can redact a conversation part or the source message of a
-        conversation (as seen in the source object).\n\n> \U0001F4D8 Which parts and
-        source messages can I redact?\n>\n> If you are redacting a conversation part,
-        it must have a `body`.\n> If you are redacting a source message, it must have
-        been created by a contact.\n> We will return a `conversation_part_not_redactable`
-        error if these criteria are not met.\n\n"
+      description: |+
+        You can redact a conversation part or the source message of a conversation (as seen in the source object).
+
+        {% admonition type="info" name="Redacting parts and messages" %}
+        If you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.
+        {% /admonition %}
+
       responses:
         '200':
           description: Redact a conversation part
@@ -6765,20 +6777,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '130'
-                    created_at: 1709049710
-                    updated_at: 1709049712
-                    waiting_since: 1709049711
+                    id: '701'
+                    created_at: 1709227492
+                    updated_at: 1709227494
+                    waiting_since: 1709227493
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918135'
+                      id: '403918467'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266491'
+                        id: '991268563'
                         name: Ciaran227 Lee
                         email: admin227@email.com
                       attachments: []
@@ -6788,10 +6800,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de076eba4d127f97961d7f
+                        id: 65e0bde46abd0181dac1500f
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709049711
+                      created_at: 1709227493
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6820,15 +6832,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '24'
+                        id: '157'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1709049711
-                        updated_at: 1709049712
-                        notified_at: 1709049711
+                        created_at: 1709227493
+                        updated_at: 1709227494
+                        notified_at: 1709227493
                         assigned_to:
                         author:
-                          id: 65de076eba4d127f97961d7f
+                          id: 65e0bde46abd0181dac1500f
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6847,7 +6859,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 235d9d7f-d3f9-47dc-8120-9df5b3a7541a
+                    request_id: c0edb36c-cb13-42b7-906f-265c1acbb8b0
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -6861,7 +6873,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3c531a82-8128-4816-ab3e-61f2b9ed90a6
+                    request_id: 3773efb8-1a2e-4828-96d8-fd48e7ef9988
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6877,8 +6889,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 130
-                  conversation_part_id: 24
+                  conversation_id: 701
+                  conversation_part_id: 157
               not_found:
                 summary: Not found
                 value:
@@ -6913,20 +6925,20 @@ paths:
                 successful:
                   value:
                     type: ticket
-                    id: '133'
-                    ticket_id: '1'
+                    id: '704'
+                    ticket_id: '24'
                     ticket_attributes: {}
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '1'
+                      id: '108'
                       name: my-ticket-type-1
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id425_that_should_be_at_least_
                       archived: false
-                      created_at: 1709049719
-                      updated_at: 1709049719
+                      created_at: 1709227500
+                      updated_at: 1709227500
                       is_internal: false
                       ticket_type_attributes:
                         type: list
@@ -6936,37 +6948,37 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0775ba4d127f97961d82
+                        id: 65e0bde96abd0181dac15012
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709049717
-                    updated_at: 1709049719
+                    created_at: 1709227497
+                    updated_at: 1709227500
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '26'
+                        id: '159'
                         part_type: comment
                         body: "<p>Comment for message</p>"
-                        created_at: 1709049717
-                        updated_at: 1709049717
+                        created_at: 1709227497
+                        updated_at: 1709227497
                         author:
-                          id: 65de0775ba4d127f97961d82
+                          id: 65e0bde96abd0181dac15012
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '27'
+                        id: '160'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709049719
-                        updated_at: 1709049719
+                        created_at: 1709227500
+                        updated_at: 1709227500
                         author:
-                          id: '991266501'
+                          id: '991268573'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id425_that_should_be_at_least_@intercom.io
@@ -6991,7 +7003,7 @@ paths:
                 Bad request:
                   value:
                     type: error.list
-                    request_id: 0eb83571-a9f9-4931-8d5c-8b24c6768ece
+                    request_id: be98374f-dcf5-46c0-ac8b-92087b66003a
                     errors:
                     - code: parameter_invalid
                       message: Ticket type is not a customer ticket type
@@ -7006,11 +7018,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  ticket_type_id: '1'
+                  ticket_type_id: '108'
               bad_request:
                 summary: Bad request
                 value:
-                  ticket_type_id: '2'
+                  ticket_type_id: '109'
   "/custom_object_instances/{custom_object_type_identifier}":
     parameters:
     - name: custom_object_type_identifier
@@ -7045,8 +7057,8 @@ paths:
                     external_id: '123'
                     external_created_at: 1392036272
                     external_updated_at: 1392036272
-                    created_at: 1709049723
-                    updated_at: 1709049723
+                    created_at: 1709227504
+                    updated_at: 1709227504
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7057,7 +7069,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 592ce9bf-b800-482d-8ff9-ba2ce6aafe50
+                    request_id: 4fae9acc-de4e-4c14-bb37-3cbf35f258c3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7123,8 +7135,8 @@ paths:
                     external_id: '123'
                     external_created_at:
                     external_updated_at:
-                    created_at: 1709049725
-                    updated_at: 1709049725
+                    created_at: 1709227506
+                    updated_at: 1709227506
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7135,7 +7147,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cec9e1da-99ad-4804-9e4b-c25c45aaa48d
+                    request_id: f1a6e58a-5ef5-4525-a642-57ac73c819d3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7181,8 +7193,8 @@ paths:
                     external_id: '123'
                     external_created_at:
                     external_updated_at:
-                    created_at: 1709049726
-                    updated_at: 1709049726
+                    created_at: 1709227506
+                    updated_at: 1709227506
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7193,7 +7205,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 80894eb9-4714-4c92-a646-dfaf3e7d307b
+                    request_id: 19027344-b407-4221-bfad-ace66fe02384
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7237,7 +7249,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b823ea12-bd6f-4aef-806e-2bb23c528f6b
+                    request_id: 5ec30eb9-37be-4386-af29-f9422a98bd3f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7423,7 +7435,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 2
+                    - id: 66
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -7436,9 +7448,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991266518'
-                      created_at: 1709049728
-                      updated_at: 1709049728
+                      admin_id: '991268590'
+                      created_at: 1709227508
+                      updated_at: 1709227508
                       model: company
                     - type: data_attribute
                       name: id
@@ -7510,7 +7522,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 45aeda3d-cd77-4d04-be62-2bb20c3bdbd3
+                    request_id: 4c512e09-e1a6-4a1d-8eeb-e4a5cfd6fa98
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7535,7 +7547,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 5
+                    id: 69
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -7546,9 +7558,9 @@ paths:
                     messenger_writable: false
                     custom: true
                     archived: false
-                    admin_id: '991266520'
-                    created_at: 1709049729
-                    updated_at: 1709049729
+                    admin_id: '991268592'
+                    created_at: 1709227509
+                    updated_at: 1709227509
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -7560,7 +7572,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: 5e1e5b8e-6392-40bd-b8cd-9c22f99f90dd
+                    request_id: 70f655d4-09ad-43d5-bbcd-0c6f7ee965b0
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -7568,7 +7580,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: a5588d68-3483-4230-bc7d-d86c01884436
+                    request_id: 57d5bd8b-1054-4f2d-9039-cb8a4edbd9fe
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -7576,7 +7588,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: a7b7e236-f736-4963-94f9-0aa18a1a5432
+                    request_id: 34ca565e-dd6b-46fd-9db1-db438a772cf1
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -7584,14 +7596,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: 52e75df7-6209-4e6f-9bb3-f7d92a8c447e
+                    request_id: 503b9800-97b8-4733-9b10-8e1f90f5c530
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: 77bcbf82-7daa-4064-99d9-8d15b44774d0
+                    request_id: d86de746-2d01-4d3b-8bcf-0191f2e02720
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -7606,7 +7618,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 75d90825-9cc4-4686-9c52-2b69d3a60958
+                    request_id: 7ca0fdf9-5b80-4bea-adeb-437e57ca3743
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7685,7 +7697,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 12
+                    id: 76
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -7700,9 +7712,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991266527'
-                    created_at: 1709049732
-                    updated_at: 1709049733
+                    admin_id: '991268599'
+                    created_at: 1709227513
+                    updated_at: 1709227513
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -7714,7 +7726,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: d0540f82-8c68-4da1-a671-1ce05d5ac716
+                    request_id: e0b19ae4-26ee-49f0-adda-8f2181794669
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -7728,7 +7740,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: d8a98624-c9ca-48df-9373-e3a93af2ffc6
+                    request_id: ca222eb9-4834-425e-84b5-0b9c18732160
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -7742,7 +7754,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: 737f556f-1c96-4677-9f6d-19cac537ec4a
+                    request_id: 45a6dd4e-a17a-4ddd-a312-9ca7e54e5b3a
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -7757,7 +7769,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e20b04ae-dafd-4dff-b273-b0d085670b56
+                    request_id: e00fba61-d13b-4256-b524-6512e903bd52
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7862,7 +7874,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7e3924a1-eb20-4a41-b0a3-944ee45134f4
+                    request_id: 60c3c221-b223-40e2-a9e9-1a4e9fbda004
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7949,7 +7961,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 65de0789ba4d127f97961d88
+                    intercom_user_id: 65e0bdfd6abd0181dac15018
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -7961,7 +7973,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7f795f3d-874c-46c0-aa24-2c548ca1feaa
+                    request_id: b98ed429-a7dd-4d67-a7a9-2a1d90fd1bd2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7992,7 +8004,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 38790ef4-9da2-4301-8749-c5c3c9a61e9e
+                    request_id: 0e97670a-c94d-4519-82d4-0a6dd223ca9f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8036,7 +8048,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: z6rlup6ejpepxkip
+                    job_identifier: l6utcvon3s6kyk64
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -8051,8 +8063,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1709031740
-                  created_at_before: 1709049740
+                  created_at_after: 1709209520
+                  created_at_before: 1709227520
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -8086,7 +8098,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: roeottajqevmtkto
+                    job_identifier: mn6k0skjojst06me
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -8118,7 +8130,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: juiy3w6ltqvsf41c
+                    job_identifier: l8p9t5l1h95cfpin
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -8179,30 +8191,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918140'
-                    created_at: 1709049743
+                    id: '403918472'
+                    created_at: 1709227522
                     body: heyy
                     message_type: inapp
-                    conversation_id: '135'
+                    conversation_id: '706'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918141'
-                    created_at: 1709049744
+                    id: '403918473'
+                    created_at: 1709227523
                     body: heyy
                     message_type: inapp
-                    conversation_id: '136'
+                    conversation_id: '707'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '5'
-                    created_at: 1709049745
+                    id: '25'
+                    created_at: 1709227525
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991266550'
+                      id: '991268622'
                       name: Ciaran279 Lee
                       email: admin279@email.com
                       away_mode_enabled: false
@@ -8217,14 +8229,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: b103a5fb-c0ad-494b-9edd-158b026e441c
+                    request_id: 39feb561-faad-4f8e-a22f-eabbe0883eaf
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: d511c40b-f650-43ff-aefc-c94cb81d949b
+                    request_id: 2fb2d043-9631-40ac-9508-b3fc2c53f109
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -8238,7 +8250,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: f22d2ba3-15b8-42c3-b224-49a13f01a77d
+                    request_id: fda2a426-353e-4e7d-898d-59f8d5ca771c
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -8252,7 +8264,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 710980e0-4899-4431-9a61-78788d2016e8
+                    request_id: 5ea84b3e-d6f9-4806-be6c-bee4f9b6d130
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8266,7 +8278,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: f12bc70b-304a-4a9c-b17d-12db4904676a
+                    request_id: 302f7ff2-f9d6-4e6e-83d4-2d3a1b99e0e2
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -8283,7 +8295,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65de078eba4d127f97961d8d
+                    id: 65e0be026abd0181dac1501d
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -8291,7 +8303,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 65de0790ba4d127f97961d8e
+                    id: 65e0be036abd0181dac1501e
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -8299,10 +8311,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991266550'
+                    id: '991268622'
                   to:
                     type: user
-                    id: 65de0791ba4d127f97961d8f
+                    id: 65e0be046abd0181dac1501f
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -8310,10 +8322,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991266552'
+                    id: '991268624'
                   to:
                     type: user
-                    id: 65de0792ba4d127f97961d90
+                    id: 65e0be056abd0181dac15020
                   message_type: inapp
                   body:
                   subject: heyy
@@ -8322,7 +8334,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991266553'
+                    id: '991268625'
                   to:
                     type: user
                     user_id: '70'
@@ -8333,10 +8345,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991266554'
+                    id: '991268626'
                   to:
                     type: user
-                    id: 65de0793ba4d127f97961d92
+                    id: 65e0be066abd0181dac15022
                   message_type: email
                   body:
                   subject: heyy
@@ -8367,12 +8379,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '1'
+                    - id: '57'
                       type: news-item
                       workspace_id: this_is_an_id515_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991266559
+                      sender_id: 991268631
                       state: draft
                       labels: []
                       cover_image_url:
@@ -8382,15 +8394,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709049749
-                      updated_at: 1709049749
+                      created_at: 1709227528
+                      updated_at: 1709227528
                       newsfeed_assignments: []
-                    - id: '2'
+                    - id: '58'
                       type: news-item
                       workspace_id: this_is_an_id515_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991266561
+                      sender_id: 991268633
                       state: draft
                       labels: []
                       cover_image_url:
@@ -8400,8 +8412,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709049749
-                      updated_at: 1709049749
+                      created_at: 1709227528
+                      updated_at: 1709227528
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -8414,7 +8426,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e5ffb45b-3dfc-4a65-9629-e7771f4e78a3
+                    request_id: 8b7d531b-3345-4885-9f92-6643d9bd81e4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8439,12 +8451,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '5'
+                    id: '61'
                     type: news-item
                     workspace_id: this_is_an_id519_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991266568
+                    sender_id: 991268640
                     state: live
                     labels:
                     - New
@@ -8455,10 +8467,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1709049751
-                    updated_at: 1709049751
+                    created_at: 1709227530
+                    updated_at: 1709227530
                     newsfeed_assignments:
-                    - newsfeed_id: 3
+                    - newsfeed_id: 103
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -8470,7 +8482,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b7b93669-b74d-4b13-b146-ca776ad76663
+                    request_id: 678c9b5a-37f9-4227-a080-d48c42c182a7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8491,14 +8503,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991266568
+                  sender_id: 991268640
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 3
+                  - newsfeed_id: 103
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -8527,12 +8539,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '6'
+                    id: '62'
                     type: news-item
                     workspace_id: this_is_an_id523_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991266571
+                    sender_id: 991268643
                     state: live
                     labels: []
                     cover_image_url:
@@ -8542,11 +8554,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1709049752
-                    updated_at: 1709049752
+                    created_at: 1709227531
+                    updated_at: 1709227531
                     newsfeed_assignments:
-                    - newsfeed_id: 5
-                      published_at: 1709049752
+                    - newsfeed_id: 105
+                      published_at: 1709227531
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -8557,7 +8569,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 01c693af-2324-4494-bb7b-7d43fd56aae8
+                    request_id: 5b3530af-e03e-4b4e-9096-dc7c2b7c7475
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8571,7 +8583,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 67ab8383-97f7-49e8-bed1-ca6c76905ce4
+                    request_id: 8badf7a4-31b3-4098-8bd5-1561536435c6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8602,12 +8614,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '9'
+                    id: '65'
                     type: news-item
                     workspace_id: this_is_an_id529_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991266579
+                    sender_id: 991268651
                     state: live
                     labels: []
                     cover_image_url:
@@ -8615,8 +8627,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1709049754
-                    updated_at: 1709049754
+                    created_at: 1709227532
+                    updated_at: 1709227533
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -8628,7 +8640,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: ff77fec8-ea7a-45da-8c43-ece68593f28b
+                    request_id: 5e36a61e-34da-406d-ac2a-cd7d1a803e0e
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8642,7 +8654,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b8477e7b-e04f-40c3-97a2-1090336dc608
+                    request_id: bcf06938-ed48-4bee-a8f0-b4112421030b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8659,7 +8671,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991266579
+                  sender_id: 991268651
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -8668,7 +8680,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991266582
+                  sender_id: 991268654
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -8698,7 +8710,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '12'
+                    id: '68'
                     object: news-item
                     deleted: true
               schema:
@@ -8711,7 +8723,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 895ab289-d2b2-41d7-9fb2-0f11ac40ed2d
+                    request_id: 894409a1-50ed-443a-bdc3-cc12b20ab680
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8725,7 +8737,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4bba3a5e-fd3a-4997-a14b-9f99cea5aa3e
+                    request_id: 9a48c278-8b6d-4683-b950-cf0726224435
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8778,7 +8790,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cf0d66f7-61aa-4ba4-aacb-418c801fb4ba
+                    request_id: 7d3c9ca9-d7d5-415d-960c-3622590a9e90
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8811,16 +8823,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '18'
+                    - id: '118'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709049759
-                      updated_at: 1709049759
-                    - id: '19'
+                      created_at: 1709227538
+                      updated_at: 1709227538
+                    - id: '119'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709049759
-                      updated_at: 1709049759
+                      created_at: 1709227538
+                      updated_at: 1709227538
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -8832,7 +8844,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 70729cd7-137e-4679-ba1c-67882c5e8378
+                    request_id: 695a8e56-b83c-49b1-93a6-77bc34f7ebc1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8866,11 +8878,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '22'
+                    id: '122'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1709049760
-                    updated_at: 1709049760
+                    created_at: 1709227538
+                    updated_at: 1709227538
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -8881,7 +8893,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 21a194b5-595e-46f2-958c-572d6e4372dc
+                    request_id: 5d03d0a7-669f-49cf-95e6-84b8bcb44123
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8915,14 +8927,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '11'
-                    created_at: 1708358561
+                    id: '63'
+                    created_at: 1708536339
                     contact:
                       type: contact
-                      id: 65de07a1ba4d127f97961d95
+                      id: 65e0be136abd0181dac15025
                     author:
                       type: admin
-                      id: '991266598'
+                      id: '991268670'
                       name: Ciaran326 Lee
                       email: admin326@email.com
                       away_mode_enabled: false
@@ -8938,7 +8950,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: 5a41e865-b3bb-48d5-bd63-465c231c90e2
+                    request_id: ab298099-1d96-4570-affc-34210a313212
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8952,7 +8964,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 505d6eab-8ef5-48c6-88cf-9d7bec68e5da
+                    request_id: 00ba6a8c-efba-45e6-8c47-cddcd1a722a6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8988,16 +9000,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 65de07a3ba4d127f97961d98
+                      id: 65e0be156abd0181dac15028
                       name: John segment
-                      created_at: 1709049763
-                      updated_at: 1709049763
+                      created_at: 1709227541
+                      updated_at: 1709227541
                       person_type: user
                     - type: segment
-                      id: 65de07a3ba4d127f97961d99
+                      id: 65e0be156abd0181dac15029
                       name: Jane segment
-                      created_at: 1709049763
-                      updated_at: 1709049763
+                      created_at: 1709227541
+                      updated_at: 1709227541
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -9009,7 +9021,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 042b127f-38cc-430c-b994-f7ff6beb2e22
+                    request_id: 144674bc-8e04-4e16-8a2f-2fd129366699
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9043,10 +9055,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 65de07a4ba4d127f97961d9c
+                    id: 65e0be166abd0181dac1502c
                     name: John segment
-                    created_at: 1709049764
-                    updated_at: 1709049764
+                    created_at: 1709227542
+                    updated_at: 1709227542
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -9058,7 +9070,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: c5874c78-33f0-440c-8848-af5d8f28f433
+                    request_id: 66a03d15-5922-4f85-85d4-581e6fe15029
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9072,7 +9084,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d2a7ff61-6916-4584-a6d1-e0d0f9726ab4
+                    request_id: 7c2d75bc-9e7b-433c-baec-8553d8923deb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9102,7 +9114,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '45'
+                      id: '229'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -9125,7 +9137,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 559bed1c-4c1f-400d-82d4-870208ac4454
+                    request_id: fd7b22ee-0b65-4407-988b-5eecac5e0139
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9155,7 +9167,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/df3be477-a8f2-4414-b3e9-29cbb70b26b7
+                    url: http://via.intercom.io/msgr/fb68eebc-ddd4-430e-b3f7-287bb388d7bf
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -9188,7 +9200,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 903afa89-0fe1-4d1c-b95f-5d75dbf79f2e
+                    request_id: '083b682e-1657-4a62-b9f4-322adfeae5fd'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9251,7 +9263,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '23'
+                      id: '192'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -9263,7 +9275,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7b56e848-e796-48d2-90b9-5d4b3bbfef6a
+                    request_id: 39bd135a-f677-4ecc-9f24-528d1565fe1f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9302,7 +9314,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '26'
+                    id: '195'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9314,7 +9326,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: 3f941938-2cfe-49d5-993d-a7ec831d808b
+                    request_id: 5cd7b647-7e2f-4169-ba61-8c8541ec2ad5
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -9328,14 +9340,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: 83e81ed0-491c-4928-b320-0cd7518715f2
+                    request_id: 040c319f-bdd8-423e-8cd4-6e787202ad5f
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: e20e0b10-be27-41de-9da5-45c3ef589064
+                    request_id: 68b00384-fc9b-4af1-bfea-eb4f60c6b14e
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -9349,7 +9361,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1e159566-9aaa-4f4e-b016-5b4eaa8a3aea
+                    request_id: ddb970dd-a463-4675-8977-a3f1aaf869b1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9415,7 +9427,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '34'
+                    id: '203'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9427,7 +9439,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: b7c4b577-176a-4db2-9171-91cea82390ec
+                    request_id: c0a49163-7dde-4af4-b629-3024f318b516
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9441,7 +9453,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0d88834d-a885-4866-9fc0-c0821b6f3072
+                    request_id: b7fef1f5-0877-4842-afc7-24c371c88070
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9477,7 +9489,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: acfde1bb-385b-4b08-a28d-d73506c87bf0
+                    request_id: 2b431786-898a-450d-81d1-6f18d9fcefc8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9491,7 +9503,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: f8941863-9859-4398-9392-80a07f233cf6
+                    request_id: 49561cea-8bb6-4b7f-9005-072659563869
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -9506,7 +9518,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c8053300-32f9-4a6d-9b31-10870a6f22f4
+                    request_id: 93d5ee54-8e35-40a0-ac2f-b2e8747b303f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9544,7 +9556,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4c188a2b-4b80-4fe1-9b5b-8a649f3e8eb8
+                    request_id: b92bd16f-3633-46f0-b6da-7074b6ea24ee
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9579,7 +9591,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991266636'
+                    id: '991268708'
                     name: team 1
                     admin_ids: []
               schema:
@@ -9592,7 +9604,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: eabe6aa7-f134-49ef-97fc-34e075f74226
+                    request_id: 901cb30c-5af6-477c-b654-058c925abce3
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -9606,7 +9618,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a34a7354-d10b-4173-8805-2cc3399a28dd
+                    request_id: 39b43da3-8f71-4795-ae98-47dadbafa9dc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9639,7 +9651,7 @@ paths:
                 Ticket Type Attribute created:
                   value:
                     type: ticket_type_attribute
-                    id: '22'
+                    id: '322'
                     workspace_id: this_is_an_id621_that_should_be_at_least_
                     name: Attribute Title
                     description: Attribute Description
@@ -9652,10 +9664,10 @@ paths:
                     visible_on_create: true
                     visible_to_contacts: true
                     default: false
-                    ticket_type_id: 3
+                    ticket_type_id: 110
                     archived: false
-                    created_at: 1709049783
-                    updated_at: 1709049783
+                    created_at: 1709227560
+                    updated_at: 1709227560
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -9666,7 +9678,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b531d02e-40f9-42b6-81b3-a1a67a264312
+                    request_id: 38fbdd5e-3561-44f6-9a7e-e83e380fb0f8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9719,7 +9731,7 @@ paths:
                 Ticket Type Attribute updated:
                   value:
                     type: ticket_type_attribute
-                    id: '27'
+                    id: '327'
                     workspace_id: this_is_an_id625_that_should_be_at_least_
                     name: name
                     description: New Attribute Description
@@ -9730,10 +9742,10 @@ paths:
                     visible_on_create: false
                     visible_to_contacts: false
                     default: false
-                    ticket_type_id: 5
+                    ticket_type_id: 112
                     archived: false
-                    created_at: 1709049784
-                    updated_at: 1709049784
+                    created_at: 1709227561
+                    updated_at: 1709227561
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -9744,7 +9756,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4a5ac9c0-89fc-4f66-85a1-2e897a7b45a4
+                    request_id: dc4d6571-91c5-4a5c-b8ac-94eab339d855
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9783,20 +9795,20 @@ paths:
                     type: list
                     data:
                     - type: ticket_type
-                      id: '7'
+                      id: '114'
                       name: Bug Report
                       description: Bug Report Template
                       icon: "\U0001F39F️"
                       workspace_id: this_is_an_id629_that_should_be_at_least_
                       archived: false
-                      created_at: 1709049785
-                      updated_at: 1709049785
+                      created_at: 1709227562
+                      updated_at: 1709227562
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '30'
+                          id: '330'
                           workspace_id: this_is_an_id629_that_should_be_at_least_
                           name: _default_title_
                           description: ''
@@ -9809,12 +9821,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 7
+                          ticket_type_id: 114
                           archived: false
-                          created_at: 1709049785
-                          updated_at: 1709049785
+                          created_at: 1709227562
+                          updated_at: 1709227562
                         - type: ticket_type_attribute
-                          id: '32'
+                          id: '332'
                           workspace_id: this_is_an_id629_that_should_be_at_least_
                           name: name
                           description: description
@@ -9826,12 +9838,12 @@ paths:
                           visible_on_create: false
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 7
+                          ticket_type_id: 114
                           archived: false
-                          created_at: 1709049785
-                          updated_at: 1709049785
+                          created_at: 1709227562
+                          updated_at: 1709227562
                         - type: ticket_type_attribute
-                          id: '31'
+                          id: '331'
                           workspace_id: this_is_an_id629_that_should_be_at_least_
                           name: _default_description_
                           description: ''
@@ -9844,10 +9856,10 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 7
+                          ticket_type_id: 114
                           archived: false
-                          created_at: 1709049785
-                          updated_at: 1709049785
+                          created_at: 1709227562
+                          updated_at: 1709227562
                       category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type_list"
@@ -9859,7 +9871,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 93d83ac7-5312-462a-8d80-3b24515838cf
+                    request_id: 56035eff-972a-4ae6-9357-f7422eb26110
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9888,20 +9900,20 @@ paths:
                 Ticket type created:
                   value:
                     type: ticket_type
-                    id: '10'
+                    id: '117'
                     name: Customer Issue
                     description: Customer Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id633_that_should_be_at_least_
                     archived: false
-                    created_at: 1709049787
-                    updated_at: 1709049787
+                    created_at: 1709227563
+                    updated_at: 1709227563
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '39'
+                        id: '339'
                         workspace_id: this_is_an_id633_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -9914,12 +9926,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 10
+                        ticket_type_id: 117
                         archived: false
-                        created_at: 1709049787
-                        updated_at: 1709049787
+                        created_at: 1709227563
+                        updated_at: 1709227563
                       - type: ticket_type_attribute
-                        id: '40'
+                        id: '340'
                         workspace_id: this_is_an_id633_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -9932,10 +9944,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 10
+                        ticket_type_id: 117
                         archived: false
-                        created_at: 1709049787
-                        updated_at: 1709049787
+                        created_at: 1709227563
+                        updated_at: 1709227563
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -9947,7 +9959,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d88e5cd0-78bd-4a2b-b668-d00a4537f6ed
+                    request_id: ecf3ddb6-d105-4c92-ad99-cea3e05bcb4c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9993,20 +10005,20 @@ paths:
                 Ticket type found:
                   value:
                     type: ticket_type
-                    id: '12'
+                    id: '119'
                     name: Bug Report
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id637_that_should_be_at_least_
                     archived: false
-                    created_at: 1709049787
-                    updated_at: 1709049787
+                    created_at: 1709227564
+                    updated_at: 1709227564
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '44'
+                        id: '344'
                         workspace_id: this_is_an_id637_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -10019,12 +10031,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 12
+                        ticket_type_id: 119
                         archived: false
-                        created_at: 1709049787
-                        updated_at: 1709049787
+                        created_at: 1709227564
+                        updated_at: 1709227564
                       - type: ticket_type_attribute
-                        id: '46'
+                        id: '346'
                         workspace_id: this_is_an_id637_that_should_be_at_least_
                         name: name
                         description: description
@@ -10036,12 +10048,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 12
+                        ticket_type_id: 119
                         archived: false
-                        created_at: 1709049787
-                        updated_at: 1709049787
+                        created_at: 1709227564
+                        updated_at: 1709227564
                       - type: ticket_type_attribute
-                        id: '45'
+                        id: '345'
                         workspace_id: this_is_an_id637_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -10054,10 +10066,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 12
+                        ticket_type_id: 119
                         archived: false
-                        created_at: 1709049787
-                        updated_at: 1709049787
+                        created_at: 1709227564
+                        updated_at: 1709227564
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -10069,7 +10081,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f4c955db-d017-4fb6-86d1-3a4ee716d3c7
+                    request_id: cc7abf41-6b93-43be-ae29-97fd72b290b1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10102,20 +10114,20 @@ paths:
                 Ticket type updated:
                   value:
                     type: ticket_type
-                    id: '14'
+                    id: '121'
                     name: Bug Report 2
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id641_that_should_be_at_least_
                     archived: false
-                    created_at: 1709049789
-                    updated_at: 1709049789
+                    created_at: 1709227565
+                    updated_at: 1709227565
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '50'
+                        id: '350'
                         workspace_id: this_is_an_id641_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -10128,12 +10140,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 14
+                        ticket_type_id: 121
                         archived: false
-                        created_at: 1709049789
-                        updated_at: 1709049789
+                        created_at: 1709227565
+                        updated_at: 1709227565
                       - type: ticket_type_attribute
-                        id: '52'
+                        id: '352'
                         workspace_id: this_is_an_id641_that_should_be_at_least_
                         name: name
                         description: description
@@ -10145,12 +10157,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 14
+                        ticket_type_id: 121
                         archived: false
-                        created_at: 1709049789
-                        updated_at: 1709049789
+                        created_at: 1709227565
+                        updated_at: 1709227565
                       - type: ticket_type_attribute
-                        id: '51'
+                        id: '351'
                         workspace_id: this_is_an_id641_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -10163,10 +10175,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 14
+                        ticket_type_id: 121
                         archived: false
-                        created_at: 1709049789
-                        updated_at: 1709049789
+                        created_at: 1709227565
+                        updated_at: 1709227565
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -10178,7 +10190,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b38d5317-b521-4f28-bc4a-0122b82b06fb
+                    request_id: c56634a7-edd2-4115-b316-0b6d2e064055
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10224,13 +10236,13 @@ paths:
                 User reply:
                   value:
                     type: ticket_part
-                    id: '30'
+                    id: '163'
                     part_type: comment
                     body: "<p>Thanks again :)</p>"
-                    created_at: 1709049792
-                    updated_at: 1709049792
+                    created_at: 1709227568
+                    updated_at: 1709227568
                     author:
-                      id: 65de07c0ba4d127f97961dbf
+                      id: 65e0be2f6abd0181dac1504f
                       type: user
                       name:
                       email: user30@email.com
@@ -10239,7 +10251,7 @@ paths:
                 Admin note reply:
                   value:
                     type: ticket_part
-                    id: '32'
+                    id: '165'
                     part_type: note
                     body: |-
                       <h2>An Unordered HTML List</h2>
@@ -10254,10 +10266,10 @@ paths:
                       <li>Tea</li>
                       <li>Milk</li>
                       </ol>
-                    created_at: 1709049795
-                    updated_at: 1709049795
+                    created_at: 1709227570
+                    updated_at: 1709227570
                     author:
-                      id: '991266663'
+                      id: '991268735'
                       type: admin
                       name: Ciaran385 Lee
                       email: admin385@email.com
@@ -10266,12 +10278,12 @@ paths:
                 Admin quick_reply reply:
                   value:
                     type: ticket_part
-                    id: '34'
+                    id: '167'
                     part_type: quick_reply
-                    created_at: 1709049797
-                    updated_at: 1709049797
+                    created_at: 1709227573
+                    updated_at: 1709227573
                     author:
-                      id: '991266668'
+                      id: '991268740'
                       type: admin
                       name: Ciaran389 Lee
                       email: admin389@email.com
@@ -10287,7 +10299,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 478e01ec-551a-4fa8-8406-b6bd850c785e
+                    request_id: ba42ac82-044b-47ef-a7a4-50ae1f86443f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -10301,7 +10313,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 45bc49f6-4a9b-47f8-82f2-1b4329e39db3
+                    request_id: b9dbfb7f-28d9-4b02-b6b2-c9592ed8f656
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10318,14 +10330,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de07c0ba4d127f97961dbf
+                  intercom_user_id: 65e0be2f6abd0181dac1504f
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991266663
+                  admin_id: 991268735
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -10335,18 +10347,18 @@ paths:
                 value:
                   message_type: quick_reply
                   type: admin
-                  admin_id: 991266668
+                  admin_id: 991268740
                   reply_options:
                   - text: 'Yes'
-                    uuid: e45aee79-c5c6-4295-aa42-4f864b767fb3
+                    uuid: 7c62a524-65c0-4e3f-a2a6-62fd1ebab674
                   - text: 'No'
-                    uuid: b200466a-8c82-4e1a-8ad5-52cb71404520
+                    uuid: b158b19a-d87a-4d13-835f-73d2d854910e
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de07c6ba4d127f97961dc2
+                  intercom_user_id: 65e0be366abd0181dac15052
                   body: Thanks again :)
   "/tickets/{ticket_id}/tags":
     post:
@@ -10378,7 +10390,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '42'
+                    id: '211'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -10390,7 +10402,7 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: 89098c0f-79e7-4854-9e4b-caa2cb20cad2
+                    request_id: 285d793f-8f0f-43a2-9780-d74d0aad4141
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
@@ -10404,7 +10416,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d9fe0db2-72de-4726-b0ce-95eab4e56d6e
+                    request_id: '04615268-ef02-4704-88ce-09305d222ef3'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10433,13 +10445,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 42
-                  admin_id: 991266678
+                  id: 211
+                  admin_id: 991268750
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  id: 43
-                  admin_id: 991266681
+                  id: 212
+                  admin_id: 991268753
   "/tickets/{ticket_id}/tags/{id}":
     delete:
       summary: Remove tag from a ticket
@@ -10477,7 +10489,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '45'
+                    id: '214'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -10489,14 +10501,14 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: 97c5f105-c6a3-40f1-bee1-51f3eb6094e3
+                    request_id: 2494e815-8f3d-4def-83e9-5e95d44ea94e
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: c059f4f0-b25f-493a-962a-9c8c8eeab1db
+                    request_id: 851f364a-389e-4165-9d09-176d2a9930c9
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -10510,7 +10522,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4798a244-2c51-4268-8c68-312866970971
+                    request_id: f91cde7d-68dc-4496-8f07-1c3331af7049
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10533,15 +10545,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991266687
+                  admin_id: 991268759
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  admin_id: 991266690
+                  admin_id: 991268762
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991266693
+                  admin_id: 991268765
   "/tickets":
     post:
       summary: Create a ticket
@@ -10563,28 +10575,28 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '148'
-                    ticket_id: '12'
+                    id: '719'
+                    ticket_id: '35'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '28'
+                      id: '135'
                       name: my-ticket-type-15
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id669_that_should_be_at_least_
                       archived: false
-                      created_at: 1709049815
-                      updated_at: 1709049815
+                      created_at: 1709227586
+                      updated_at: 1709227586
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '64'
+                          id: '364'
                           workspace_id: this_is_an_id669_that_should_be_at_least_
                           name: title
                           description: ola
@@ -10596,12 +10608,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 28
+                          ticket_type_id: 135
                           archived: false
-                          created_at: 1709049815
-                          updated_at: 1709049815
+                          created_at: 1709227586
+                          updated_at: 1709227586
                         - type: ticket_type_attribute
-                          id: '65'
+                          id: '365'
                           workspace_id: this_is_an_id669_that_should_be_at_least_
                           name: description
                           description: ola
@@ -10613,33 +10625,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 28
+                          ticket_type_id: 135
                           archived: false
-                          created_at: 1709049815
-                          updated_at: 1709049815
+                          created_at: 1709227587
+                          updated_at: 1709227587
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de07d7ba4d127f97961dca
+                        id: 65e0be436abd0181dac1505a
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709049816
-                    updated_at: 1709049816
+                    created_at: 1709227587
+                    updated_at: 1709227587
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '35'
+                        id: '168'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709049816
-                        updated_at: 1709049816
+                        created_at: 1709227587
+                        updated_at: 1709227587
                         author:
-                          id: '991266705'
+                          id: '991268777'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id669_that_should_be_at_least_@intercom.io
@@ -10664,7 +10676,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f29647a5-ea6d-4474-b72e-26435b3943ed
+                    request_id: 4a4bd392-66f5-4a3c-a9b1-c6d89ff62362
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10679,9 +10691,9 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  ticket_type_id: 28
+                  ticket_type_id: 135
                   contacts:
-                  - id: 65de07d7ba4d127f97961dca
+                  - id: 65e0be436abd0181dac1505a
                   ticket_attributes:
                     title: example
                     description: there is a problem
@@ -10712,28 +10724,28 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '149'
-                    ticket_id: '13'
+                    id: '720'
+                    ticket_id: '36'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: in_progress
                     ticket_type:
                       type: ticket_type
-                      id: '30'
+                      id: '137'
                       name: my-ticket-type-17
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id673_that_should_be_at_least_
                       archived: false
-                      created_at: 1709049817
-                      updated_at: 1709049817
+                      created_at: 1709227589
+                      updated_at: 1709227589
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '69'
+                          id: '369'
                           workspace_id: this_is_an_id673_that_should_be_at_least_
                           name: title
                           description: ola
@@ -10745,12 +10757,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 30
+                          ticket_type_id: 137
                           archived: false
-                          created_at: 1709049817
-                          updated_at: 1709049817
+                          created_at: 1709227589
+                          updated_at: 1709227589
                         - type: ticket_type_attribute
-                          id: '70'
+                          id: '370'
                           workspace_id: this_is_an_id673_that_should_be_at_least_
                           name: description
                           description: ola
@@ -10762,98 +10774,98 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 30
+                          ticket_type_id: 137
                           archived: false
-                          created_at: 1709049818
-                          updated_at: 1709049818
+                          created_at: 1709227589
+                          updated_at: 1709227589
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de07daba4d127f97961dcb
-                        external_id: a1aa2806-f4ef-479b-a896-86092dac1e91
-                    admin_assignee_id: '991266719'
+                        id: 65e0be456abd0181dac1505b
+                        external_id: df39deff-f249-4449-b4cb-673dd9be8a4d
+                    admin_assignee_id: '991268791'
                     team_assignee_id: '0'
-                    created_at: 1709049818
-                    updated_at: 1709049820
+                    created_at: 1709227589
+                    updated_at: 1709227592
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '36'
+                        id: '169'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709049818
-                        updated_at: 1709049818
+                        created_at: 1709227590
+                        updated_at: 1709227590
                         author:
-                          id: '991266717'
+                          id: '991268789'
                           type: admin
                           name: Ciaran429 Lee
                           email: admin429@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '37'
+                        id: '170'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709049819
-                        updated_at: 1709049819
+                        created_at: 1709227591
+                        updated_at: 1709227591
                         author:
-                          id: '991266718'
+                          id: '991268790'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id673_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '38'
+                        id: '171'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709049820
-                        updated_at: 1709049820
+                        created_at: 1709227591
+                        updated_at: 1709227591
                         author:
-                          id: '991266718'
+                          id: '991268790'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id673_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '39'
+                        id: '172'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: in_progress
                         previous_ticket_state: submitted
-                        created_at: 1709049820
-                        updated_at: 1709049820
+                        created_at: 1709227591
+                        updated_at: 1709227591
                         author:
-                          id: '991266718'
+                          id: '991268790'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id673_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '40'
+                        id: '173'
                         part_type: assignment
-                        created_at: 1709049820
-                        updated_at: 1709049820
+                        created_at: 1709227591
+                        updated_at: 1709227591
                         assigned_to:
                           type: admin
-                          id: '991266719'
+                          id: '991268791'
                         author:
-                          id: '991266717'
+                          id: '991268789'
                           type: admin
                           name: Ciaran429 Lee
                           email: admin429@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '41'
+                        id: '174'
                         part_type: snoozed
-                        created_at: 1709049820
-                        updated_at: 1709049820
+                        created_at: 1709227592
+                        updated_at: 1709227592
                         author:
-                          id: '991266718'
+                          id: '991268790'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id673_that_should_be_at_least_@intercom.io
@@ -10861,7 +10873,7 @@ paths:
                         redacted: false
                       total_count: 6
                     open: true
-                    snoozed_until: 1709139600
+                    snoozed_until: 1709312400
                     linked_objects:
                       type: list
                       data: []
@@ -10879,14 +10891,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: af0c3430-47bb-4f0c-971d-7c1dee9edc8e
+                    request_id: 89174ebe-8645-4da3-b905-365118a661fc
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
                 Assignee not found:
                   value:
                     type: error.list
-                    request_id: 7ebb2e30-8806-4446-9e89-4bbdc1bdbb15
+                    request_id: 82897bf7-81b5-42e9-a2b5-2174aad14478
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
@@ -10898,7 +10910,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4134092b-8a90-4d92-907a-f585cb902c1a
+                    request_id: c55fb7e2-086c-4af4-a055-dfe6acfbce94
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10918,8 +10930,8 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991266717'
-                    assignee_id: '991266719'
+                    admin_id: '991268789'
+                    assignee_id: '991268791'
                   open: true
                   snoozed_until: 1673609604
               admin_not_found:
@@ -10931,7 +10943,7 @@ paths:
                   state: in_progress
                   assignment:
                     admin_id: '123'
-                    assignee_id: '991266727'
+                    assignee_id: '991268799'
               assignee_not_found:
                 summary: Assignee not found
                 value:
@@ -10940,7 +10952,7 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991266733'
+                    admin_id: '991268805'
                     assignee_id: '456'
     get:
       summary: Retrieve a ticket
@@ -10968,28 +10980,28 @@ paths:
                 Ticket found:
                   value:
                     type: ticket
-                    id: '152'
-                    ticket_id: '16'
+                    id: '723'
+                    ticket_id: '39'
                     ticket_attributes:
                       title: attribute_value
                       description:
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '34'
+                      id: '141'
                       name: my-ticket-type-21
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id681_that_should_be_at_least_
                       archived: false
-                      created_at: 1709049827
-                      updated_at: 1709049827
+                      created_at: 1709227597
+                      updated_at: 1709227597
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '80'
+                          id: '380'
                           workspace_id: this_is_an_id681_that_should_be_at_least_
                           name: title
                           description: ola
@@ -11001,12 +11013,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 34
+                          ticket_type_id: 141
                           archived: false
-                          created_at: 1709049827
-                          updated_at: 1709049827
+                          created_at: 1709227597
+                          updated_at: 1709227597
                         - type: ticket_type_attribute
-                          id: '81'
+                          id: '381'
                           workspace_id: this_is_an_id681_that_should_be_at_least_
                           name: description
                           description: ola
@@ -11018,33 +11030,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 34
+                          ticket_type_id: 141
                           archived: false
-                          created_at: 1709049827
-                          updated_at: 1709049827
+                          created_at: 1709227597
+                          updated_at: 1709227597
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de07e3ba4d127f97961dce
-                        external_id: 6ff7a273-a1ac-42c4-a185-2766b7165cbc
+                        id: 65e0be4d6abd0181dac1505e
+                        external_id: 3bf85af7-4d13-46d8-9305-32afc85940ae
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709049827
-                    updated_at: 1709049828
+                    created_at: 1709227598
+                    updated_at: 1709227598
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '44'
+                        id: '177'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709049828
-                        updated_at: 1709049828
+                        created_at: 1709227598
+                        updated_at: 1709227598
                         author:
-                          id: '991266746'
+                          id: '991268818'
                           type: admin
                           name: Ciaran455 Lee
                           email: admin455@email.com
@@ -11069,7 +11081,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 748324c3-cee5-4abb-8ea7-6a0a85ebb885
+                    request_id: a85f0d0d-356d-412c-8115-b74fff1d52de
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11155,28 +11167,28 @@ paths:
                     total_count: 1
                     tickets:
                     - type: ticket
-                      id: '153'
-                      ticket_id: '17'
+                      id: '724'
+                      ticket_id: '40'
                       ticket_attributes:
                         title: attribute_value
                         description:
                       ticket_state: submitted
                       ticket_type:
                         type: ticket_type
-                        id: '36'
+                        id: '143'
                         name: my-ticket-type-23
                         description: my ticket type description is awesome.
                         icon: "\U0001F981"
                         workspace_id: this_is_an_id685_that_should_be_at_least_
                         archived: false
-                        created_at: 1709049830
-                        updated_at: 1709049830
+                        created_at: 1709227599
+                        updated_at: 1709227599
                         is_internal: false
                         ticket_type_attributes:
                           type: list
                           data:
                           - type: ticket_type_attribute
-                            id: '85'
+                            id: '385'
                             workspace_id: this_is_an_id685_that_should_be_at_least_
                             name: title
                             description: ola
@@ -11188,12 +11200,12 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 36
+                            ticket_type_id: 143
                             archived: false
-                            created_at: 1709049830
-                            updated_at: 1709049830
+                            created_at: 1709227600
+                            updated_at: 1709227600
                           - type: ticket_type_attribute
-                            id: '86'
+                            id: '386'
                             workspace_id: this_is_an_id685_that_should_be_at_least_
                             name: description
                             description: ola
@@ -11205,33 +11217,33 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 36
+                            ticket_type_id: 143
                             archived: false
-                            created_at: 1709049830
-                            updated_at: 1709049830
+                            created_at: 1709227600
+                            updated_at: 1709227600
                         category: Back-office
                       contacts:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de07e7ba4d127f97961dcf
-                          external_id: 32e29a81-bdab-44e9-a385-85a28c08848b
+                          id: 65e0be506abd0181dac1505f
+                          external_id: 91a518b5-8bd2-4b9f-85b4-4355059f3da1
                       admin_assignee_id: '0'
                       team_assignee_id: '0'
-                      created_at: 1709049831
-                      updated_at: 1709049831
+                      created_at: 1709227600
+                      updated_at: 1709227600
                       ticket_parts:
                         type: ticket_part.list
                         ticket_parts:
                         - type: ticket_part
-                          id: '45'
+                          id: '178'
                           part_type: ticket_state_updated_by_admin
                           ticket_state: submitted
                           previous_ticket_state: submitted
-                          created_at: 1709049831
-                          updated_at: 1709049831
+                          created_at: 1709227600
+                          updated_at: 1709227600
                           author:
-                            id: '991266759'
+                            id: '991268831'
                             type: admin
                             name: Ciaran467 Lee
                             email: admin467@email.com
@@ -11262,15 +11274,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '153'
+                      value: '724'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '153'
+                        value: '724'
                       - field: id
                         operator: "="
-                        value: '153'
+                        value: '724'
   "/visitors":
     put:
       summary: Update a visitor
@@ -11297,26 +11309,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de07e9ba4d127f97961dd2
+                    id: 65e0be526abd0181dac15062
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Turquoise Trailer
+                    pseudonym: Cyan Rhino
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/turquoise-trailer.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/cyan-rhino.png
                     app_id: this_is_an_id689_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709049833
-                    remote_created_at: 1709049833
-                    signed_up_at: 1709049833
-                    updated_at: 1709049833
+                    created_at: 1709227602
+                    remote_created_at: 1709227602
+                    signed_up_at: 1709227602
+                    updated_at: 1709227603
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -11349,7 +11361,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 2771ac5b-7f81-416a-9673-8ed21533cf28
+                    request_id: 77cb6760-4e67-449c-ba50-09ee30264f49
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -11363,7 +11375,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: de17f5fc-8abc-482f-88ca-60a09f58efb0
+                    request_id: 25236b69-f2bd-4bc6-aed5-efac7043034e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11378,7 +11390,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 65de07e9ba4d127f97961dd2
+                  id: 65e0be526abd0181dac15062
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -11411,7 +11423,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de07ebba4d127f97961dd8
+                    id: 65e0be546abd0181dac15068
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -11427,10 +11439,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709049835
-                    remote_created_at: 1709049835
-                    signed_up_at: 1709049835
-                    updated_at: 1709049835
+                    created_at: 1709227604
+                    remote_created_at: 1709227604
+                    signed_up_at: 1709227604
+                    updated_at: 1709227604
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -11463,7 +11475,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: ebda107a-6c0a-4ed7-93e5-386118351856
+                    request_id: e000120c-8039-4698-b482-d6db4cd323d7
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -11477,7 +11489,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 67e127d5-77cf-44e1-b8f3-d95bf6d080c2
+                    request_id: d7bc39a1-c111-4e73-a4ad-ee5f1435347c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11511,7 +11523,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de07ecba4d127f97961dde
+                    id: 65e0be556abd0181dac1506e
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -11527,10 +11539,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709049836
-                    remote_created_at: 1709049836
-                    signed_up_at: 1709049836
-                    updated_at: 1709049836
+                    created_at: 1709227605
+                    remote_created_at: 1709227605
+                    signed_up_at: 1709227605
+                    updated_at: 1709227605
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -11563,7 +11575,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: 1e3dc3df-ea94-4bfb-a037-f313017082b8
+                    request_id: 726551fa-cbb8-4ded-8083-0d6e607f9a6c
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -11577,7 +11589,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9a36399b-9e65-424b-a3b0-4fa36d4f9cb5
+                    request_id: b2eb50d0-699c-482b-b6ba-5d0d46d00255
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11610,7 +11622,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de07eeba4d127f97961de4
+                    id: 65e0be576abd0181dac15074
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -11626,10 +11638,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709049838
-                    remote_created_at: 1709049838
-                    signed_up_at: 1709049838
-                    updated_at: 1709049838
+                    created_at: 1709227607
+                    remote_created_at: 1709227607
+                    signed_up_at: 1709227607
+                    updated_at: 1709227607
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -11662,7 +11674,7 @@ paths:
                 Visitor Not Found:
                   value:
                     type: error.list
-                    request_id: a30891f3-3b7c-4441-b20a-18c4ac2dc12e
+                    request_id: 8f42d00b-4153-4a0f-adee-91bba99a278b
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -11676,7 +11688,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 145a2e8c-774b-4a13-9391-4d0e217342fc
+                    request_id: ef8f8037-045b-4ccd-b06b-483c404f727d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11707,7 +11719,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de07efba4d127f97961deb
+                    id: 65e0be596abd0181dac1507b
                     workspace_id: this_is_an_id713_that_should_be_at_least_
                     external_id:
                     role: user
@@ -11723,9 +11735,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709049839
-                    updated_at: 1709049840
-                    signed_up_at: 1709049839
+                    created_at: 1709227609
+                    updated_at: 1709227609
+                    signed_up_at: 1709227609
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -11759,31 +11771,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de07efba4d127f97961deb/tags"
+                      url: "/contacts/65e0be596abd0181dac1507b/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de07efba4d127f97961deb/notes"
+                      url: "/contacts/65e0be596abd0181dac1507b/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de07efba4d127f97961deb/companies"
+                      url: "/contacts/65e0be596abd0181dac1507b/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de07efba4d127f97961deb/subscriptions"
+                      url: "/contacts/65e0be596abd0181dac1507b/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de07efba4d127f97961deb/subscriptions"
+                      url: "/contacts/65e0be596abd0181dac1507b/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -11802,7 +11814,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a328b26b-ee66-4b1c-bf94-62b68c930790
+                    request_id: 860672f5-a2dc-4beb-8e98-4ccb244f43b5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -12122,12 +12134,32 @@ components:
             - text
             - uuid
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -13618,12 +13650,32 @@ components:
             time will be used.
           example: 1590000000
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -13656,12 +13708,32 @@ components:
             time will be used.
           example: 1590000000
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -13700,12 +13772,32 @@ components:
             time will be used.
           example: 1590000000
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991268781'
+                    id: '991267745'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1709051394
+                      created_at: 1709226901
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991268782'
+                    id: '991267746'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: e4192424-1941-4060-ab5c-df2dadc67253
+                    request_id: 12b20f82-7795-45d9-90ad-c065e5b6addb
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e034323c-b6da-4142-9bbc-b5ee6982a071
+                    request_id: 1bdb7f19-ab4a-4261-88df-159ddcea4a5a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: 710395a4-52f2-419d-8f80-90365f50889f
+                    - id: 6664db46-c98d-4b15-b035-743881f8f972
                       performed_by:
                         type: admin
-                        id: '991268786'
+                        id: '991267750'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1709051401
+                      created_at: 1709226907
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: caeb1640-735a-49e0-ae6c-8cea9d498c9b
+                    - id: 6e15efe4-d65d-4fc0-a095-282e6232c216
                       performed_by:
                         type: admin
-                        id: '991268786'
+                        id: '991267750'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1709051401
+                      created_at: 1709226907
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 33f8508c-4319-4525-a549-9bf41da07af7
+                    request_id: 8654b76a-ad4d-463c-96c6-d517d5452461
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991268788'
+                      id: '991267752'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a881f392-293e-4e1a-90a2-523f88ca79ff
+                    request_id: 2996d7d0-5087-42b0-ace1-73c6b001a7af
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991268790'
+                    id: '991267754'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 7ed0e3bf-4457-4eb3-8d24-9dafa028a7c5
+                    request_id: 8358826a-0a4b-4a69-805a-f48100354c72
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 74dec858-4313-4e8d-ace1-e3d93762bfda
+                    request_id: 001e5fbe-ba41-49e9-8b37-1e37cd7ef835
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -390,20 +390,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '88'
+                    - id: '57'
                       type: article
                       workspace_id: this_is_an_id22_that_should_be_at_least_4
-                      parent_id: 360
+                      parent_id: 221
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991268793
+                      author_id: 991267757
                       state: published
-                      created_at: 1709051405
-                      updated_at: 1709051405
-                      url: http://help-center.test/myapp-22/en/articles/88-this-is-the-article-title
+                      created_at: 1709226912
+                      updated_at: 1709226912
+                      url: http://help-center.test/myapp-22/en/articles/57-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -414,7 +414,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 61771792-d330-4b67-aa3a-1b0612696289
+                    request_id: 015ded0d-c178-475f-83c6-4abb47167951
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -439,10 +439,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '91'
+                    id: '60'
                     type: article
                     workspace_id: this_is_an_id26_that_should_be_at_least_4
-                    parent_id: 362
+                    parent_id: 223
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -456,11 +456,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991268798
+                    author_id: 991267762
                     state: published
-                    created_at: 1709051407
-                    updated_at: 1709051407
-                    url: http://help-center.test/myapp-26/en/articles/91-thanks-for-everything
+                    created_at: 1709226914
+                    updated_at: 1709226914
+                    url: http://help-center.test/myapp-26/en/articles/60-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -471,7 +471,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: b5054e5b-0bb9-477d-8d54-e5f1da3c9cd7
+                    request_id: 559e679b-868d-46d7-9ff5-03bee5e5eb7b
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -486,7 +486,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b892ec96-cd37-4bea-8c5f-4a16ba0209d5
+                    request_id: 231c39bf-2f35-4df9-abd9-08787786c6db
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -504,16 +504,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991268798
+                  author_id: 991267762
                   state: published
-                  parent_id: 362
+                  parent_id: 223
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991268798
+                      author_id: 991267762
                       state: published
               bad_request:
                 summary: Bad Request
@@ -550,10 +550,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '94'
+                    id: '63'
                     type: article
                     workspace_id: this_is_an_id32_that_should_be_at_least_4
-                    parent_id: 365
+                    parent_id: 226
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -567,11 +567,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991268803
+                    author_id: 991267767
                     state: published
-                    created_at: 1709051409
-                    updated_at: 1709051409
-                    url: http://help-center.test/myapp-32/en/articles/94-this-is-the-article-title
+                    created_at: 1709226916
+                    updated_at: 1709226916
+                    url: http://help-center.test/myapp-32/en/articles/63-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -582,7 +582,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: 21a943c6-6625-4d5f-80bb-8fe23c13d156
+                    request_id: 5bd26f7a-5d20-4129-acc1-d4500c68a099
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -596,7 +596,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5c83fe16-339b-4d33-81bb-95f736b3835f
+                    request_id: f21e7edc-ec2a-4da6-b1c1-55a83a6cedd2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -629,10 +629,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '97'
+                    id: '66'
                     type: article
                     workspace_id: this_is_an_id38_that_should_be_at_least_4
-                    parent_id: 368
+                    parent_id: 229
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -646,11 +646,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991268809
+                    author_id: 991267773
                     state: published
-                    created_at: 1709051412
-                    updated_at: 1709051412
-                    url: http://help-center.test/myapp-38/en/articles/97-christmas-is-here
+                    created_at: 1709226918
+                    updated_at: 1709226919
+                    url: http://help-center.test/myapp-38/en/articles/66-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -661,7 +661,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: b21d9970-49b8-4f3b-b6e7-11a817087a08
+                    request_id: 5ebe236b-035d-4e88-a6e3-78c37438d73b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -675,7 +675,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3a753045-d955-44d9-aab5-e99a515c318a
+                    request_id: e5c4c9d0-d26e-405b-a90d-0c385684a6ab
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -723,7 +723,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '100'
+                    id: '69'
                     object: article
                     deleted: true
               schema:
@@ -736,7 +736,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 10a09e90-290a-44d5-90c5-25fab39554cf
+                    request_id: afa061e8-aaca-48db-b99c-c978cc042725
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -750,7 +750,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1f6b0803-f417-44f1-98cc-aa7464e0d8be
+                    request_id: 233572e4-de1c-4ee9-b34a-7cef15c3fefe
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -810,7 +810,7 @@ paths:
                     total_count: 1
                     data:
                       articles:
-                      - id: '104'
+                      - id: '73'
                         type: article
                         workspace_id: this_is_an_id50_that_should_be_at_least_4
                         parent_id:
@@ -819,10 +819,10 @@ paths:
                         title: Title 1
                         description: ''
                         body: ''
-                        author_id: 991268822
+                        author_id: 991267786
                         state: draft
-                        created_at: 1709051417
-                        updated_at: 1709051417
+                        created_at: 1709226923
+                        updated_at: 1709226923
                         url:
                       highlights: []
                     pages:
@@ -840,7 +840,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 228dfa24-17da-4d04-a885-d5f24ab95976
+                    request_id: 5800eb4a-b70a-4b7a-9bc3-d79f99423408
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -871,27 +871,27 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '376'
+                    - id: '237'
                       workspace_id: this_is_an_id54_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-54/collection-17
                       order: 17
-                      created_at: 1709051418
-                      updated_at: 1709051418
+                      created_at: 1709226924
+                      updated_at: 1709226924
                       description: english collection description
                       icon: bookmark
                       parent_id:
-                      help_center_id: 192
-                    - id: '377'
+                      help_center_id: 129
+                    - id: '238'
                       workspace_id: this_is_an_id54_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-54/section-1
                       order: 1
-                      created_at: 1709051418
-                      updated_at: 1709051418
+                      created_at: 1709226924
+                      updated_at: 1709226924
                       description:
                       icon: bookmark
-                      parent_id: '376'
+                      parent_id: '237'
                       help_center_id:
                     total_count: 2
                     pages:
@@ -909,7 +909,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 067a6bc2-1a9b-4eea-92c4-ea44722ef44e
+                    request_id: b0d7f7d1-2b95-4be1-9aa4-5c13e83f751d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -934,17 +934,17 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '382'
+                    id: '243'
                     workspace_id: this_is_an_id58_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-58/
                     order: 1
-                    created_at: 1709051419
-                    updated_at: 1709051419
+                    created_at: 1709226925
+                    updated_at: 1709226925
                     description: ''
                     icon: book-bookmark
                     parent_id:
-                    help_center_id: 194
+                    help_center_id: 131
               schema:
                 "$ref": "#/components/schemas/collection"
         '400':
@@ -955,7 +955,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: bfe01e5a-b3e5-456d-85b0-754aa4af6c73
+                    request_id: db079605-c80d-495f-ad51-368ba8d74b71
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -969,7 +969,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8c4e4c80-008f-4314-9be5-43190124d9ed
+                    request_id: 3a46e9c6-4fce-42ce-b538-6be6bc70dd0d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1017,17 +1017,17 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '387'
+                    id: '248'
                     workspace_id: this_is_an_id64_that_should_be_at_least_4
                     name: English collection title
                     url: http://help-center.test/myapp-64/collection-22
                     order: 22
-                    created_at: 1709051420
-                    updated_at: 1709051420
+                    created_at: 1709226926
+                    updated_at: 1709226926
                     description: english collection description
                     icon: bookmark
                     parent_id:
-                    help_center_id: 197
+                    help_center_id: 134
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1038,7 +1038,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: '0191cb50-0fe7-4fb7-b671-76d783568b32'
+                    request_id: 298b0b45-1c54-4d82-9588-e76d13fa44c8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1052,7 +1052,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 914f4c42-5313-403e-8c58-fcedcc05ef08
+                    request_id: 2f59df93-190d-4f78-b29a-69443744359e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1085,17 +1085,17 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '393'
+                    id: '254'
                     workspace_id: this_is_an_id70_that_should_be_at_least_4
                     name: Update collection name
                     url: http://help-center.test/myapp-70/collection-25
                     order: 25
-                    created_at: 1709051422
-                    updated_at: 1709051422
+                    created_at: 1709226928
+                    updated_at: 1709226928
                     description: english collection description
                     icon: folder
                     parent_id:
-                    help_center_id: 200
+                    help_center_id: 137
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1106,7 +1106,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: 50f65dac-dda4-47ae-a894-c6ce1ef1de19
+                    request_id: 42d88494-6121-4f3d-87ad-fa07652699e9
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1120,7 +1120,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: edac8ed0-ae31-4bf3-8642-6d94762fdd06
+                    request_id: 2b2e328d-c578-4b4a-ba6e-7e52eed3566d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1167,7 +1167,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '399'
+                    id: '260'
                     object: collection
                     deleted: true
               schema:
@@ -1180,7 +1180,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: 12de0ac7-3280-4056-874c-eb43361602db
+                    request_id: 0de03e48-d55b-4407-9d86-39f7011e4c4b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1194,7 +1194,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5df5ca5d-b6f3-4827-894f-7d0115b54187
+                    request_id: 3fe6e33b-4ef9-4654-bd84-3e17f99db7ac
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1228,10 +1228,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '206'
+                    id: '143'
                     workspace_id: this_is_an_id82_that_should_be_at_least_4
-                    created_at: 1709051425
-                    updated_at: 1709051425
+                    created_at: 1709226931
+                    updated_at: 1709226931
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1245,7 +1245,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: d8bd25c6-249f-48ef-ad2a-005fe868bf51
+                    request_id: 9f29c135-2a12-4116-9435-975257ba31c9
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1259,7 +1259,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5ca0bc72-174b-431d-9816-dc5b95049275
+                    request_id: 2892f9e0-c6c4-4664-996b-584fb137f6ad
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1297,7 +1297,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fdc5f688-474d-4718-9ccb-67c1655c3fae
+                    request_id: f3217845-6263-4d7b-b742-16434e7d86cf
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1330,12 +1330,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 65de0e26ba4d12057e509825
+                    id: 65e0bbb76abd017f5e8b1c6b
                     app_id: this_is_an_id105_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1709051430
-                    updated_at: 1709051430
+                    created_at: 1709226935
+                    updated_at: 1709226935
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1372,7 +1372,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7395fca9-d47f-4b39-8a5e-2fde4a86fd2c
+                    request_id: dcd7cbd4-1546-4b8d-ba15-f3588cfa10e5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1470,12 +1470,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0e27ba4d12057e50982d
+                      id: 65e0bbb96abd017f5e8b1c73
                       app_id: this_is_an_id111_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709051431
-                      created_at: 1709051431
-                      updated_at: 1709051431
+                      remote_created_at: 1709226937
+                      created_at: 1709226937
+                      updated_at: 1709226937
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -1504,7 +1504,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 2a16b40b-3fb7-45b5-9466-bf3d8ba4a558
+                    request_id: fb2f8351-ed76-417d-b022-f33bc01239a8
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1518,7 +1518,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 52b8b0c5-966a-4e16-bb1d-2474a2eac638
+                    request_id: 483c3a26-31d2-4daa-8b3f-749953bb6901
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1553,12 +1553,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0e2aba4d12057e509838
+                    id: 65e0bbbb6abd017f5e8b1c7e
                     app_id: this_is_an_id117_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1709051434
-                    created_at: 1709051434
-                    updated_at: 1709051434
+                    remote_created_at: 1709226939
+                    created_at: 1709226939
+                    updated_at: 1709226939
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1580,7 +1580,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 1c605356-35e3-4c92-89cc-661a8db95ff8
+                    request_id: 8ff82e10-70f6-42f5-ab05-8d8a67e28d20
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1594,7 +1594,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3777575c-4314-4dc7-a2d9-621ad3d40365
+                    request_id: 1d70ab10-a77e-43ea-86d9-36d08e3a5499
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1628,12 +1628,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0e2cba4d12057e509842
+                    id: 65e0bbbd6abd017f5e8b1c88
                     app_id: this_is_an_id123_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1709051436
-                    created_at: 1709051436
-                    updated_at: 1709051436
+                    remote_created_at: 1709226941
+                    created_at: 1709226941
+                    updated_at: 1709226941
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1655,7 +1655,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 5644f201-aadf-4681-9692-d3699854f3f7
+                    request_id: 4322e74e-b39d-4136-a97e-a29baf278888
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1669,7 +1669,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 29d30e0a-167f-4651-b9f4-e804175f90d5
+                    request_id: d442d667-428d-4330-af94-3b60e80f7795
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1701,7 +1701,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 65de0e2eba4d12057e50984c
+                    id: 65e0bbbf6abd017f5e8b1c92
                     object: company
                     deleted: true
               schema:
@@ -1714,7 +1714,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 495ead9e-90a0-4275-a00c-5323574c4d7d
+                    request_id: ffab64b6-a268-42ba-9586-ccc02439f998
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1728,7 +1728,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4daddbe5-8e44-4dc5-84b4-b99a14e2d4bd
+                    request_id: 12d7270f-48d1-4b2c-bcb5-bf7e84ab1e5d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1780,7 +1780,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 9ee6ff5c-0b5d-4bd3-a5bf-b761e9bb8472
+                    request_id: b2cc006b-fc83-4624-b81b-e0f3de684c79
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1794,7 +1794,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bcdccae6-02b1-41c8-bd0a-e05d4b6eb942
+                    request_id: 2c063246-317e-4ec2-9ddd-f505794f474b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1839,7 +1839,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 31b5eb62-6a4a-4455-a2f1-bdd6100d89c6
+                    request_id: dd8f67bd-afa4-4a36-b569-8e8d5eb882f2
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1853,7 +1853,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4c379293-11bc-424d-a35d-6a2575d98c05
+                    request_id: 231946f0-3a12-41b3-8c68-0ab620046309
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1910,12 +1910,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0e34ba4d12057e509868
+                      id: 65e0bbc56abd017f5e8b1cae
                       app_id: this_is_an_id147_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709051444
-                      created_at: 1709051444
-                      updated_at: 1709051444
+                      remote_created_at: 1709226949
+                      created_at: 1709226949
+                      updated_at: 1709226949
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -1944,7 +1944,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2c09dba6-24a3-47af-b6db-9ceff9b2d46c
+                    request_id: 18c2818c-a255-4c9c-aabd-8fd703dec8de
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1996,12 +1996,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0e35ba4d12057e50986e
+                      id: 65e0bbc76abd017f5e8b1cb4
                       app_id: this_is_an_id151_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709051445
-                      created_at: 1709051445
-                      updated_at: 1709051445
+                      remote_created_at: 1709226951
+                      created_at: 1709226951
+                      updated_at: 1709226951
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2015,7 +2015,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: 9b25b979-e67f-4a14-8bf7-c5f5e3a4742d
+                    scroll_param: c315e41c-bc6e-4ffa-a01d-fced6e340385
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2026,7 +2026,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 60883c7a-8b89-4d90-9808-622d4882fd4f
+                    request_id: dd4fc69c-cba9-4f74-87e9-daba9ee9d642
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2061,12 +2061,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0e37ba4d12057e509877
+                    id: 65e0bbc86abd017f5e8b1cbd
                     app_id: this_is_an_id155_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1709051447
-                    created_at: 1709051447
-                    updated_at: 1709051447
+                    remote_created_at: 1709226952
+                    created_at: 1709226952
+                    updated_at: 1709226952
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2088,7 +2088,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 6c405220-e71c-4ed8-acd1-d628b593af4f
+                    request_id: 42af9932-3ef1-4a2b-b32a-5ea4e386a11c
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2102,7 +2102,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: c57c8006-3ffd-4ef9-8ae5-89976f0d8313
+                    request_id: 426beab3-b15f-4f46-a2f0-7ccd0d999f74
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2116,7 +2116,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bffa69ee-69cf-4d9c-83f0-773206aed1f7
+                    request_id: b9eee486-7a21-4635-b647-fc9e3f24323e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2139,7 +2139,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 65de0e37ba4d12057e509877
+                  id: 65e0bbc86abd017f5e8b1cbd
               bad_request:
                 summary: Bad Request
                 value:
@@ -2178,13 +2178,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 65de0e3dba4d12057e509898
+                      id: 65e0bbce6abd017f5e8b1cde
                       app_id: this_is_an_id171_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1709051453
-                      created_at: 1709051453
-                      updated_at: 1709051453
-                      last_request_at: 1708878653
+                      remote_created_at: 1709226958
+                      created_at: 1709226958
+                      updated_at: 1709226958
+                      last_request_at: 1709054158
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2213,7 +2213,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 6f14dfab-a572-47c5-801d-637e7d3964ce
+                    request_id: 9ae854be-0777-44c7-96f1-72dcd804ff2b
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2227,7 +2227,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 19972570-b3a4-445b-8454-4300ea102512
+                    request_id: b16d43b7-09fc-4d24-bece-db20eb5b0bc6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2270,12 +2270,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0e3aba4d12057e509887
+                    id: 65e0bbcb6abd017f5e8b1ccd
                     app_id: this_is_an_id163_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1709051450
-                    created_at: 1709051450
-                    updated_at: 1709051450
+                    remote_created_at: 1709226955
+                    created_at: 1709226955
+                    updated_at: 1709226955
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2297,14 +2297,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 01fdf105-577f-4a12-9a7a-f0b5271d2b76
+                    request_id: 3c81fe2f-3879-419a-9e74-345cde47f285
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 736e8a3d-57d5-445b-9e94-5cb877db40c0
+                    request_id: 79d85fbb-2d0c-4f01-bad2-8b3ae5b1b9b1
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2318,7 +2318,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6347fa23-b188-43e5-b22b-97346fb3f7ce
+                    request_id: 36cc5ae9-85b4-4e07-b859-2ecbe43d7835
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2354,42 +2354,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '68'
-                      created_at: 1708446656
+                      id: '42'
+                      created_at: 1708622161
                       contact:
                         type: contact
-                        id: 65de0e40ba4d12057e5098a3
+                        id: 65e0bbd06abd017f5e8b1ce9
                       author:
                         type: admin
-                        id: '991268882'
+                        id: '991267846'
                         name: Ciaran101 Lee
                         email: admin101@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '67'
-                      created_at: 1708360256
+                      id: '41'
+                      created_at: 1708535761
                       contact:
                         type: contact
-                        id: 65de0e40ba4d12057e5098a3
+                        id: 65e0bbd06abd017f5e8b1ce9
                       author:
                         type: admin
-                        id: '991268882'
+                        id: '991267846'
                         name: Ciaran101 Lee
                         email: admin101@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '66'
-                      created_at: 1708360256
+                      id: '40'
+                      created_at: 1708535760
                       contact:
                         type: contact
-                        id: 65de0e40ba4d12057e5098a3
+                        id: 65e0bbd06abd017f5e8b1ce9
                       author:
                         type: admin
-                        id: '991268882'
+                        id: '991267846'
                         name: Ciaran101 Lee
                         email: admin101@email.com
                         away_mode_enabled: false
@@ -2412,7 +2412,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 3d0ab9e9-ca9e-438a-8262-0e4fdb5462e7
+                    request_id: 38077aed-62a1-4a60-96c0-eb578d148810
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2446,14 +2446,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '73'
-                    created_at: 1709051457
+                    id: '47'
+                    created_at: 1709226962
                     contact:
                       type: contact
-                      id: 65de0e41ba4d12057e5098a5
+                      id: 65e0bbd26abd017f5e8b1ceb
                     author:
                       type: admin
-                      id: '991268884'
+                      id: '991267848'
                       name: Ciaran103 Lee
                       email: admin103@email.com
                       away_mode_enabled: false
@@ -2469,14 +2469,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: ae951b4b-af3f-4d0b-ba2e-2c0c76024d49
+                    request_id: 5dbe456f-2486-45d2-96c7-e7d84dabe34b
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 41692576-0852-443d-bac0-39ee839e4f29
+                    request_id: 5c3ad6ff-06f7-400c-af20-a33f698092f5
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2506,20 +2506,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 65de0e41ba4d12057e5098a5
-                  admin_id: 991268884
+                  contact_id: 65e0bbd26abd017f5e8b1ceb
+                  admin_id: 991267848
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 65de0e41ba4d12057e5098a6
+                  contact_id: 65e0bbd26abd017f5e8b1cec
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991268886
+                  admin_id: 991267850
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -2552,10 +2552,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 65de0e43ba4d12057e5098a8
+                      id: 65e0bbd36abd017f5e8b1cee
                       name: segment
-                      created_at: 1709051459
-                      updated_at: 1709051459
+                      created_at: 1709226963
+                      updated_at: 1709226963
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -2567,7 +2567,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: fea6cc3d-9617-403f-b484-523e4fee2d56
+                    request_id: 70a7dbe4-1765-41c3-ba9e-2c2683e57491
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2581,7 +2581,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0c159a1f-49e3-42a6-9679-41f8a5123311
+                    request_id: 73f5de9f-7afa-465b-be6e-48d496783725
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2625,7 +2625,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '231'
+                      id: '139'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -2639,7 +2639,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '233'
+                      id: '141'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -2662,7 +2662,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 31ef9f29-0d8e-46fb-affd-7ddf641ad4b4
+                    request_id: '05336519-b173-426e-9149-b9c4ce393b93'
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2676,7 +2676,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4ddc6c62-633b-4bad-9031-83e3c80d3d0f
+                    request_id: 20be9888-0dd5-491c-80a1-d2954389b6b8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2717,7 +2717,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '246'
+                    id: '154'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -2740,14 +2740,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 57b79c76-0393-4f5e-b87d-f139b984e200
+                    request_id: 5bfae25f-6f16-4992-a3b4-38420d8e1788
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 2a81bc04-d42d-47bd-bd90-d8914304beb3
+                    request_id: 03e66990-170c-4c24-a102-e000c5ddbe57
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -2761,7 +2761,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bfbc5f0c-22b5-4717-9c16-741a6dae1243
+                    request_id: 85ffd93f-7faa-47ac-a54b-f28c26362434
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2789,12 +2789,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 246
+                  id: 154
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 250
+                  id: 158
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -2840,7 +2840,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '262'
+                    id: '170'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -2863,14 +2863,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: c0186af7-d285-4c70-8728-b84a705aa6ed
+                    request_id: 03c585cb-61d2-4931-8bd8-4f08000b2939
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: cc1938b7-39e8-4fa4-845a-148faa1abef1
+                    request_id: 81b8da87-2f98-4ebf-8380-4837044e05c1
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -2884,7 +2884,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c0503c37-6a87-4b20-a832-fcf3b3443019
+                    request_id: 52a2943b-90f2-44cc-98a9-72bc0fe407b6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2922,7 +2922,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '211'
+                      id: '124'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -2934,7 +2934,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: f236c8b0-bd11-454f-a34d-d71feb2492d1
+                    request_id: d041b380-4b49-48e4-a1f0-fdf743e0511f
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2948,7 +2948,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 66063f54-6fa0-423e-a729-801eb1bbac12
+                    request_id: 1a71f0e2-c633-4b0c-bd4e-bc88cbe820d7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2983,7 +2983,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '212'
+                    id: '125'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -2995,14 +2995,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: a7119b2a-7792-48ff-aab1-4f21dac776fb
+                    request_id: cb0a23cc-1443-4cea-9c0d-5eaf6a72f39b
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: e69b548e-9d54-4378-a2f3-062453d007e2
+                    request_id: 57525bdf-c16c-40ca-8e0c-68c65473c34d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3016,7 +3016,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 52305f25-8469-42db-bb93-cc5a0f0e5706
+                    request_id: 17afbc10-9009-4794-8a81-18a1490be630
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3039,11 +3039,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 212
+                  id: 125
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 213
+                  id: 126
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3085,7 +3085,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '215'
+                    id: '128'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3097,14 +3097,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 40156d71-ef4c-4128-877a-0e9251107736
+                    request_id: 74aa7a93-d182-4804-9c2e-476f2ecfbaf2
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 34ec0b45-fb41-4d14-ae98-3e2cbfb4870f
+                    request_id: d6be8014-e355-4d66-99c0-10a66389edf4
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3118,7 +3118,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5c70217b-7451-4730-8d4e-4d298ed324d0
+                    request_id: 4a7bd93e-0c34-413d-a8c3-8db6ce280ef2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3152,7 +3152,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0e51ba4d12057e5098bf
+                    id: 65e0bbe26abd017f5e8b1d05
                     workspace_id: this_is_an_id237_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3167,9 +3167,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709051473
-                    updated_at: 1709051473
-                    signed_up_at: 1709051473
+                    created_at: 1709226978
+                    updated_at: 1709226978
+                    signed_up_at: 1709226978
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3203,31 +3203,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0e51ba4d12057e5098bf/tags"
+                      url: "/contacts/65e0bbe26abd017f5e8b1d05/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0e51ba4d12057e5098bf/notes"
+                      url: "/contacts/65e0bbe26abd017f5e8b1d05/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0e51ba4d12057e5098bf/companies"
+                      url: "/contacts/65e0bbe26abd017f5e8b1d05/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0e51ba4d12057e5098bf/subscriptions"
+                      url: "/contacts/65e0bbe26abd017f5e8b1d05/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0e51ba4d12057e5098bf/subscriptions"
+                      url: "/contacts/65e0bbe26abd017f5e8b1d05/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3246,7 +3246,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 713980ba-3b95-4549-9a76-60a6e99c2638
+                    request_id: b6fb56ff-a28b-4595-a185-fb2444c254ad
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3291,7 +3291,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0e52ba4d12057e5098c0
+                    id: 65e0bbe36abd017f5e8b1d06
                     workspace_id: this_is_an_id241_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3306,9 +3306,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709051474
-                    updated_at: 1709051474
-                    signed_up_at: 1709051474
+                    created_at: 1709226979
+                    updated_at: 1709226979
+                    signed_up_at: 1709226979
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3342,31 +3342,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0e52ba4d12057e5098c0/tags"
+                      url: "/contacts/65e0bbe36abd017f5e8b1d06/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0e52ba4d12057e5098c0/notes"
+                      url: "/contacts/65e0bbe36abd017f5e8b1d06/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0e52ba4d12057e5098c0/companies"
+                      url: "/contacts/65e0bbe36abd017f5e8b1d06/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0e52ba4d12057e5098c0/subscriptions"
+                      url: "/contacts/65e0bbe36abd017f5e8b1d06/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0e52ba4d12057e5098c0/subscriptions"
+                      url: "/contacts/65e0bbe36abd017f5e8b1d06/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3385,7 +3385,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 104e9c37-2122-454f-b6b2-f4413ec55743
+                    request_id: 9108b733-05d3-45c9-9d60-451d0ee8450c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3416,7 +3416,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de0e54ba4d12057e5098c1
+                    id: 65e0bbe46abd017f5e8b1d07
                     external_id: '70'
                     type: contact
                     deleted: true
@@ -3430,7 +3430,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dedc36bc-c7c8-4e0b-96c3-63df06e168c3
+                    request_id: 39f90cee-d013-4270-bb7a-caa9197ff48c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3458,7 +3458,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0e55ba4d12057e5098c3
+                    id: 65e0bbe66abd017f5e8b1d09
                     workspace_id: this_is_an_id249_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3473,9 +3473,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709051477
-                    updated_at: 1709051477
-                    signed_up_at: 1709051477
+                    created_at: 1709226982
+                    updated_at: 1709226982
+                    signed_up_at: 1709226982
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3509,31 +3509,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0e55ba4d12057e5098c3/tags"
+                      url: "/contacts/65e0bbe66abd017f5e8b1d09/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0e55ba4d12057e5098c3/notes"
+                      url: "/contacts/65e0bbe66abd017f5e8b1d09/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0e55ba4d12057e5098c3/companies"
+                      url: "/contacts/65e0bbe66abd017f5e8b1d09/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0e55ba4d12057e5098c3/subscriptions"
+                      url: "/contacts/65e0bbe66abd017f5e8b1d09/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0e55ba4d12057e5098c3/subscriptions"
+                      url: "/contacts/65e0bbe66abd017f5e8b1d09/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3552,7 +3552,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 68e85a63-6413-4299-9aa2-725518763933
+                    request_id: 6e407882-9abb-4efc-b11c-46f87764c8f5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3567,8 +3567,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 65de0e55ba4d12057e5098c2
-                  into: 65de0e55ba4d12057e5098c3
+                  from: 65e0bbe66abd017f5e8b1d08
+                  into: 65e0bbe66abd017f5e8b1d09
   "/contacts/search":
     post:
       summary: Search contacts
@@ -3697,7 +3697,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 43830e89-3107-42be-a097-9bc8b9aeb25a
+                    request_id: eefa42a6-876c-43db-af23-6a2e0d4ecb09
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3717,15 +3717,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: 65de0e57ba4d12057e5098c6
+                      value: 65e0bbe86abd017f5e8b1d0c
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: 65de0e57ba4d12057e5098c6
+                        value: 65e0bbe86abd017f5e8b1d0c
                       - field: id
                         operator: "="
-                        value: 65de0e57ba4d12057e5098c6
+                        value: 65e0bbe86abd017f5e8b1d0c
   "/contacts":
     get:
       summary: List all contacts
@@ -3764,7 +3764,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dd5e4ad2-6ea2-49ff-8b83-00523e04d0e7
+                    request_id: bd034244-574e-4c7e-b6d8-3a1cc3b847c4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3790,7 +3790,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0e59ba4d12057e5098c8
+                    id: 65e0bbea6abd017f5e8b1d0e
                     workspace_id: this_is_an_id261_that_should_be_at_least_
                     external_id:
                     role: user
@@ -3805,8 +3805,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709051481
-                    updated_at: 1709051481
+                    created_at: 1709226986
+                    updated_at: 1709226986
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -3841,31 +3841,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0e59ba4d12057e5098c8/tags"
+                      url: "/contacts/65e0bbea6abd017f5e8b1d0e/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0e59ba4d12057e5098c8/notes"
+                      url: "/contacts/65e0bbea6abd017f5e8b1d0e/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0e59ba4d12057e5098c8/companies"
+                      url: "/contacts/65e0bbea6abd017f5e8b1d0e/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0e59ba4d12057e5098c8/subscriptions"
+                      url: "/contacts/65e0bbea6abd017f5e8b1d0e/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0e59ba4d12057e5098c8/subscriptions"
+                      url: "/contacts/65e0bbea6abd017f5e8b1d0e/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3884,7 +3884,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1b0f2f85-85ad-4edf-9b03-ac68f59667af
+                    request_id: 0b03115d-61f7-4bab-89e6-214baf716a01
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3928,7 +3928,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de0e5aba4d12057e5098c9
+                    id: 65e0bbeb6abd017f5e8b1d0f
                     external_id: '70'
                     type: contact
                     archived: true
@@ -3961,7 +3961,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de0e5bba4d12057e5098ca
+                    id: 65e0bbec6abd017f5e8b1d10
                     external_id: '70'
                     type: contact
                     archived: false
@@ -3997,7 +3997,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '217'
+                    id: '130'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4009,7 +4009,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: bba70d0b-09f5-4928-b8ff-57c2c263e8ed
+                    request_id: 440b75c4-b905-47f6-99ad-a79ff5e70524
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4023,7 +4023,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 40ae2971-0f86-4214-b600-34fb9bf13a09
+                    request_id: 9c73204a-1999-4d33-8d59-846a9c407324
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4052,13 +4052,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 217
-                  admin_id: 991268917
+                  id: 130
+                  admin_id: 991267881
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 218
-                  admin_id: 991268919
+                  id: 131
+                  admin_id: 991267883
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4096,7 +4096,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '220'
+                    id: '133'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4108,14 +4108,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: c2845e5d-c801-467f-b75f-046969e0b1d5
+                    request_id: d85c0a71-73bb-4644-ace6-36a48e99adf7
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 7512ad23-122c-4535-8997-725879ea283b
+                    request_id: 4a614343-ddd8-4ed7-96fe-01221306b6d7
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4129,7 +4129,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e7cf6df4-af0c-4ce9-a89b-111804df0ead
+                    request_id: 9a8e7f98-8071-4cf9-978d-18fc7de8c072
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4152,15 +4152,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991268921
+                  admin_id: 991267885
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991268923
+                  admin_id: 991267887
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991268924
+                  admin_id: 991267888
   "/conversations":
     get:
       summary: List all conversations
@@ -4207,20 +4207,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '712'
-                      created_at: 1709051491
-                      updated_at: 1709051491
+                      id: '423'
+                      created_at: 1709226995
+                      updated_at: 1709226995
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918477'
+                        id: '403918309'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991268927'
+                          id: '991267891'
                           name: Ciaran143 Lee
                           email: admin143@email.com
                         attachments: []
@@ -4230,7 +4230,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de0e63ba4d12057e5098ce
+                          id: 65e0bbf36abd017f5e8b1d14
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -4265,7 +4265,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f28ec206-0cd6-43ac-897e-38db5cf9d280
+                    request_id: fb96da81-a7dc-4311-b093-ae21599c775e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4279,7 +4279,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 9990cd6f-258f-4634-bf21-04952d2a799b
+                    request_id: b163b990-8d50-410b-813a-86773cb6683a
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4295,13 +4295,17 @@ paths:
       tags:
       - Conversations
       operationId: createConversation
-      description: "You can create a conversation that has been initiated by a contact
-        (ie. user or lead).\nThe conversation can be an in-app message only.\n\n>
-        \U0001F4D8 Sending for visitors\n>\n> You can also send a message from a visitor
-        by specifying their `user_id` or `id` value in the `from` field, along with
-        a `type` field value of `contact`.\n> This visitor will be automatically converted
-        to a contact with a lead role once the conversation is created.\n\nThis will
-        return the Message model that has been created.\n\n"
+      description: |+
+        You can create a conversation that has been initiated by a contact (ie. user or lead).
+        The conversation can be an in-app message only.
+
+        {% admonition type="info" name="Sending for visitors" %}
+        You can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.
+        This visitor will be automatically converted to a contact with a lead role once the conversation is created.
+        {% /admonition %}
+
+        This will return the Message model that has been created.
+
       responses:
         '200':
           description: conversation created
@@ -4311,11 +4315,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918487'
-                    created_at: 1709051515
+                    id: '403918319'
+                    created_at: 1709227017
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '737'
+                    conversation_id: '448'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -4326,7 +4330,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: ef51c0bf-05e3-4c51-bc2f-b53281229fe6
+                    request_id: dce90210-d88f-4c08-bb5d-647fc1406740
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -4340,7 +4344,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 16282e28-76ab-4803-a8ea-68d59a9dc195
+                    request_id: 7134971d-e494-48a6-a4b5-a10117d6abe4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4354,7 +4358,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 3eaa1c56-73f7-4ae4-a7ec-cbf1da53dd27
+                    request_id: 984d350a-ddb3-469c-8e67-b70a571551be
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4371,7 +4375,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65de0e7aba4d12057e5098e3
+                    id: 65e0bc086abd017f5e8b1d29
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -4405,15 +4409,21 @@ paths:
       tags:
       - Conversations
       operationId: retrieveConversation
-      description: "\nYou can fetch the details of a single conversation.\n\nThis
-        will return a single Conversation model with all its conversation parts.\n\n>
-        \U0001F6A7 Hard limit of 500 parts\n>\n> The maximum number of conversation
-        parts that can be returned via the API is 500. If you have more than that
-        we will return the 500 most recent conversation parts.\n\n> \U0001F4D8 Bot
-        name in conversation parts\n>\n> For conversation parts generated by a bot,
-        bot name will depend on the following:\n- Customers that never turned on AI
-        answers will have `operator` as the bot name\n- Customers that have turned
-        on AI answers at some point will have `fin` as the bot name\n"
+      description: |2
+
+        You can fetch the details of a single conversation.
+
+        This will return a single Conversation model with all its conversation parts.
+
+        {% admonition type="warning" name="Hard limit of 500 parts" %}
+        The maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.
+        {% /admonition %}
+
+        ### Bot Name in Conversation Parts
+
+        For conversation parts generated by a bot, bot name will depend on the following:
+        - Customers that never turned on AI answers will have `operator` as the bot name
+        - Customers that have turned on AI answers at some point will have `fin` as the bot name
       responses:
         '200':
           description: conversation found
@@ -4423,20 +4433,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '741'
-                    created_at: 1709051521
-                    updated_at: 1709051521
+                    id: '452'
+                    created_at: 1709227022
+                    updated_at: 1709227022
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918491'
+                      id: '403918323'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268941'
+                        id: '991267905'
                         name: Ciaran150 Lee
                         email: admin150@email.com
                       attachments: []
@@ -4446,7 +4456,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0e80ba4d12057e5098e7
+                        id: 65e0bc0d6abd017f5e8b1d2d
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -4485,7 +4495,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: c0001121-eebc-4c2a-a0ce-c8b0c0d4a1c4
+                    request_id: ff72c245-8adc-453b-a154-96cd4e6af4e6
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4499,7 +4509,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c1b4fc39-6e24-4ba1-92e4-5ea915c50517
+                    request_id: 64544f40-1641-45b2-945e-12f554d7060a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4513,7 +4523,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 31ba6fb3-4e47-4f79-bd09-c8278f12661e
+                    request_id: d0bf4d14-a8cc-435d-b9b6-7ea82fe39cd9
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4543,10 +4553,14 @@ paths:
       tags:
       - Conversations
       operationId: updateConversation
-      description: "\nYou can update an existing conversation.\n\n> \U0001F4D8\n>\n>
-        If you want to update a conversation with either a reply (or actions such
-        as assign, unassign, open, close or snooze) then take a look at their own
-        sections respectively as they currently require different endpoints and parameters.\n\n"
+      description: |2+
+
+        You can update an existing conversation.
+
+        {% admonition type="info" name="Replying and other actions" %}
+        If you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.
+        {% /admonition %}
+
       responses:
         '200':
           description: conversation found
@@ -4556,20 +4570,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '745'
-                    created_at: 1709051527
-                    updated_at: 1709051529
+                    id: '456'
+                    created_at: 1709227028
+                    updated_at: 1709227029
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918495'
+                      id: '403918327'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268949'
+                        id: '991267913'
                         name: Ciaran154 Lee
                         email: admin154@email.com
                       attachments: []
@@ -4579,7 +4593,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0e87ba4d12057e5098eb
+                        id: 65e0bc146abd017f5e8b1d31
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -4610,15 +4624,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '164'
+                        id: '93'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709051529
-                        updated_at: 1709051529
-                        notified_at: 1709051529
+                        created_at: 1709227029
+                        updated_at: 1709227029
+                        notified_at: 1709227029
                         assigned_to:
                         author:
-                          id: '991268950'
+                          id: '991267914'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id305_that_should_be_at_least_@intercom.io
@@ -4626,15 +4640,15 @@ paths:
                         external_id:
                         redacted: false
                       - type: conversation_part
-                        id: '165'
+                        id: '94'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709051529
-                        updated_at: 1709051529
-                        notified_at: 1709051529
+                        created_at: 1709227029
+                        updated_at: 1709227029
+                        notified_at: 1709227029
                         assigned_to:
                         author:
-                          id: '991268950'
+                          id: '991267914'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id305_that_should_be_at_least_@intercom.io
@@ -4652,7 +4666,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 10fec065-5a4d-4ad1-ae86-ff019640ba0e
+                    request_id: 573eca45-e843-4b15-9f8b-2c32d116dca1
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4666,7 +4680,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4c8b9305-2698-46e1-8d3a-46a7dc7561ce
+                    request_id: 234cb124-841c-47a3-a6d3-379edf330b19
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4680,7 +4694,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 11e348f2-0139-47b9-972c-8879e66d4c00
+                    request_id: 5b528481-8996-4dd1-9f0c-a4844ad20fb5
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4820,20 +4834,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '752'
-                      created_at: 1709051539
-                      updated_at: 1709051539
+                      id: '463'
+                      created_at: 1709227039
+                      updated_at: 1709227039
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918502'
+                        id: '403918334'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991268979'
+                          id: '991267943'
                           name: Ciaran177 Lee
                           email: admin177@email.com
                         attachments: []
@@ -4843,7 +4857,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de0e93ba4d12057e5098f2
+                          id: 65e0bc1f6abd017f5e8b1d38
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -4884,15 +4898,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '752'
+                      value: '463'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '752'
+                        value: '463'
                       - field: id
                         operator: "="
-                        value: '752'
+                        value: '463'
   "/conversations/{id}/reply":
     post:
       summary: Reply to a conversation
@@ -4904,19 +4918,11 @@ paths:
       - name: id
         in: path
         required: true
+        description: The Intercom provisioned identifier for the conversation or the
+          string "last" to reply to the last part of the conversation
+        example: 123 or "last"
         schema:
-          oneOf:
-          - title: Conversation ID
-            type: string
-            description: The id of the conversation to target.
-            example: '123'
-          - title: The most recent conversation
-            type: string
-            enum:
-            - last
-            description: You can also reply to the most recent conversation on a workspace
-              by specifying `last` as the string.
-            example: last
+          type: string
       tags:
       - Conversations
       operationId: replyConversation
@@ -4931,20 +4937,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '760'
-                    created_at: 1709051548
-                    updated_at: 1709051548
-                    waiting_since: 1709051548
+                    id: '471'
+                    created_at: 1709227047
+                    updated_at: 1709227048
+                    waiting_since: 1709227048
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918505'
+                      id: '403918337'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268981'
+                        id: '991267945'
                         name: Ciaran178 Lee
                         email: admin178@email.com
                       attachments: []
@@ -4954,10 +4960,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0e9bba4d12057e5098f9
+                        id: 65e0bc276abd017f5e8b1d3f
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709051548
+                      created_at: 1709227048
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -4986,15 +4992,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '167'
+                        id: '96'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709051548
-                        updated_at: 1709051548
-                        notified_at: 1709051548
+                        created_at: 1709227048
+                        updated_at: 1709227048
+                        notified_at: 1709227048
                         assigned_to:
                         author:
-                          id: 65de0e9bba4d12057e5098f9
+                          id: 65e0bc276abd017f5e8b1d3f
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5005,20 +5011,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '761'
-                    created_at: 1709051550
-                    updated_at: 1709051550
+                    id: '472'
+                    created_at: 1709227049
+                    updated_at: 1709227050
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918506'
+                      id: '403918338'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268983'
+                        id: '991267947'
                         name: Ciaran179 Lee
                         email: admin179@email.com
                       attachments: []
@@ -5028,7 +5034,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0e9dba4d12057e5098fa
+                        id: 65e0bc296abd017f5e8b1d40
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5057,7 +5063,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '168'
+                        id: '97'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5072,12 +5078,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1709051550
-                        updated_at: 1709051550
-                        notified_at: 1709051550
+                        created_at: 1709227050
+                        updated_at: 1709227050
+                        notified_at: 1709227050
                         assigned_to:
                         author:
-                          id: '991268983'
+                          id: '991267947'
                           type: admin
                           name: Ciaran179 Lee
                           email: admin179@email.com
@@ -5088,20 +5094,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '763'
-                    created_at: 1709051553
-                    updated_at: 1709051554
-                    waiting_since: 1709051554
+                    id: '474'
+                    created_at: 1709227052
+                    updated_at: 1709227053
+                    waiting_since: 1709227053
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918508'
+                      id: '403918340'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268987'
+                        id: '991267951'
                         name: Ciaran181 Lee
                         email: admin181@email.com
                       attachments: []
@@ -5111,10 +5117,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0ea1ba4d12057e5098fc
+                        id: 65e0bc2c6abd017f5e8b1d42
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709051554
+                      created_at: 1709227053
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5143,15 +5149,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '169'
+                        id: '98'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709051554
-                        updated_at: 1709051554
-                        notified_at: 1709051554
+                        created_at: 1709227053
+                        updated_at: 1709227053
+                        notified_at: 1709227053
                         assigned_to:
                         author:
-                          id: 65de0ea1ba4d12057e5098fc
+                          id: 65e0bc2c6abd017f5e8b1d42
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5169,7 +5175,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: eda59249-76d1-4cb2-b1f9-e395a44ecbcf
+                    request_id: 9cd975bc-d2fd-4c81-873f-6903a1c29eb1
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5183,7 +5189,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f58d539f-1113-483b-95ba-cec583c78bdc
+                    request_id: b4336a2f-a35a-4075-94b8-f129b1a39a06
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5197,7 +5203,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 667b152e-8b07-4934-85d8-41a5930b8a58
+                    request_id: a4c20f07-a9c8-471b-8c30-eadd0db3e380
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5214,14 +5220,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0e9bba4d12057e5098f9
+                  intercom_user_id: 65e0bc276abd017f5e8b1d3f
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991268983
+                  admin_id: 991267947
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -5231,14 +5237,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0ea1ba4d12057e5098fc
+                  intercom_user_id: 65e0bc2c6abd017f5e8b1d42
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0ea3ba4d12057e5098fd
+                  intercom_user_id: 65e0bc2e6abd017f5e8b1d43
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -5259,10 +5265,11 @@ paths:
       - Conversations
       operationId: manageConversation
       description: |
-        You can close a conversation.
-        You can snooze a conversation to reopen on a future date.
-        You can open a conversation which is `snoozed` or `closed`.
-        You can assign a conversation to an admin and/or team.
+        For managing conversations you can:
+        - Close a conversation
+        - Snooze a conversation to reopen on a future date
+        - Open a conversation which is `snoozed` or `closed`
+        - Assign a conversation to an admin and/or team.
       responses:
         '200':
           description: Assign a conversation
@@ -5272,20 +5279,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '767'
-                    created_at: 1709051559
-                    updated_at: 1709051560
+                    id: '478'
+                    created_at: 1709227058
+                    updated_at: 1709227059
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918512'
+                      id: '403918344'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268995'
+                        id: '991267959'
                         name: Ciaran185 Lee
                         email: admin185@email.com
                       attachments: []
@@ -5295,7 +5302,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0ea7ba4d12057e509900
+                        id: 65e0bc326abd017f5e8b1d46
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5324,15 +5331,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '170'
+                        id: '99'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1709051560
-                        updated_at: 1709051560
-                        notified_at: 1709051560
+                        created_at: 1709227059
+                        updated_at: 1709227059
+                        notified_at: 1709227059
                         assigned_to:
                         author:
-                          id: '991268995'
+                          id: '991267959'
                           type: admin
                           name: Ciaran185 Lee
                           email: admin185@email.com
@@ -5343,20 +5350,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '768'
-                    created_at: 1709051561
-                    updated_at: 1709051562
+                    id: '479'
+                    created_at: 1709227060
+                    updated_at: 1709227061
                     waiting_since:
-                    snoozed_until: 1709055162
+                    snoozed_until: 1709230661
                     source:
                       type: conversation
-                      id: '403918513'
+                      id: '403918345'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268997'
+                        id: '991267961'
                         name: Ciaran186 Lee
                         email: admin186@email.com
                       attachments: []
@@ -5366,7 +5373,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0ea9ba4d12057e509901
+                        id: 65e0bc346abd017f5e8b1d47
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5395,15 +5402,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '171'
+                        id: '100'
                         part_type: snoozed
                         body:
-                        created_at: 1709051562
-                        updated_at: 1709051562
-                        notified_at: 1709051562
+                        created_at: 1709227061
+                        updated_at: 1709227061
+                        notified_at: 1709227061
                         assigned_to:
                         author:
-                          id: '991268997'
+                          id: '991267961'
                           type: admin
                           name: Ciaran186 Lee
                           email: admin186@email.com
@@ -5414,20 +5421,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '773'
-                    created_at: 1709051561
-                    updated_at: 1709051570
+                    id: '484'
+                    created_at: 1709227060
+                    updated_at: 1709227068
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918514'
+                      id: '403918346'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268999'
+                        id: '991267963'
                         name: Ciaran187 Lee
                         email: admin187@email.com
                       attachments: []
@@ -5437,7 +5444,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0eaeba4d12057e509906
+                        id: 65e0bc386abd017f5e8b1d4c
                         external_id: '74'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5466,15 +5473,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '173'
+                        id: '102'
                         part_type: open
                         body:
-                        created_at: 1709051570
-                        updated_at: 1709051570
-                        notified_at: 1709051570
+                        created_at: 1709227068
+                        updated_at: 1709227068
+                        notified_at: 1709227068
                         assigned_to:
                         author:
-                          id: '991268999'
+                          id: '991267963'
                           type: admin
                           name: Ciaran187 Lee
                           email: admin187@email.com
@@ -5485,20 +5492,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '777'
-                    created_at: 1709051571
-                    updated_at: 1709051572
+                    id: '488'
+                    created_at: 1709227069
+                    updated_at: 1709227070
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918517'
+                      id: '403918349'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269001'
+                        id: '991267965'
                         name: Ciaran188 Lee
                         email: admin188@email.com
                       attachments: []
@@ -5508,10 +5515,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0eb3ba4d12057e509909
+                        id: 65e0bc3d6abd017f5e8b1d4f
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991269001
+                    admin_assignee_id: 991267965
                     team_assignee_id:
                     open: true
                     state: open
@@ -5537,17 +5544,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '174'
+                        id: '103'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1709051572
-                        updated_at: 1709051572
-                        notified_at: 1709051572
+                        created_at: 1709227070
+                        updated_at: 1709227070
+                        notified_at: 1709227070
                         assigned_to:
                           type: admin
-                          id: '991269001'
+                          id: '991267965'
                         author:
-                          id: '991269001'
+                          id: '991267965'
                           type: admin
                           name: Ciaran188 Lee
                           email: admin188@email.com
@@ -5565,7 +5572,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 124206fd-5050-424a-bf3a-84eea3653e84
+                    request_id: 1be29ddf-4e60-40dc-99d2-4f2333958a12
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5579,7 +5586,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5f563355-0dc0-444f-975b-c32581a2072a
+                    request_id: 33622903-93e1-476a-b011-81c72c9287e5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5593,7 +5600,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 90e8aefd-4947-49c4-b8aa-354032ee94fd
+                    request_id: 6a09f49a-d0ff-4c19-959d-098000a49cb5
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5614,32 +5621,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991268995
+                  admin_id: 991267959
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991268997
-                  snoozed_until: 1709055162
+                  admin_id: 991267961
+                  snoozed_until: 1709230661
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991268999
+                  admin_id: 991267963
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991269001
-                  assignee_id: 991269001
+                  admin_id: 991267965
+                  assignee_id: 991267965
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991269003
+                  admin_id: 991267967
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -5670,20 +5677,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '781'
-                    created_at: 1709051578
-                    updated_at: 1709051579
+                    id: '492'
+                    created_at: 1709227075
+                    updated_at: 1709227076
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918521'
+                      id: '403918353'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269009'
+                        id: '991267973'
                         name: Ciaran192 Lee
                         email: admin192@email.com
                       attachments: []
@@ -5693,7 +5700,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0ebaba4d12057e50990d
+                        id: 65e0bc436abd017f5e8b1d53
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5722,17 +5729,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '175'
+                        id: '104'
                         part_type: default_assignment
                         body:
-                        created_at: 1709051579
-                        updated_at: 1709051579
-                        notified_at: 1709051579
+                        created_at: 1709227076
+                        updated_at: 1709227076
+                        notified_at: 1709227076
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991269010'
+                          id: '991267974'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id346_that_should_be_at_least_@intercom.io
@@ -5750,7 +5757,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 055ed0e2-2729-48b2-a80a-9c5f552c9ee8
+                    request_id: 5c62b90a-e006-4e71-85d3-c26ec1b50e21
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5764,7 +5771,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 30e4493d-b3ec-4826-9a47-ce2c0bbb99cf
+                    request_id: d97926b1-cc73-40fa-9da4-f1bb96ac37f0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5778,7 +5785,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 94a87e52-f9a2-4a61-bb37-71a130a524b7
+                    request_id: c2b87f95-f601-4c36-8d6e-7c539dbcd29f
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5802,11 +5809,13 @@ paths:
       tags:
       - Conversations
       operationId: attachContactToConversation
-      description: "You can add participants who are contacts to a conversation, on
-        behalf of either another contact or an admin.\n\n> \U0001F6A7 Note about contacts
-        without an email\n>\n> If you add a contact via the email parameter and there
-        is no user/lead found on that workspace with he given email, then we will
-        create a new contact with `role` set to `lead`.\n\n"
+      description: |+
+        You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.
+
+        {% admonition type="attention" name="Contacts without an email" %}
+        If you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.
+        {% /admonition %}
+
       responses:
         '200':
           description: Attach a contact to a conversation
@@ -5817,7 +5826,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65de0ec0ba4d12057e509911
+                      id: 65e0bc496abd017f5e8b1d57
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -5828,7 +5837,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 509abe6a-05aa-4670-9b22-4e611a27e52d
+                    request_id: e6439b35-3b38-4798-bad3-7ac2c6818691
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5842,7 +5851,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 58117822-c765-454d-aaec-88631372c2cc
+                    request_id: 9acda9ff-5595-43f8-9152-661596b42580
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5856,7 +5865,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 36e5f4ca-640c-46a9-be58-2b7c0309f4fa
+                    request_id: baf954ef-4887-48b3-a293-e651902a31ab
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5871,15 +5880,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991269017
+                  admin_id: 991267981
                   customer:
-                    intercom_user_id: 65de0ec0ba4d12057e509911
+                    intercom_user_id: 65e0bc496abd017f5e8b1d57
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991269019
+                  admin_id: 991267983
                   customer:
-                    intercom_user_id: 65de0ec2ba4d12057e509912
+                    intercom_user_id: 65e0bc4a6abd017f5e8b1d58
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -5905,11 +5914,13 @@ paths:
       tags:
       - Conversations
       operationId: detachContactFromConversation
-      description: "You can add participants who are contacts to a conversation, on
-        behalf of either another contact or an admin.\n\n> \U0001F6A7 Note about contacts
-        without an email\n>\n> If you add a contact via the email parameter and there
-        is no user/lead found on that workspace with he given email, then we will
-        create a new contact with `role` set to `lead`.\n\n"
+      description: |+
+        You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.
+
+        {% admonition type="attention" name="Contacts without an email" %}
+        If you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.
+        {% /admonition %}
+
       responses:
         '200':
           description: Detach a contact from a group conversation
@@ -5920,7 +5931,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65de0eccba4d12057e50991c
+                      id: 65e0bc556abd017f5e8b1d62
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -5931,14 +5942,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 547001f3-1933-4ef1-9ee1-c62ed978704d
+                    request_id: d32e0065-d12a-4dc6-9800-771ad2ae4a76
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 5c7ef76a-ba36-4ecd-af43-ddcf88712187
+                    request_id: 49d34e88-6ed8-4fe3-8031-ea0d64af717e
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -5952,7 +5963,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: 2ce0e42e-96a0-4dde-85d3-bd823af95199
+                    request_id: cecd600e-6372-4669-b40b-38380c9640de
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -5966,7 +5977,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c7185fbf-0699-4a9d-8936-aa0b18d90329
+                    request_id: fcc64c1f-e463-4e1f-84ec-40cf102717df
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5980,7 +5991,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 5b72b4ce-fc8d-49fa-82af-66d9aa83fe81
+                    request_id: c5e91558-d6c5-439d-92d5-7c6e4483f046
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5995,27 +6006,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991269025
+                  admin_id: 991267989
                   customer:
-                    intercom_user_id: 65de0ec6ba4d12057e509915
+                    intercom_user_id: 65e0bc4e6abd017f5e8b1d5b
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991269027
+                  admin_id: 991267991
                   customer:
-                    intercom_user_id: 65de0ecdba4d12057e50991d
+                    intercom_user_id: 65e0bc566abd017f5e8b1d63
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991269029
+                  admin_id: 991267993
                   customer:
-                    intercom_user_id: 65de0ed5ba4d12057e509924
+                    intercom_user_id: 65e0bc5d6abd017f5e8b1d6a
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991269031
+                  admin_id: 991267995
                   customer:
-                    intercom_user_id: 65de0edcba4d12057e50992b
+                    intercom_user_id: 65e0bc646abd017f5e8b1d71
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6027,12 +6038,13 @@ paths:
       tags:
       - Conversations
       operationId: redactConversation
-      description: "You can redact a conversation part or the source message of a
-        conversation (as seen in the source object).\n\n> \U0001F4D8 Which parts and
-        source messages can I redact?\n>\n> If you are redacting a conversation part,
-        it must have a `body`.\n> If you are redacting a source message, it must have
-        been created by a contact.\n> We will return a `conversation_part_not_redactable`
-        error if these criteria are not met.\n\n"
+      description: |+
+        You can redact a conversation part or the source message of a conversation (as seen in the source object).
+
+        {% admonition type="info" name="Redacting parts and messages" %}
+        If you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.
+        {% /admonition %}
+
       responses:
         '200':
           description: Redact a conversation part
@@ -6042,20 +6054,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '837'
-                    created_at: 1709051634
-                    updated_at: 1709051636
-                    waiting_since: 1709051635
+                    id: '548'
+                    created_at: 1709227130
+                    updated_at: 1709227132
+                    waiting_since: 1709227131
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918547'
+                      id: '403918379'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269037'
+                        id: '991268001'
                         name: Ciaran206 Lee
                         email: admin206@email.com
                       attachments: []
@@ -6065,10 +6077,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0ef2ba4d12057e509940
+                        id: 65e0bc7a6abd017f5e8b1d86
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709051635
+                      created_at: 1709227131
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6097,15 +6109,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '183'
+                        id: '112'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1709051635
-                        updated_at: 1709051636
-                        notified_at: 1709051635
+                        created_at: 1709227131
+                        updated_at: 1709227132
+                        notified_at: 1709227131
                         assigned_to:
                         author:
-                          id: 65de0ef2ba4d12057e509940
+                          id: 65e0bc7a6abd017f5e8b1d86
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6123,7 +6135,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: b637dcf9-081c-499a-a27f-875783e3fff0
+                    request_id: a766bcf8-478e-4c5f-81cc-a8d194376ce5
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -6137,7 +6149,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c371c1a4-4c33-4d63-b8ab-389d3479a5b4
+                    request_id: 6304270a-1297-400b-9df6-2d8dbb9e8b9a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6153,8 +6165,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 837
-                  conversation_part_id: 183
+                  conversation_id: 548
+                  conversation_part_id: 112
               not_found:
                 summary: Not found
                 value:
@@ -6189,20 +6201,20 @@ paths:
                 successful:
                   value:
                     type: ticket
-                    id: '840'
-                    ticket_id: '24'
+                    id: '551'
+                    ticket_id: '7'
                     ticket_attributes: {}
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '130'
+                      id: '72'
                       name: my-ticket-type-1
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id380_that_should_be_at_least_
                       archived: false
-                      created_at: 1709051643
-                      updated_at: 1709051643
+                      created_at: 1709227139
+                      updated_at: 1709227139
                       is_internal: false
                       ticket_type_attributes:
                         type: list
@@ -6212,37 +6224,37 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0ef8ba4d12057e509943
+                        id: 65e0bc806abd017f5e8b1d89
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709051640
-                    updated_at: 1709051643
+                    created_at: 1709227136
+                    updated_at: 1709227139
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '185'
+                        id: '114'
                         part_type: comment
                         body: "<p>Comment for message</p>"
-                        created_at: 1709051640
-                        updated_at: 1709051640
+                        created_at: 1709227136
+                        updated_at: 1709227136
                         author:
-                          id: 65de0ef8ba4d12057e509943
+                          id: 65e0bc806abd017f5e8b1d89
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '186'
+                        id: '115'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709051643
-                        updated_at: 1709051643
+                        created_at: 1709227139
+                        updated_at: 1709227139
                         author:
-                          id: '991269047'
+                          id: '991268011'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id380_that_should_be_at_least_@intercom.io
@@ -6267,7 +6279,7 @@ paths:
                 Bad request:
                   value:
                     type: error.list
-                    request_id: 620d4680-d0c1-4090-8f28-c12be5bf128b
+                    request_id: 49df80b5-797f-44aa-8758-fb3ab5565f88
                     errors:
                     - code: parameter_invalid
                       message: Ticket type is not a customer ticket type
@@ -6282,11 +6294,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  ticket_type_id: '130'
+                  ticket_type_id: '72'
               bad_request:
                 summary: Bad request
                 value:
-                  ticket_type_id: '131'
+                  ticket_type_id: '73'
   "/data_attributes":
     get:
       summary: List all data attributes
@@ -6467,7 +6479,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 82
+                    - id: 50
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -6480,9 +6492,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991269064'
-                      created_at: 1709051650
-                      updated_at: 1709051650
+                      admin_id: '991268028'
+                      created_at: 1709227146
+                      updated_at: 1709227146
                       model: company
                     - type: data_attribute
                       name: id
@@ -6554,7 +6566,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 148163dd-60b1-45f8-b7af-1e1ac0aeb443
+                    request_id: 1858f7bc-9b35-4569-bdd0-57c4c190be3e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6579,7 +6591,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 85
+                    id: 53
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -6590,9 +6602,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991269066'
-                    created_at: 1709051651
-                    updated_at: 1709051651
+                    admin_id: '991268030'
+                    created_at: 1709227147
+                    updated_at: 1709227147
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6604,7 +6616,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: 4343d6ea-02fb-4a16-a961-85a034879b1b
+                    request_id: b4191980-4b01-4088-837c-b3c0461e843d
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6612,7 +6624,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: 9543d712-c92b-4b4d-bb6c-5cff14322db3
+                    request_id: 76de463d-66be-429b-982f-95be4d2998bd
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -6620,7 +6632,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: 6e0f55b8-ab83-4aa5-92f4-88cfeb3ec902
+                    request_id: 733a9ffa-251a-4d0c-b883-a5f455c273d1
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6628,14 +6640,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: b3399d83-61e0-44fa-aa13-503f5ebd0659
+                    request_id: 3d91b7ea-98b1-4216-a06e-341fe23a80e5
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: 6fe05854-7b2a-4433-97ae-9f6adf1314f8
+                    request_id: 2c4a99d4-9755-4946-ac67-51da9e7471ac
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -6650,7 +6662,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 07666c02-9f10-4b9f-a73f-d1ee380a0152
+                    request_id: 91f3a31a-d634-46f5-b3bd-bd325bdf00d9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6729,7 +6741,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 92
+                    id: 60
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -6744,9 +6756,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991269073'
-                    created_at: 1709051655
-                    updated_at: 1709051655
+                    admin_id: '991268037'
+                    created_at: 1709227150
+                    updated_at: 1709227150
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6758,7 +6770,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: d97987bd-2a33-425d-bd93-ac145992ad72
+                    request_id: 4c7a16ae-05a4-47c1-a836-e0b15b412586
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -6772,7 +6784,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: 44561b1a-d849-4e62-988b-f66a8bf1ca14
+                    request_id: b0c9b7cf-3528-49c4-bb0e-758f9a6b6438
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -6786,7 +6798,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: d8d0906d-cc54-40c3-b983-8d7a9e71537f
+                    request_id: e10959e3-fa38-44fc-9e1a-1ec0b4fd0faa
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -6801,7 +6813,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 19ec7624-a242-40d6-9294-f5f7ae8a0179
+                    request_id: 6b1d6846-f634-4c9a-a657-12ef3030ee26
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6906,7 +6918,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b11631b8-f370-4245-b210-e3872000a120
+                    request_id: 4943fdff-2a08-434f-9bc3-a3d621379eef
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6993,7 +7005,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 65de0f0bba4d12057e509949
+                    intercom_user_id: 65e0bc936abd017f5e8b1d8f
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -7005,7 +7017,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bcbfed5d-c767-4c6a-8ece-caab40ebb307
+                    request_id: ef0e8bfc-9a47-4866-8653-111224e8d603
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7036,7 +7048,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ea523f3e-43bb-42dd-af65-0ccaea0c9fdf
+                    request_id: b1c0cdd0-615d-441b-bf73-1767517ef966
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7080,7 +7092,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: 7g1ihtpi4m913ve8
+                    job_identifier: esyqm003bj18c28i
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7095,8 +7107,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1709033662
-                  created_at_before: 1709051662
+                  created_at_after: 1709209157
+                  created_at_before: 1709227157
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -7130,7 +7142,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: 95vpch6jdle2wn8u
+                    job_identifier: 5vqtmyiobty6dfyy
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7162,7 +7174,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: w2pgxogsnfg7pdr7
+                    job_identifier: 91qnzmx1wib1t5q3
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -7223,30 +7235,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918552'
-                    created_at: 1709051664
+                    id: '403918384'
+                    created_at: 1709227160
                     body: heyy
                     message_type: inapp
-                    conversation_id: '842'
+                    conversation_id: '553'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918553'
-                    created_at: 1709051666
+                    id: '403918385'
+                    created_at: 1709227161
                     body: heyy
                     message_type: inapp
-                    conversation_id: '843'
+                    conversation_id: '554'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '30'
-                    created_at: 1709051667
+                    id: '20'
+                    created_at: 1709227162
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991269096'
+                      id: '991268060'
                       name: Ciaran258 Lee
                       email: admin258@email.com
                       away_mode_enabled: false
@@ -7261,14 +7273,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: 6948770c-bfc3-4238-b2a9-425cc5013606
+                    request_id: e652929a-0604-43d6-90b0-155c335a0c69
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: df47522a-e9f9-4ac0-b9a4-4b8bc4aaecbc
+                    request_id: 3cd97535-5ebe-4002-97f1-529df56a55ba
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -7282,7 +7294,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: f55c81fd-7180-49fd-a85e-a31ef8779a5b
+                    request_id: e16bac74-8abc-431e-82ac-302989e2f014
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -7296,7 +7308,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0b2f6c4a-69b6-4d1b-82f4-e5c566f7d052
+                    request_id: f260b9ad-57f0-40c1-bef6-3e60fd92c9af
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7310,7 +7322,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 9b45f016-bba4-4799-99f4-392492e092f6
+                    request_id: 1f4cc0b9-b494-406b-8017-97f9bdd41bd9
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -7327,7 +7339,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65de0f10ba4d12057e50994e
+                    id: 65e0bc976abd017f5e8b1d94
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -7335,7 +7347,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 65de0f11ba4d12057e50994f
+                    id: 65e0bc986abd017f5e8b1d95
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -7343,10 +7355,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991269096'
+                    id: '991268060'
                   to:
                     type: user
-                    id: 65de0f13ba4d12057e509950
+                    id: 65e0bc9a6abd017f5e8b1d96
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -7354,10 +7366,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991269098'
+                    id: '991268062'
                   to:
                     type: user
-                    id: 65de0f14ba4d12057e509951
+                    id: 65e0bc9a6abd017f5e8b1d97
                   message_type: inapp
                   body:
                   subject: heyy
@@ -7366,7 +7378,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991269099'
+                    id: '991268063'
                   to:
                     type: user
                     user_id: '70'
@@ -7377,10 +7389,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991269100'
+                    id: '991268064'
                   to:
                     type: user
-                    id: 65de0f15ba4d12057e509953
+                    id: 65e0bc9b6abd017f5e8b1d99
                   message_type: email
                   body:
                   subject: heyy
@@ -7411,12 +7423,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '70'
+                    - id: '43'
                       type: news-item
                       workspace_id: this_is_an_id470_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991269105
+                      sender_id: 991268069
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7426,15 +7438,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709051671
-                      updated_at: 1709051671
+                      created_at: 1709227165
+                      updated_at: 1709227165
                       newsfeed_assignments: []
-                    - id: '71'
+                    - id: '44'
                       type: news-item
                       workspace_id: this_is_an_id470_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991269107
+                      sender_id: 991268071
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7444,8 +7456,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709051671
-                      updated_at: 1709051671
+                      created_at: 1709227165
+                      updated_at: 1709227165
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -7458,7 +7470,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 69fa1f14-18f2-4119-860e-2e436c0e4f7e
+                    request_id: 23c4180d-329e-49c6-8ca0-3ae2f8f658cf
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7483,12 +7495,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '74'
+                    id: '47'
                     type: news-item
                     workspace_id: this_is_an_id474_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991269114
+                    sender_id: 991268078
                     state: live
                     labels:
                     - New
@@ -7499,10 +7511,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1709051673
-                    updated_at: 1709051673
+                    created_at: 1709227167
+                    updated_at: 1709227167
                     newsfeed_assignments:
-                    - newsfeed_id: 128
+                    - newsfeed_id: 78
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7514,7 +7526,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bfd2bb10-fcc1-49c2-956c-0d19b5d8bd9a
+                    request_id: 1901475c-da26-4915-8d03-bbf34f5011e1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7535,14 +7547,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991269114
+                  sender_id: 991268078
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 128
+                  - newsfeed_id: 78
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -7571,12 +7583,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '75'
+                    id: '48'
                     type: news-item
                     workspace_id: this_is_an_id478_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991269117
+                    sender_id: 991268081
                     state: live
                     labels: []
                     cover_image_url:
@@ -7586,11 +7598,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1709051674
-                    updated_at: 1709051674
+                    created_at: 1709227168
+                    updated_at: 1709227168
                     newsfeed_assignments:
-                    - newsfeed_id: 130
-                      published_at: 1709051674
+                    - newsfeed_id: 80
+                      published_at: 1709227168
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -7601,7 +7613,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 4624009e-de97-462f-9989-837f8a10e3d5
+                    request_id: fb1337ec-c776-4715-8648-86fd1cc0666b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7615,7 +7627,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 61025376-d607-497e-b858-bf08f6934c59
+                    request_id: 8bb53ae3-0cdc-4378-a87e-3372ee69f1f0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7646,12 +7658,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '78'
+                    id: '51'
                     type: news-item
                     workspace_id: this_is_an_id484_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991269125
+                    sender_id: 991268089
                     state: live
                     labels: []
                     cover_image_url:
@@ -7659,8 +7671,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1709051676
-                    updated_at: 1709051677
+                    created_at: 1709227170
+                    updated_at: 1709227170
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7672,7 +7684,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 75f56397-23c3-4c25-a538-6aaafd70ab72
+                    request_id: d4f45ee7-e098-4766-ab6b-3e83891a4a03
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7686,7 +7698,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3aa634d3-05fc-4453-806d-1f24244ee793
+                    request_id: de3b7aa7-79d7-493a-b62c-283ac07de5c9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7703,7 +7715,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991269125
+                  sender_id: 991268089
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7712,7 +7724,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991269128
+                  sender_id: 991268092
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7742,7 +7754,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '81'
+                    id: '54'
                     object: news-item
                     deleted: true
               schema:
@@ -7755,7 +7767,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: ea818c42-a703-42a4-862c-ca65faf3a63e
+                    request_id: fdca9c26-5421-4a1f-8bf6-dfc65aabf1a9
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7769,7 +7781,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e6fd00df-f1fb-47f2-ba4e-d7b367d56c4f
+                    request_id: c9d3e6b5-e490-4ebc-b42a-ae8bcf9dde04
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7822,7 +7834,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 374bc4b2-85de-471a-a5a8-ecff048a7830
+                    request_id: 5ffe384e-95b7-4b76-937f-5e877b75e9ce
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7855,16 +7867,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '143'
+                    - id: '93'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709051681
-                      updated_at: 1709051681
-                    - id: '144'
+                      created_at: 1709227175
+                      updated_at: 1709227175
+                    - id: '94'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709051681
-                      updated_at: 1709051681
+                      created_at: 1709227175
+                      updated_at: 1709227175
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -7876,7 +7888,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6086e909-d2e2-46dd-aa01-114e6c12919c
+                    request_id: 2ed4631c-c291-4d38-afd0-079ed2e1205a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7910,11 +7922,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '147'
+                    id: '97'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1709051682
-                    updated_at: 1709051682
+                    created_at: 1709227176
+                    updated_at: 1709227176
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -7925,7 +7937,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 99eb81ce-9f69-47ef-9c25-802310c6ca5a
+                    request_id: f2fc2a2f-b952-43c0-bb0f-b90175453c94
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7959,14 +7971,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '76'
-                    created_at: 1708360483
+                    id: '50'
+                    created_at: 1708535977
                     contact:
                       type: contact
-                      id: 65de0f24ba4d12057e509956
+                      id: 65e0bca96abd017f5e8b1d9c
                     author:
                       type: admin
-                      id: '991269144'
+                      id: '991268108'
                       name: Ciaran305 Lee
                       email: admin305@email.com
                       away_mode_enabled: false
@@ -7982,7 +7994,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: 24931086-5493-4e01-8dbe-bf2a5442253d
+                    request_id: cc73a727-65fc-4ae7-b8cc-9f41f1af4b6a
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7996,7 +8008,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b7936c2b-6dbf-4f0b-8fc7-aa2a34e660f9
+                    request_id: 06ff4266-c527-4313-899a-7f611913f5df
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8032,16 +8044,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 65de0f25ba4d12057e509959
+                      id: 65e0bcaa6abd017f5e8b1d9f
                       name: John segment
-                      created_at: 1709051685
-                      updated_at: 1709051685
+                      created_at: 1709227178
+                      updated_at: 1709227178
                       person_type: user
                     - type: segment
-                      id: 65de0f25ba4d12057e50995a
+                      id: 65e0bcaa6abd017f5e8b1da0
                       name: Jane segment
-                      created_at: 1709051685
-                      updated_at: 1709051685
+                      created_at: 1709227178
+                      updated_at: 1709227178
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -8053,7 +8065,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 75f97af5-0680-47a0-88bf-26f222f489b3
+                    request_id: abd6fe52-3e86-4f29-9bfb-7e9d70e60970
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8087,10 +8099,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 65de0f26ba4d12057e50995d
+                    id: 65e0bcab6abd017f5e8b1da3
                     name: John segment
-                    created_at: 1709051686
-                    updated_at: 1709051686
+                    created_at: 1709227179
+                    updated_at: 1709227179
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -8102,7 +8114,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: 8fd16c4d-8c63-435d-b0a0-3cdf99b812d3
+                    request_id: 0b62c8d2-61e3-4517-b2ad-3a6134e76d29
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8116,7 +8128,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 87c5f276-8402-4b21-87f3-57e34a64a464
+                    request_id: 9f42ef01-58d8-4d5c-8a7e-c164efc14fb5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8146,7 +8158,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '275'
+                      id: '183'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -8169,7 +8181,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 63627f2a-b6b1-4e60-8ec0-543fae589f3e
+                    request_id: 4d6c1cc7-8955-4dbc-b92a-fd2d5a4200c9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8199,7 +8211,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/3a13b3b6-0973-43ba-bb13-e7a31e30ba25
+                    url: http://via.intercom.io/msgr/5ce7a322-e2cf-456b-a809-dd3bf7cb85d9
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -8232,7 +8244,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ec92d471-4591-4b81-a040-6bb2dcd70a10
+                    request_id: b72d1a91-b2d5-458c-97e2-1ff8d7223d56
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8295,7 +8307,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '233'
+                      id: '146'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -8307,7 +8319,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f4c4db19-532c-4730-8b40-8e9f5ccaf338
+                    request_id: 669e9942-5f07-41f6-b64f-1b4055a5804e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8346,7 +8358,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '236'
+                    id: '149'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8358,7 +8370,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: 2699fc53-c5b8-405a-a1f0-4be750a3bae8
+                    request_id: 815a79e2-0216-4b86-bad3-5cca932278f2
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -8372,14 +8384,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: 503e5c0f-3d49-4c4d-a214-3322a00122af
+                    request_id: b74ebdda-5c0e-41f6-988e-7a716a3af3c3
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: 2af5e927-5f4c-47c4-95e0-015f7a9b467b
+                    request_id: 1f4895e6-11db-4893-aecc-8ce2bdfe4f44
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -8393,7 +8405,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6e6c1e32-94c8-48ea-99f1-bf82eda2718a
+                    request_id: 8afe5491-588d-4296-99ca-7f3b33fb5b26
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8459,7 +8471,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '244'
+                    id: '157'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8471,7 +8483,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: cfc75cbc-b35e-4e5e-907d-2e9307edba5f
+                    request_id: bd2d2a80-d811-4745-b78b-716ab9996401
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8485,7 +8497,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7fb78159-9123-46cb-a385-4b0e6fb78058
+                    request_id: ac8ebc44-e11f-4bc8-bcdc-d832fe7b78f8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8521,7 +8533,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 12284960-a7e3-40a2-bcab-e11bc0cb122f
+                    request_id: c6631264-a63e-4dcb-8845-60655a47195e
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8535,7 +8547,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: c88c6d45-8746-4005-8fed-72760de0a93b
+                    request_id: 15ba1e69-1f84-45c0-afa7-ca9dbe29affc
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -8550,7 +8562,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9ff8f35f-7dd7-4b97-9898-4c45fbd0b95c
+                    request_id: 61fd329f-a9b4-4d95-8541-064eb2fb68a1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8588,7 +8600,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a931c69d-472c-482f-9b8f-da72a837861e
+                    request_id: 69427588-5cc7-44e5-8961-a65fccc09460
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8623,7 +8635,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991269182'
+                    id: '991268146'
                     name: team 1
                     admin_ids: []
               schema:
@@ -8636,7 +8648,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: 508350a6-b4d8-4360-9a52-a225702f5af8
+                    request_id: e90496ca-c9f4-4627-b79f-4a0ee4cd1161
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -8650,7 +8662,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9820177b-3aca-4355-a283-ddf63f0f8903
+                    request_id: 9ceac5bd-03f4-4cad-b17f-53cbb416ad4f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8683,7 +8695,7 @@ paths:
                 Ticket Type Attribute created:
                   value:
                     type: ticket_type_attribute
-                    id: '387'
+                    id: '235'
                     workspace_id: this_is_an_id576_that_should_be_at_least_
                     name: Attribute Title
                     description: Attribute Description
@@ -8696,10 +8708,10 @@ paths:
                     visible_on_create: true
                     visible_to_contacts: true
                     default: false
-                    ticket_type_id: 132
+                    ticket_type_id: 74
                     archived: false
-                    created_at: 1709051705
-                    updated_at: 1709051705
+                    created_at: 1709227196
+                    updated_at: 1709227196
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -8710,7 +8722,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6927a70d-0854-452e-bdc0-dd11d229a30e
+                    request_id: d74228d8-c3a6-4bd6-9ea8-3597fb23f29e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8763,7 +8775,7 @@ paths:
                 Ticket Type Attribute updated:
                   value:
                     type: ticket_type_attribute
-                    id: '392'
+                    id: '240'
                     workspace_id: this_is_an_id580_that_should_be_at_least_
                     name: name
                     description: New Attribute Description
@@ -8774,10 +8786,10 @@ paths:
                     visible_on_create: false
                     visible_to_contacts: false
                     default: false
-                    ticket_type_id: 134
+                    ticket_type_id: 76
                     archived: false
-                    created_at: 1709051706
-                    updated_at: 1709051706
+                    created_at: 1709227197
+                    updated_at: 1709227198
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -8788,7 +8800,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 040baf87-4c20-4622-819c-192787d495d3
+                    request_id: 7b5405e3-31b2-4c53-bba6-b485b60d8e04
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8827,20 +8839,20 @@ paths:
                     type: list
                     data:
                     - type: ticket_type
-                      id: '136'
+                      id: '78'
                       name: Bug Report
                       description: Bug Report Template
                       icon: "\U0001F39F️"
                       workspace_id: this_is_an_id584_that_should_be_at_least_
                       archived: false
-                      created_at: 1709051707
-                      updated_at: 1709051707
+                      created_at: 1709227198
+                      updated_at: 1709227198
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '395'
+                          id: '243'
                           workspace_id: this_is_an_id584_that_should_be_at_least_
                           name: _default_title_
                           description: ''
@@ -8853,12 +8865,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 136
+                          ticket_type_id: 78
                           archived: false
-                          created_at: 1709051707
-                          updated_at: 1709051707
+                          created_at: 1709227198
+                          updated_at: 1709227198
                         - type: ticket_type_attribute
-                          id: '397'
+                          id: '245'
                           workspace_id: this_is_an_id584_that_should_be_at_least_
                           name: name
                           description: description
@@ -8870,12 +8882,12 @@ paths:
                           visible_on_create: false
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 136
+                          ticket_type_id: 78
                           archived: false
-                          created_at: 1709051707
-                          updated_at: 1709051707
+                          created_at: 1709227198
+                          updated_at: 1709227198
                         - type: ticket_type_attribute
-                          id: '396'
+                          id: '244'
                           workspace_id: this_is_an_id584_that_should_be_at_least_
                           name: _default_description_
                           description: ''
@@ -8888,10 +8900,10 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 136
+                          ticket_type_id: 78
                           archived: false
-                          created_at: 1709051707
-                          updated_at: 1709051707
+                          created_at: 1709227198
+                          updated_at: 1709227198
                       category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type_list"
@@ -8903,7 +8915,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1639cef5-00db-4837-ac4c-3727011ebcc2
+                    request_id: 66f97eb1-3833-43ac-bc87-dd342090032a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8932,20 +8944,20 @@ paths:
                 Ticket type created:
                   value:
                     type: ticket_type
-                    id: '139'
+                    id: '81'
                     name: Customer Issue
                     description: Customer Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id588_that_should_be_at_least_
                     archived: false
-                    created_at: 1709051709
-                    updated_at: 1709051709
+                    created_at: 1709227200
+                    updated_at: 1709227200
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '404'
+                        id: '252'
                         workspace_id: this_is_an_id588_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -8958,12 +8970,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 139
+                        ticket_type_id: 81
                         archived: false
-                        created_at: 1709051709
-                        updated_at: 1709051709
+                        created_at: 1709227200
+                        updated_at: 1709227200
                       - type: ticket_type_attribute
-                        id: '405'
+                        id: '253'
                         workspace_id: this_is_an_id588_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -8976,10 +8988,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 139
+                        ticket_type_id: 81
                         archived: false
-                        created_at: 1709051709
-                        updated_at: 1709051709
+                        created_at: 1709227200
+                        updated_at: 1709227200
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -8991,7 +9003,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a7d4d8ff-90df-4913-8e27-9ed3d4e6ac81
+                    request_id: 3a24b627-c80d-410a-a09e-c3d7f953f712
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9037,20 +9049,20 @@ paths:
                 Ticket type found:
                   value:
                     type: ticket_type
-                    id: '141'
+                    id: '83'
                     name: Bug Report
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id592_that_should_be_at_least_
                     archived: false
-                    created_at: 1709051709
-                    updated_at: 1709051709
+                    created_at: 1709227201
+                    updated_at: 1709227201
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '409'
+                        id: '257'
                         workspace_id: this_is_an_id592_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -9063,12 +9075,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 141
+                        ticket_type_id: 83
                         archived: false
-                        created_at: 1709051709
-                        updated_at: 1709051709
+                        created_at: 1709227201
+                        updated_at: 1709227201
                       - type: ticket_type_attribute
-                        id: '411'
+                        id: '259'
                         workspace_id: this_is_an_id592_that_should_be_at_least_
                         name: name
                         description: description
@@ -9080,12 +9092,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 141
+                        ticket_type_id: 83
                         archived: false
-                        created_at: 1709051710
-                        updated_at: 1709051710
+                        created_at: 1709227201
+                        updated_at: 1709227201
                       - type: ticket_type_attribute
-                        id: '410'
+                        id: '258'
                         workspace_id: this_is_an_id592_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -9098,10 +9110,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 141
+                        ticket_type_id: 83
                         archived: false
-                        created_at: 1709051709
-                        updated_at: 1709051709
+                        created_at: 1709227201
+                        updated_at: 1709227201
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -9113,7 +9125,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7e6cfaee-e9f0-4b18-b8f3-099d076fd903
+                    request_id: bc86862e-ee87-406d-9e4b-f71a615beb76
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9146,20 +9158,20 @@ paths:
                 Ticket type updated:
                   value:
                     type: ticket_type
-                    id: '143'
+                    id: '85'
                     name: Bug Report 2
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id596_that_should_be_at_least_
                     archived: false
-                    created_at: 1709051711
-                    updated_at: 1709051711
+                    created_at: 1709227202
+                    updated_at: 1709227203
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '415'
+                        id: '263'
                         workspace_id: this_is_an_id596_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -9172,12 +9184,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 143
+                        ticket_type_id: 85
                         archived: false
-                        created_at: 1709051711
-                        updated_at: 1709051711
+                        created_at: 1709227202
+                        updated_at: 1709227202
                       - type: ticket_type_attribute
-                        id: '417'
+                        id: '265'
                         workspace_id: this_is_an_id596_that_should_be_at_least_
                         name: name
                         description: description
@@ -9189,12 +9201,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 143
+                        ticket_type_id: 85
                         archived: false
-                        created_at: 1709051711
-                        updated_at: 1709051711
+                        created_at: 1709227202
+                        updated_at: 1709227202
                       - type: ticket_type_attribute
-                        id: '416'
+                        id: '264'
                         workspace_id: this_is_an_id596_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -9207,10 +9219,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 143
+                        ticket_type_id: 85
                         archived: false
-                        created_at: 1709051711
-                        updated_at: 1709051711
+                        created_at: 1709227202
+                        updated_at: 1709227202
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -9222,7 +9234,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bff05eb4-f9a3-4bf4-ad6f-f8590c3afe8d
+                    request_id: ecd1ad0d-5292-4551-a1cf-f3ea0d030e9f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9268,13 +9280,13 @@ paths:
                 User reply:
                   value:
                     type: ticket_part
-                    id: '189'
+                    id: '118'
                     part_type: comment
                     body: "<p>Thanks again :)</p>"
-                    created_at: 1709051714
-                    updated_at: 1709051714
+                    created_at: 1709227205
+                    updated_at: 1709227205
                     author:
-                      id: 65de0f42ba4d12057e509980
+                      id: 65e0bcc56abd017f5e8b1dc6
                       type: user
                       name:
                       email: user30@email.com
@@ -9283,7 +9295,7 @@ paths:
                 Admin note reply:
                   value:
                     type: ticket_part
-                    id: '191'
+                    id: '120'
                     part_type: note
                     body: |-
                       <h2>An Unordered HTML List</h2>
@@ -9298,10 +9310,10 @@ paths:
                       <li>Tea</li>
                       <li>Milk</li>
                       </ol>
-                    created_at: 1709051717
-                    updated_at: 1709051717
+                    created_at: 1709227207
+                    updated_at: 1709227207
                     author:
-                      id: '991269209'
+                      id: '991268173'
                       type: admin
                       name: Ciaran364 Lee
                       email: admin364@email.com
@@ -9310,12 +9322,12 @@ paths:
                 Admin quick_reply reply:
                   value:
                     type: ticket_part
-                    id: '193'
+                    id: '122'
                     part_type: quick_reply
-                    created_at: 1709051719
-                    updated_at: 1709051719
+                    created_at: 1709227210
+                    updated_at: 1709227210
                     author:
-                      id: '991269214'
+                      id: '991268178'
                       type: admin
                       name: Ciaran368 Lee
                       email: admin368@email.com
@@ -9331,7 +9343,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 77dc3881-41ea-4e9e-9f25-f43cf4e074b9
+                    request_id: 05a4c8fc-882c-4c6e-a1b8-7789e79b3335
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9345,7 +9357,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: debfe55d-d852-43ec-89a7-4cba3c662f42
+                    request_id: 23f3c4bb-86e6-4c3c-803f-021fce5750ad
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9362,14 +9374,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0f42ba4d12057e509980
+                  intercom_user_id: 65e0bcc56abd017f5e8b1dc6
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991269209
+                  admin_id: 991268173
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -9379,18 +9391,18 @@ paths:
                 value:
                   message_type: quick_reply
                   type: admin
-                  admin_id: 991269214
+                  admin_id: 991268178
                   reply_options:
                   - text: 'Yes'
-                    uuid: 0b1b1bf4-1b98-4252-9410-705b13ea4b20
+                    uuid: 7835e161-274e-42fb-9742-7d8f7fa1d4e9
                   - text: 'No'
-                    uuid: febf4ba4-1be8-4176-97fa-b8dc47fd5236
+                    uuid: f79091ab-b086-40d8-81fe-514313df98f5
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0f48ba4d12057e509983
+                  intercom_user_id: 65e0bccb6abd017f5e8b1dc9
                   body: Thanks again :)
   "/tickets/{ticket_id}/tags":
     post:
@@ -9422,7 +9434,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '252'
+                    id: '165'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9434,7 +9446,7 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: ded834dc-b61a-4759-b5ff-6409775c3de5
+                    request_id: 0332171a-9a0c-49d2-bc0f-ab9a4bef15d1
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
@@ -9448,7 +9460,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: da918ecd-3f57-445d-a4a4-83a606a54b76
+                    request_id: 98c3ea8a-9874-4c79-9b7f-a978e7fa6dd6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9477,13 +9489,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 252
-                  admin_id: 991269224
+                  id: 165
+                  admin_id: 991268188
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  id: 253
-                  admin_id: 991269227
+                  id: 166
+                  admin_id: 991268191
   "/tickets/{ticket_id}/tags/{id}":
     delete:
       summary: Remove tag from a ticket
@@ -9521,7 +9533,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '255'
+                    id: '168'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9533,14 +9545,14 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: 03f68772-bd92-4dad-8f33-1582440cd1bc
+                    request_id: 73626a6e-0a87-41e8-959b-f301abd0ee27
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 4efd3885-e732-407f-b07d-75ea99e59f52
+                    request_id: 076f5a61-c53d-4c06-b8e2-caa9114ae523
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -9554,7 +9566,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 88ab8bce-a4b9-4cf0-8ba6-d494faf3021e
+                    request_id: da3e1793-6492-42eb-a47c-632c0af7e571
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9577,15 +9589,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991269233
+                  admin_id: 991268197
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  admin_id: 991269236
+                  admin_id: 991268200
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991269239
+                  admin_id: 991268203
   "/tickets":
     post:
       summary: Create a ticket
@@ -9607,28 +9619,28 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '855'
-                    ticket_id: '35'
+                    id: '566'
+                    ticket_id: '18'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '157'
+                      id: '99'
                       name: my-ticket-type-15
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id624_that_should_be_at_least_
                       archived: false
-                      created_at: 1709051737
-                      updated_at: 1709051737
+                      created_at: 1709227224
+                      updated_at: 1709227224
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '429'
+                          id: '277'
                           workspace_id: this_is_an_id624_that_should_be_at_least_
                           name: title
                           description: ola
@@ -9640,12 +9652,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 157
+                          ticket_type_id: 99
                           archived: false
-                          created_at: 1709051737
-                          updated_at: 1709051737
+                          created_at: 1709227225
+                          updated_at: 1709227225
                         - type: ticket_type_attribute
-                          id: '430'
+                          id: '278'
                           workspace_id: this_is_an_id624_that_should_be_at_least_
                           name: description
                           description: ola
@@ -9657,33 +9669,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 157
+                          ticket_type_id: 99
                           archived: false
-                          created_at: 1709051737
-                          updated_at: 1709051737
+                          created_at: 1709227225
+                          updated_at: 1709227225
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0f59ba4d12057e50998b
+                        id: 65e0bcd96abd017f5e8b1dd1
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709051737
-                    updated_at: 1709051738
+                    created_at: 1709227225
+                    updated_at: 1709227226
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '194'
+                        id: '123'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709051738
-                        updated_at: 1709051738
+                        created_at: 1709227226
+                        updated_at: 1709227226
                         author:
-                          id: '991269251'
+                          id: '991268215'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id624_that_should_be_at_least_@intercom.io
@@ -9708,7 +9720,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d2d9881a-b1c0-4819-9d71-8caa7321b424
+                    request_id: 71ff7891-44a1-4742-a98d-c2906dee6763
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9723,9 +9735,9 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  ticket_type_id: 157
+                  ticket_type_id: 99
                   contacts:
-                  - id: 65de0f59ba4d12057e50998b
+                  - id: 65e0bcd96abd017f5e8b1dd1
                   ticket_attributes:
                     title: example
                     description: there is a problem
@@ -9756,28 +9768,28 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '856'
-                    ticket_id: '36'
+                    id: '567'
+                    ticket_id: '19'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: in_progress
                     ticket_type:
                       type: ticket_type
-                      id: '159'
+                      id: '101'
                       name: my-ticket-type-17
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id628_that_should_be_at_least_
                       archived: false
-                      created_at: 1709051739
-                      updated_at: 1709051739
+                      created_at: 1709227227
+                      updated_at: 1709227227
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '434'
+                          id: '282'
                           workspace_id: this_is_an_id628_that_should_be_at_least_
                           name: title
                           description: ola
@@ -9789,12 +9801,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 159
+                          ticket_type_id: 101
                           archived: false
-                          created_at: 1709051739
-                          updated_at: 1709051739
+                          created_at: 1709227227
+                          updated_at: 1709227227
                         - type: ticket_type_attribute
-                          id: '435'
+                          id: '283'
                           workspace_id: this_is_an_id628_that_should_be_at_least_
                           name: description
                           description: ola
@@ -9806,98 +9818,98 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 159
+                          ticket_type_id: 101
                           archived: false
-                          created_at: 1709051739
-                          updated_at: 1709051739
+                          created_at: 1709227227
+                          updated_at: 1709227227
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0f5cba4d12057e50998c
-                        external_id: 4930828b-7598-445e-adb2-feb035398279
-                    admin_assignee_id: '991269265'
+                        id: 65e0bcdb6abd017f5e8b1dd2
+                        external_id: 860beef7-731e-4075-9ecc-263180af3f0d
+                    admin_assignee_id: '991268229'
                     team_assignee_id: '0'
-                    created_at: 1709051740
-                    updated_at: 1709051743
+                    created_at: 1709227227
+                    updated_at: 1709227230
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '195'
+                        id: '124'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709051740
-                        updated_at: 1709051740
+                        created_at: 1709227228
+                        updated_at: 1709227228
                         author:
-                          id: '991269263'
+                          id: '991268227'
                           type: admin
                           name: Ciaran408 Lee
                           email: admin408@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '196'
+                        id: '125'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709051742
-                        updated_at: 1709051742
+                        created_at: 1709227229
+                        updated_at: 1709227229
                         author:
-                          id: '991269264'
+                          id: '991268228'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id628_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '197'
+                        id: '126'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709051742
-                        updated_at: 1709051742
+                        created_at: 1709227229
+                        updated_at: 1709227229
                         author:
-                          id: '991269264'
+                          id: '991268228'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id628_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '198'
+                        id: '127'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: in_progress
                         previous_ticket_state: submitted
-                        created_at: 1709051742
-                        updated_at: 1709051742
+                        created_at: 1709227229
+                        updated_at: 1709227229
                         author:
-                          id: '991269264'
+                          id: '991268228'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id628_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '199'
+                        id: '128'
                         part_type: assignment
-                        created_at: 1709051742
-                        updated_at: 1709051742
+                        created_at: 1709227230
+                        updated_at: 1709227230
                         assigned_to:
                           type: admin
-                          id: '991269265'
+                          id: '991268229'
                         author:
-                          id: '991269263'
+                          id: '991268227'
                           type: admin
                           name: Ciaran408 Lee
                           email: admin408@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '200'
+                        id: '129'
                         part_type: snoozed
-                        created_at: 1709051743
-                        updated_at: 1709051743
+                        created_at: 1709227230
+                        updated_at: 1709227230
                         author:
-                          id: '991269264'
+                          id: '991268228'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id628_that_should_be_at_least_@intercom.io
@@ -9905,7 +9917,7 @@ paths:
                         redacted: false
                       total_count: 6
                     open: true
-                    snoozed_until: 1709139600
+                    snoozed_until: 1709312400
                     linked_objects:
                       type: list
                       data: []
@@ -9923,14 +9935,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 2d5bcc30-2aa0-419e-bf0c-a4b7d533c27b
+                    request_id: e69db6e4-39c0-414e-bea9-567b5683f77c
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
                 Assignee not found:
                   value:
                     type: error.list
-                    request_id: 0d1520b8-7240-46c5-b211-a5e86a1c5a88
+                    request_id: dc7ef4c0-5199-40f0-923b-4ca688202120
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
@@ -9942,7 +9954,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '097758d4-2281-45d9-aa12-71764a6bf177'
+                    request_id: 7d3165c3-3014-49bd-9eb1-1b2254637b21
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9962,8 +9974,8 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991269263'
-                    assignee_id: '991269265'
+                    admin_id: '991268227'
+                    assignee_id: '991268229'
                   open: true
                   snoozed_until: 1673609604
               admin_not_found:
@@ -9975,7 +9987,7 @@ paths:
                   state: in_progress
                   assignment:
                     admin_id: '123'
-                    assignee_id: '991269273'
+                    assignee_id: '991268237'
               assignee_not_found:
                 summary: Assignee not found
                 value:
@@ -9984,7 +9996,7 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991269279'
+                    admin_id: '991268243'
                     assignee_id: '456'
     get:
       summary: Retrieve a ticket
@@ -10012,28 +10024,28 @@ paths:
                 Ticket found:
                   value:
                     type: ticket
-                    id: '859'
-                    ticket_id: '39'
+                    id: '570'
+                    ticket_id: '22'
                     ticket_attributes:
                       title: attribute_value
                       description:
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '163'
+                      id: '105'
                       name: my-ticket-type-21
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id636_that_should_be_at_least_
                       archived: false
-                      created_at: 1709051749
-                      updated_at: 1709051749
+                      created_at: 1709227235
+                      updated_at: 1709227235
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '445'
+                          id: '293'
                           workspace_id: this_is_an_id636_that_should_be_at_least_
                           name: title
                           description: ola
@@ -10045,12 +10057,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 163
+                          ticket_type_id: 105
                           archived: false
-                          created_at: 1709051749
-                          updated_at: 1709051749
+                          created_at: 1709227236
+                          updated_at: 1709227236
                         - type: ticket_type_attribute
-                          id: '446'
+                          id: '294'
                           workspace_id: this_is_an_id636_that_should_be_at_least_
                           name: description
                           description: ola
@@ -10062,33 +10074,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 163
+                          ticket_type_id: 105
                           archived: false
-                          created_at: 1709051749
-                          updated_at: 1709051749
+                          created_at: 1709227236
+                          updated_at: 1709227236
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0f66ba4d12057e50998f
-                        external_id: 47217117-3dd5-48d2-979d-a590b0d19881
+                        id: 65e0bce46abd017f5e8b1dd5
+                        external_id: 1acbc940-9927-4a6c-9368-544d1c6baf71
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709051750
-                    updated_at: 1709051750
+                    created_at: 1709227236
+                    updated_at: 1709227236
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '203'
+                        id: '132'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709051750
-                        updated_at: 1709051750
+                        created_at: 1709227236
+                        updated_at: 1709227236
                         author:
-                          id: '991269292'
+                          id: '991268256'
                           type: admin
                           name: Ciaran434 Lee
                           email: admin434@email.com
@@ -10113,7 +10125,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a1042c5a-aead-4d44-906c-ac8760c9a923
+                    request_id: 5ad0ec9b-d634-46fd-8d4b-d6cb0d14500b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10199,28 +10211,28 @@ paths:
                     total_count: 1
                     tickets:
                     - type: ticket
-                      id: '860'
-                      ticket_id: '40'
+                      id: '571'
+                      ticket_id: '23'
                       ticket_attributes:
                         title: attribute_value
                         description:
                       ticket_state: submitted
                       ticket_type:
                         type: ticket_type
-                        id: '165'
+                        id: '107'
                         name: my-ticket-type-23
                         description: my ticket type description is awesome.
                         icon: "\U0001F981"
                         workspace_id: this_is_an_id640_that_should_be_at_least_
                         archived: false
-                        created_at: 1709051753
-                        updated_at: 1709051753
+                        created_at: 1709227238
+                        updated_at: 1709227238
                         is_internal: false
                         ticket_type_attributes:
                           type: list
                           data:
                           - type: ticket_type_attribute
-                            id: '450'
+                            id: '298'
                             workspace_id: this_is_an_id640_that_should_be_at_least_
                             name: title
                             description: ola
@@ -10232,12 +10244,12 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 165
+                            ticket_type_id: 107
                             archived: false
-                            created_at: 1709051753
-                            updated_at: 1709051753
+                            created_at: 1709227238
+                            updated_at: 1709227238
                           - type: ticket_type_attribute
-                            id: '451'
+                            id: '299'
                             workspace_id: this_is_an_id640_that_should_be_at_least_
                             name: description
                             description: ola
@@ -10249,33 +10261,33 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 165
+                            ticket_type_id: 107
                             archived: false
-                            created_at: 1709051753
-                            updated_at: 1709051753
+                            created_at: 1709227238
+                            updated_at: 1709227238
                         category: Back-office
                       contacts:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de0f69ba4d12057e509990
-                          external_id: b0a98c5e-7a75-4380-a9ef-750c4fc15447
+                          id: 65e0bce76abd017f5e8b1dd6
+                          external_id: 98408b19-faca-471b-b302-3836ca7584c4
                       admin_assignee_id: '0'
                       team_assignee_id: '0'
-                      created_at: 1709051753
-                      updated_at: 1709051754
+                      created_at: 1709227239
+                      updated_at: 1709227239
                       ticket_parts:
                         type: ticket_part.list
                         ticket_parts:
                         - type: ticket_part
-                          id: '204'
+                          id: '133'
                           part_type: ticket_state_updated_by_admin
                           ticket_state: submitted
                           previous_ticket_state: submitted
-                          created_at: 1709051754
-                          updated_at: 1709051754
+                          created_at: 1709227239
+                          updated_at: 1709227239
                           author:
-                            id: '991269305'
+                            id: '991268269'
                             type: admin
                             name: Ciaran446 Lee
                             email: admin446@email.com
@@ -10306,15 +10318,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '860'
+                      value: '571'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '860'
+                        value: '571'
                       - field: id
                         operator: "="
-                        value: '860'
+                        value: '571'
   "/visitors":
     put:
       summary: Update a visitor
@@ -10341,26 +10353,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0f6cba4d12057e509993
+                    id: 65e0bce96abd017f5e8b1dd9
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Lilac Bear
+                    pseudonym: Violet Cloud
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/lilac-bear.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/violet-cloud.png
                     app_id: this_is_an_id644_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709051756
-                    remote_created_at: 1709051756
-                    signed_up_at: 1709051756
-                    updated_at: 1709051756
+                    created_at: 1709227241
+                    remote_created_at: 1709227241
+                    signed_up_at: 1709227241
+                    updated_at: 1709227241
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10393,7 +10405,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 5d75cf9d-49db-475b-8922-20d873e39ccb
+                    request_id: 0ff4c877-f49f-4fe6-87a3-c4da1346cde6
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -10407,7 +10419,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b24494f5-c7d8-4ed0-b35c-8b6ae204ff7d
+                    request_id: b12f83cd-891a-4a0f-bb8c-4ba9291ea29b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10422,7 +10434,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 65de0f6cba4d12057e509993
+                  id: 65e0bce96abd017f5e8b1dd9
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -10455,7 +10467,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0f6eba4d12057e509999
+                    id: 65e0bcea6abd017f5e8b1ddf
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -10471,10 +10483,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709051758
-                    remote_created_at: 1709051758
-                    signed_up_at: 1709051758
-                    updated_at: 1709051758
+                    created_at: 1709227242
+                    remote_created_at: 1709227242
+                    signed_up_at: 1709227242
+                    updated_at: 1709227242
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10507,7 +10519,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: b9df4b2e-b958-4ed0-b634-0991eb69bdb0
+                    request_id: 95c6dba5-7133-43ca-9f1e-b20b4d2d308f
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -10521,7 +10533,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 453af3ba-d9ce-487a-b6b1-4e4c9753f5b7
+                    request_id: 119af3b0-6b41-4744-ae6b-c85cb323eb13
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10555,7 +10567,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0f6fba4d12057e50999f
+                    id: 65e0bcec6abd017f5e8b1de5
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -10571,10 +10583,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709051759
-                    remote_created_at: 1709051759
-                    signed_up_at: 1709051759
-                    updated_at: 1709051759
+                    created_at: 1709227244
+                    remote_created_at: 1709227244
+                    signed_up_at: 1709227244
+                    updated_at: 1709227244
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10607,7 +10619,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: 721046cb-d458-4bb0-a5b2-6887dc7b0bef
+                    request_id: 362d0196-2d18-40dc-9c80-537892f651cf
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -10621,7 +10633,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ad5df008-1bec-4d6c-90b9-f4be88598ca6
+                    request_id: cc885ebb-a991-4cce-8d1b-6ca079a2ae4c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10654,7 +10666,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0f71ba4d12057e5099a5
+                    id: 65e0bcee6abd017f5e8b1deb
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -10670,10 +10682,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709051761
-                    remote_created_at: 1709051761
-                    signed_up_at: 1709051761
-                    updated_at: 1709051761
+                    created_at: 1709227246
+                    remote_created_at: 1709227246
+                    signed_up_at: 1709227246
+                    updated_at: 1709227246
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10706,7 +10718,7 @@ paths:
                 Visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 444dd29c-a6c4-462b-b14a-b572a5948966
+                    request_id: f12425a2-fcc6-4c19-83c6-11d8fa692456
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -10720,7 +10732,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 26bb5cb6-82c9-4cec-8734-1a445eed91bf
+                    request_id: 77e33125-5c4b-4286-ace9-ad06f4e2e7f9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10751,7 +10763,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0f73ba4d12057e5099ac
+                    id: 65e0bcef6abd017f5e8b1df2
                     workspace_id: this_is_an_id668_that_should_be_at_least_
                     external_id:
                     role: user
@@ -10766,9 +10778,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709051763
-                    updated_at: 1709051763
-                    signed_up_at: 1709051763
+                    created_at: 1709227247
+                    updated_at: 1709227248
+                    signed_up_at: 1709227247
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -10802,31 +10814,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0f73ba4d12057e5099ac/tags"
+                      url: "/contacts/65e0bcef6abd017f5e8b1df2/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0f73ba4d12057e5099ac/notes"
+                      url: "/contacts/65e0bcef6abd017f5e8b1df2/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0f73ba4d12057e5099ac/companies"
+                      url: "/contacts/65e0bcef6abd017f5e8b1df2/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0f73ba4d12057e5099ac/subscriptions"
+                      url: "/contacts/65e0bcef6abd017f5e8b1df2/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0f73ba4d12057e5099ac/subscriptions"
+                      url: "/contacts/65e0bcef6abd017f5e8b1df2/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -10845,7 +10857,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e606cf16-b225-4314-bb25-cff86e0afa9c
+                    request_id: 98286161-2cd1-4927-b628-452f4efd293d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11137,12 +11149,32 @@ components:
           description: The id of the admin who is authoring the comment.
           example: '3156780'
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -12623,12 +12655,32 @@ components:
           type: string
           description: The email you have defined for the user.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -12656,12 +12708,32 @@ components:
           type: string
           description: The identifier for the contact as given by Intercom.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -12695,12 +12767,32 @@ components:
           type: string
           description: The external_id you have defined for the contact.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991267745'
+                    id: '991270107'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1709226901
+                      created_at: 1709290215
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991267746'
+                    id: '991270108'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 12b20f82-7795-45d9-90ad-c065e5b6addb
+                    request_id: d8c4defd-4fb6-4232-8374-b89d4e4dec9d
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1bdb7f19-ab4a-4261-88df-159ddcea4a5a
+                    request_id: 6f091940-e3e8-46ac-9993-8a2f09c6733b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: 6664db46-c98d-4b15-b035-743881f8f972
+                    - id: c26d4339-f117-4ace-ac23-02360f83534a
                       performed_by:
                         type: admin
-                        id: '991267750'
+                        id: '991270112'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1709226907
+                      created_at: 1709290221
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: 6e15efe4-d65d-4fc0-a095-282e6232c216
+                    - id: 39cad271-dbf7-4d44-b181-6155393b81dd
                       performed_by:
                         type: admin
-                        id: '991267750'
+                        id: '991270112'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1709226907
+                      created_at: 1709290221
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8654b76a-ad4d-463c-96c6-d517d5452461
+                    request_id: 0b2b4e78-c23a-4013-bcd3-264c5f32539f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991267752'
+                      id: '991270114'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2996d7d0-5087-42b0-ace1-73c6b001a7af
+                    request_id: e61d5313-9da0-4a62-b967-5197720aa0cc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991267754'
+                    id: '991270116'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 8358826a-0a4b-4a69-805a-f48100354c72
+                    request_id: 5ec72442-c179-4085-b5b9-1d850c61860c
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 001e5fbe-ba41-49e9-8b37-1e37cd7ef835
+                    request_id: 87c81d6f-fdee-4427-812b-597414380d06
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -390,20 +390,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '57'
+                    - id: '161'
                       type: article
                       workspace_id: this_is_an_id22_that_should_be_at_least_4
-                      parent_id: 221
+                      parent_id: 588
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991267757
+                      author_id: 991270119
                       state: published
-                      created_at: 1709226912
-                      updated_at: 1709226912
-                      url: http://help-center.test/myapp-22/en/articles/57-this-is-the-article-title
+                      created_at: 1709290226
+                      updated_at: 1709290226
+                      url: http://help-center.test/myapp-22/en/articles/161-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -414,7 +414,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 015ded0d-c178-475f-83c6-4abb47167951
+                    request_id: 3c32cc7e-676d-43fb-939d-7d23e04d5ab5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -439,10 +439,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '60'
+                    id: '164'
                     type: article
                     workspace_id: this_is_an_id26_that_should_be_at_least_4
-                    parent_id: 223
+                    parent_id: 590
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -456,11 +456,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991267762
+                    author_id: 991270124
                     state: published
-                    created_at: 1709226914
-                    updated_at: 1709226914
-                    url: http://help-center.test/myapp-26/en/articles/60-thanks-for-everything
+                    created_at: 1709290228
+                    updated_at: 1709290228
+                    url: http://help-center.test/myapp-26/en/articles/164-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -471,7 +471,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 559e679b-868d-46d7-9ff5-03bee5e5eb7b
+                    request_id: 920126fe-fffb-4396-82e3-75f7a79a252d
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -486,7 +486,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 231c39bf-2f35-4df9-abd9-08787786c6db
+                    request_id: b90a9b2b-7434-4e16-9fc0-86f4b816afba
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -504,16 +504,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991267762
+                  author_id: 991270124
                   state: published
-                  parent_id: 223
+                  parent_id: 590
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991267762
+                      author_id: 991270124
                       state: published
               bad_request:
                 summary: Bad Request
@@ -550,10 +550,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '63'
+                    id: '167'
                     type: article
                     workspace_id: this_is_an_id32_that_should_be_at_least_4
-                    parent_id: 226
+                    parent_id: 593
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -567,11 +567,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991267767
+                    author_id: 991270129
                     state: published
-                    created_at: 1709226916
-                    updated_at: 1709226916
-                    url: http://help-center.test/myapp-32/en/articles/63-this-is-the-article-title
+                    created_at: 1709290230
+                    updated_at: 1709290230
+                    url: http://help-center.test/myapp-32/en/articles/167-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -582,7 +582,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: 5bd26f7a-5d20-4129-acc1-d4500c68a099
+                    request_id: cc740e2d-b805-4b6b-a945-de2ffd262af8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -596,7 +596,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f21e7edc-ec2a-4da6-b1c1-55a83a6cedd2
+                    request_id: 61379682-c79d-43a5-8aed-7b3970a0bb8f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -629,10 +629,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '66'
+                    id: '170'
                     type: article
                     workspace_id: this_is_an_id38_that_should_be_at_least_4
-                    parent_id: 229
+                    parent_id: 596
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -646,11 +646,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991267773
+                    author_id: 991270135
                     state: published
-                    created_at: 1709226918
-                    updated_at: 1709226919
-                    url: http://help-center.test/myapp-38/en/articles/66-christmas-is-here
+                    created_at: 1709290233
+                    updated_at: 1709290233
+                    url: http://help-center.test/myapp-38/en/articles/170-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -661,7 +661,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 5ebe236b-035d-4e88-a6e3-78c37438d73b
+                    request_id: 49841146-91d2-4159-a5ef-f774a1c3314c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -675,7 +675,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e5c4c9d0-d26e-405b-a90d-0c385684a6ab
+                    request_id: 266b94d8-92e8-4853-ac8b-906e449e5e8a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -723,7 +723,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '69'
+                    id: '173'
                     object: article
                     deleted: true
               schema:
@@ -736,7 +736,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: afa061e8-aaca-48db-b99c-c978cc042725
+                    request_id: 8562f3de-c868-4e2d-b208-594bc8747369
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -750,7 +750,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 233572e4-de1c-4ee9-b34a-7cef15c3fefe
+                    request_id: 53f78a81-77e9-424b-9fb5-f5f550802fd2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -810,7 +810,7 @@ paths:
                     total_count: 1
                     data:
                       articles:
-                      - id: '73'
+                      - id: '177'
                         type: article
                         workspace_id: this_is_an_id50_that_should_be_at_least_4
                         parent_id:
@@ -819,10 +819,10 @@ paths:
                         title: Title 1
                         description: ''
                         body: ''
-                        author_id: 991267786
+                        author_id: 991270148
                         state: draft
-                        created_at: 1709226923
-                        updated_at: 1709226923
+                        created_at: 1709290237
+                        updated_at: 1709290237
                         url:
                       highlights: []
                     pages:
@@ -840,7 +840,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5800eb4a-b70a-4b7a-9bc3-d79f99423408
+                    request_id: f4b535e1-aed5-40cd-910d-1fc1ec8da49f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -871,27 +871,27 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '237'
+                    - id: '604'
                       workspace_id: this_is_an_id54_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-54/collection-17
                       order: 17
-                      created_at: 1709226924
-                      updated_at: 1709226924
+                      created_at: 1709290239
+                      updated_at: 1709290239
                       description: english collection description
                       icon: bookmark
                       parent_id:
-                      help_center_id: 129
-                    - id: '238'
+                      help_center_id: 300
+                    - id: '605'
                       workspace_id: this_is_an_id54_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-54/section-1
                       order: 1
-                      created_at: 1709226924
-                      updated_at: 1709226924
+                      created_at: 1709290239
+                      updated_at: 1709290239
                       description:
                       icon: bookmark
-                      parent_id: '237'
+                      parent_id: '604'
                       help_center_id:
                     total_count: 2
                     pages:
@@ -909,7 +909,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b0d7f7d1-2b95-4be1-9aa4-5c13e83f751d
+                    request_id: ec6d5588-bc01-4720-ac42-a05c9089937f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -934,17 +934,17 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '243'
+                    id: '610'
                     workspace_id: this_is_an_id58_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-58/
                     order: 1
-                    created_at: 1709226925
-                    updated_at: 1709226925
+                    created_at: 1709290240
+                    updated_at: 1709290240
                     description: ''
                     icon: book-bookmark
                     parent_id:
-                    help_center_id: 131
+                    help_center_id: 302
               schema:
                 "$ref": "#/components/schemas/collection"
         '400':
@@ -955,7 +955,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: db079605-c80d-495f-ad51-368ba8d74b71
+                    request_id: 409aaa2e-a883-4739-931f-40b5c3a68d61
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -969,7 +969,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3a46e9c6-4fce-42ce-b538-6be6bc70dd0d
+                    request_id: 5a94165d-40b8-4a92-a279-94445be4214d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1017,17 +1017,17 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '248'
+                    id: '615'
                     workspace_id: this_is_an_id64_that_should_be_at_least_4
                     name: English collection title
                     url: http://help-center.test/myapp-64/collection-22
                     order: 22
-                    created_at: 1709226926
-                    updated_at: 1709226926
+                    created_at: 1709290241
+                    updated_at: 1709290241
                     description: english collection description
                     icon: bookmark
                     parent_id:
-                    help_center_id: 134
+                    help_center_id: 305
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1038,7 +1038,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 298b0b45-1c54-4d82-9588-e76d13fa44c8
+                    request_id: 9c9d4465-973d-4545-8a66-5c976e7bec67
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1052,7 +1052,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2f59df93-190d-4f78-b29a-69443744359e
+                    request_id: c8d6929d-9a44-42ae-b3ff-816b7938baad
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1085,17 +1085,17 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '254'
+                    id: '621'
                     workspace_id: this_is_an_id70_that_should_be_at_least_4
                     name: Update collection name
                     url: http://help-center.test/myapp-70/collection-25
                     order: 25
-                    created_at: 1709226928
-                    updated_at: 1709226928
+                    created_at: 1709290242
+                    updated_at: 1709290243
                     description: english collection description
                     icon: folder
                     parent_id:
-                    help_center_id: 137
+                    help_center_id: 308
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1106,7 +1106,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: 42d88494-6121-4f3d-87ad-fa07652699e9
+                    request_id: b6574917-6d50-485c-bb87-042014877842
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1120,7 +1120,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2b2e328d-c578-4b4a-ba6e-7e52eed3566d
+                    request_id: fa56b9d8-2dd4-415b-8c60-82ebd62d1dc8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1167,7 +1167,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '260'
+                    id: '627'
                     object: collection
                     deleted: true
               schema:
@@ -1180,7 +1180,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: 0de03e48-d55b-4407-9d86-39f7011e4c4b
+                    request_id: b0fecdc6-0824-4160-b0fd-15aa46fe3f86
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1194,7 +1194,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3fe6e33b-4ef9-4654-bd84-3e17f99db7ac
+                    request_id: 2d51c381-fee5-4cb4-8907-afb0ca54d9f8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1228,10 +1228,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '143'
+                    id: '314'
                     workspace_id: this_is_an_id82_that_should_be_at_least_4
-                    created_at: 1709226931
-                    updated_at: 1709226931
+                    created_at: 1709290245
+                    updated_at: 1709290245
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1245,7 +1245,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 9f29c135-2a12-4116-9435-975257ba31c9
+                    request_id: 2ec5a58f-3166-47df-95d7-0f6e5f74f737
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1259,7 +1259,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2892f9e0-c6c4-4664-996b-584fb137f6ad
+                    request_id: afd513ac-a4b6-41c6-8867-0ba1eea443e2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1297,7 +1297,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f3217845-6263-4d7b-b742-16434e7d86cf
+                    request_id: e1504765-5cf7-4722-ab51-b75d477b2f1d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1330,12 +1330,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 65e0bbb76abd017f5e8b1c6b
+                    id: 65e1b30bba4d123be7716fcb
                     app_id: this_is_an_id105_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1709226935
-                    updated_at: 1709226935
+                    created_at: 1709290251
+                    updated_at: 1709290251
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1372,7 +1372,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dcd7cbd4-1546-4b8d-ba15-f3588cfa10e5
+                    request_id: d59cafa6-2074-4acd-8c7e-563eba3aeb74
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1470,12 +1470,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0bbb96abd017f5e8b1c73
+                      id: 65e1b30dba4d123be7716fd3
                       app_id: this_is_an_id111_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709226937
-                      created_at: 1709226937
-                      updated_at: 1709226937
+                      remote_created_at: 1709290253
+                      created_at: 1709290253
+                      updated_at: 1709290253
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -1504,7 +1504,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: fb2f8351-ed76-417d-b022-f33bc01239a8
+                    request_id: cdd320c1-0ea3-410d-b84d-e3f96d6e1baa
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1518,7 +1518,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 483c3a26-31d2-4daa-8b3f-749953bb6901
+                    request_id: 723f678a-7bb6-4bb8-af0d-691491b45d32
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1553,12 +1553,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0bbbb6abd017f5e8b1c7e
+                    id: 65e1b30fba4d123be7716fde
                     app_id: this_is_an_id117_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1709226939
-                    created_at: 1709226939
-                    updated_at: 1709226939
+                    remote_created_at: 1709290255
+                    created_at: 1709290255
+                    updated_at: 1709290255
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1580,7 +1580,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 8ff82e10-70f6-42f5-ab05-8d8a67e28d20
+                    request_id: c6406c6a-075a-4b81-92d9-d26f88ffd247
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1594,7 +1594,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1d70ab10-a77e-43ea-86d9-36d08e3a5499
+                    request_id: 3ea42b9d-2b81-4b4b-bcad-69479e9650ae
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1628,12 +1628,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0bbbd6abd017f5e8b1c88
+                    id: 65e1b311ba4d123be7716fe8
                     app_id: this_is_an_id123_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1709226941
-                    created_at: 1709226941
-                    updated_at: 1709226941
+                    remote_created_at: 1709290257
+                    created_at: 1709290257
+                    updated_at: 1709290257
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1655,7 +1655,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 4322e74e-b39d-4136-a97e-a29baf278888
+                    request_id: b5327623-4921-4396-b481-d18126ec66b6
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1669,7 +1669,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d442d667-428d-4330-af94-3b60e80f7795
+                    request_id: 3a003891-7ddf-451b-9ae6-b3fb1fa37b47
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1701,7 +1701,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 65e0bbbf6abd017f5e8b1c92
+                    id: 65e1b314ba4d123be7716ff2
                     object: company
                     deleted: true
               schema:
@@ -1714,7 +1714,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: ffab64b6-a268-42ba-9586-ccc02439f998
+                    request_id: a2a484f6-08be-48ca-b13d-8f4b3d8db039
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1728,7 +1728,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 12d7270f-48d1-4b2c-bcb5-bf7e84ab1e5d
+                    request_id: 56a7d6e7-dab0-484e-aa57-b6caa471159b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1780,7 +1780,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: b2cc006b-fc83-4624-b81b-e0f3de684c79
+                    request_id: e739854b-e718-401c-a449-ba562d181380
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1794,7 +1794,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2c063246-317e-4ec2-9ddd-f505794f474b
+                    request_id: bc751ef9-fd11-4325-82ee-f75ac5a7965d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1839,7 +1839,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: dd8f67bd-afa4-4a36-b569-8e8d5eb882f2
+                    request_id: 8b9f4735-5218-41e2-b151-f3ee03aa20ed
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1853,7 +1853,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 231946f0-3a12-41b3-8c68-0ab620046309
+                    request_id: a928f798-9340-4f3e-9de9-38513f21f775
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1910,12 +1910,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0bbc56abd017f5e8b1cae
+                      id: 65e1b319ba4d123be771700e
                       app_id: this_is_an_id147_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709226949
-                      created_at: 1709226949
-                      updated_at: 1709226949
+                      remote_created_at: 1709290265
+                      created_at: 1709290265
+                      updated_at: 1709290265
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -1944,7 +1944,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 18c2818c-a255-4c9c-aabd-8fd703dec8de
+                    request_id: d7f51099-ccb9-4b7d-ae1c-febb49ed6f0b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1996,12 +1996,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0bbc76abd017f5e8b1cb4
+                      id: 65e1b31bba4d123be7717014
                       app_id: this_is_an_id151_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709226951
-                      created_at: 1709226951
-                      updated_at: 1709226951
+                      remote_created_at: 1709290267
+                      created_at: 1709290267
+                      updated_at: 1709290267
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2015,7 +2015,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: c315e41c-bc6e-4ffa-a01d-fced6e340385
+                    scroll_param: e96e7e91-e6d8-4d78-9998-2af1f9057f03
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2026,7 +2026,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dd4fc69c-cba9-4f74-87e9-daba9ee9d642
+                    request_id: a9f593da-eb7c-4005-a77c-b42d62bf1c5c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2061,12 +2061,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0bbc86abd017f5e8b1cbd
+                    id: 65e1b31dba4d123be771701d
                     app_id: this_is_an_id155_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1709226952
-                    created_at: 1709226952
-                    updated_at: 1709226952
+                    remote_created_at: 1709290269
+                    created_at: 1709290269
+                    updated_at: 1709290269
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2088,7 +2088,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 42af9932-3ef1-4a2b-b32a-5ea4e386a11c
+                    request_id: 7411c8e1-1932-43bc-bb65-666b2573fa7c
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2102,7 +2102,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 426beab3-b15f-4f46-a2f0-7ccd0d999f74
+                    request_id: abd934e7-26cb-4d85-a65a-161313a8e047
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2116,7 +2116,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b9eee486-7a21-4635-b647-fc9e3f24323e
+                    request_id: 3cecde00-f57e-46d4-9fc1-e84325114984
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2139,7 +2139,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 65e0bbc86abd017f5e8b1cbd
+                  id: 65e1b31dba4d123be771701d
               bad_request:
                 summary: Bad Request
                 value:
@@ -2178,13 +2178,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 65e0bbce6abd017f5e8b1cde
+                      id: 65e1b323ba4d123be771703e
                       app_id: this_is_an_id171_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1709226958
-                      created_at: 1709226958
-                      updated_at: 1709226958
-                      last_request_at: 1709054158
+                      remote_created_at: 1709290275
+                      created_at: 1709290275
+                      updated_at: 1709290275
+                      last_request_at: 1709117475
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2213,7 +2213,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 9ae854be-0777-44c7-96f1-72dcd804ff2b
+                    request_id: 0c97a231-dbbc-4f98-80fd-ed7288bc54cf
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2227,7 +2227,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b16d43b7-09fc-4d24-bece-db20eb5b0bc6
+                    request_id: 52b6b916-3292-4a01-850d-fb0e86a55d22
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2270,12 +2270,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0bbcb6abd017f5e8b1ccd
+                    id: 65e1b320ba4d123be771702d
                     app_id: this_is_an_id163_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1709226955
-                    created_at: 1709226955
-                    updated_at: 1709226955
+                    remote_created_at: 1709290272
+                    created_at: 1709290272
+                    updated_at: 1709290273
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2297,14 +2297,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 3c81fe2f-3879-419a-9e74-345cde47f285
+                    request_id: 3dba589f-3ec0-454d-8c57-fbb1b61f9ca4
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 79d85fbb-2d0c-4f01-bad2-8b3ae5b1b9b1
+                    request_id: 2032a4e4-59e3-4dab-ad92-4deee350ee6a
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2318,7 +2318,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 36cc5ae9-85b4-4e07-b859-2ecbe43d7835
+                    request_id: bb4aa985-1a58-4861-a4bc-0a90f7607214
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2354,42 +2354,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '42'
-                      created_at: 1708622161
+                      id: '104'
+                      created_at: 1708685478
                       contact:
                         type: contact
-                        id: 65e0bbd06abd017f5e8b1ce9
+                        id: 65e1b325ba4d123be7717049
                       author:
                         type: admin
-                        id: '991267846'
+                        id: '991270208'
                         name: Ciaran101 Lee
                         email: admin101@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '41'
-                      created_at: 1708535761
+                      id: '103'
+                      created_at: 1708599078
                       contact:
                         type: contact
-                        id: 65e0bbd06abd017f5e8b1ce9
+                        id: 65e1b325ba4d123be7717049
                       author:
                         type: admin
-                        id: '991267846'
+                        id: '991270208'
                         name: Ciaran101 Lee
                         email: admin101@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '40'
-                      created_at: 1708535760
+                      id: '102'
+                      created_at: 1708599077
                       contact:
                         type: contact
-                        id: 65e0bbd06abd017f5e8b1ce9
+                        id: 65e1b325ba4d123be7717049
                       author:
                         type: admin
-                        id: '991267846'
+                        id: '991270208'
                         name: Ciaran101 Lee
                         email: admin101@email.com
                         away_mode_enabled: false
@@ -2412,7 +2412,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 38077aed-62a1-4a60-96c0-eb578d148810
+                    request_id: cd688282-27be-401f-949f-c5a91d60d91b
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2446,14 +2446,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '47'
-                    created_at: 1709226962
+                    id: '109'
+                    created_at: 1709290279
                     contact:
                       type: contact
-                      id: 65e0bbd26abd017f5e8b1ceb
+                      id: 65e1b327ba4d123be771704b
                     author:
                       type: admin
-                      id: '991267848'
+                      id: '991270210'
                       name: Ciaran103 Lee
                       email: admin103@email.com
                       away_mode_enabled: false
@@ -2469,14 +2469,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 5dbe456f-2486-45d2-96c7-e7d84dabe34b
+                    request_id: 5c8cbb27-3c51-4bab-b566-f88e8c39ae97
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 5c3ad6ff-06f7-400c-af20-a33f698092f5
+                    request_id: 070ff1e8-d8e5-43b9-a30e-ac58aebc6f07
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2506,20 +2506,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 65e0bbd26abd017f5e8b1ceb
-                  admin_id: 991267848
+                  contact_id: 65e1b327ba4d123be771704b
+                  admin_id: 991270210
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 65e0bbd26abd017f5e8b1cec
+                  contact_id: 65e1b327ba4d123be771704c
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991267850
+                  admin_id: 991270212
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -2552,10 +2552,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 65e0bbd36abd017f5e8b1cee
+                      id: 65e1b328ba4d123be771704e
                       name: segment
-                      created_at: 1709226963
-                      updated_at: 1709226963
+                      created_at: 1709290280
+                      updated_at: 1709290280
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -2567,7 +2567,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 70a7dbe4-1765-41c3-ba9e-2c2683e57491
+                    request_id: 530e2b47-e29a-4918-9b5a-a6de646f82cb
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2581,7 +2581,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 73f5de9f-7afa-465b-be6e-48d496783725
+                    request_id: 0e7396c4-cf48-4a22-8fd6-bd65d9b7a929
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2625,7 +2625,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '139'
+                      id: '367'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -2639,7 +2639,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '141'
+                      id: '369'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -2662,7 +2662,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: '05336519-b173-426e-9149-b9c4ce393b93'
+                    request_id: 79cb92a7-5477-4e58-bb32-78479dd30b7c
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2676,7 +2676,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 20be9888-0dd5-491c-80a1-d2954389b6b8
+                    request_id: e3bbae3c-ad30-40d7-b3f5-4f7683985e2f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2717,7 +2717,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '154'
+                    id: '382'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -2740,14 +2740,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 5bfae25f-6f16-4992-a3b4-38420d8e1788
+                    request_id: 3d15aab7-1bd4-4d1c-a499-01a43d156369
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 03e66990-170c-4c24-a102-e000c5ddbe57
+                    request_id: 0daa8d7d-9a91-4138-aa99-5d75f70f25d3
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -2761,7 +2761,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 85ffd93f-7faa-47ac-a54b-f28c26362434
+                    request_id: 50a84f78-513b-489e-9e68-16fc3c14e26b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2789,12 +2789,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 154
+                  id: 382
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 158
+                  id: 386
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -2840,7 +2840,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '170'
+                    id: '398'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -2863,14 +2863,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 03c585cb-61d2-4931-8bd8-4f08000b2939
+                    request_id: 83c394aa-fb4c-4ff3-bed9-df877a811dae
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 81b8da87-2f98-4ebf-8380-4837044e05c1
+                    request_id: 8b58fac0-01e2-41f5-9284-c781954ad25d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -2884,7 +2884,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 52a2943b-90f2-44cc-98a9-72bc0fe407b6
+                    request_id: '0990c874-5782-43e9-aab0-15479c8416d1'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2922,7 +2922,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '124'
+                      id: '312'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -2934,7 +2934,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: d041b380-4b49-48e4-a1f0-fdf743e0511f
+                    request_id: d7c06562-811c-4d69-8d07-9d192baa6522
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2948,7 +2948,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1a71f0e2-c633-4b0c-bd4e-bc88cbe820d7
+                    request_id: 644a103a-6870-44a0-839a-447177cd5563
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2983,7 +2983,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '125'
+                    id: '313'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -2995,14 +2995,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: cb0a23cc-1443-4cea-9c0d-5eaf6a72f39b
+                    request_id: b2e4f4a8-c5c1-44ce-9af2-4d2778c98be6
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 57525bdf-c16c-40ca-8e0c-68c65473c34d
+                    request_id: de74c3fe-2856-4848-8918-598b72a594b7
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3016,7 +3016,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 17afbc10-9009-4794-8a81-18a1490be630
+                    request_id: bcc8577d-7643-4ed0-9931-18e6ad246957
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3039,11 +3039,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 125
+                  id: 313
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 126
+                  id: 314
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3085,7 +3085,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '128'
+                    id: '316'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3097,14 +3097,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 74aa7a93-d182-4804-9c2e-476f2ecfbaf2
+                    request_id: 2e2b8ec5-c6b3-48e0-a23c-3055034c116b
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: d6be8014-e355-4d66-99c0-10a66389edf4
+                    request_id: 9747f4b1-b338-4c45-8c81-153079f9002f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3118,7 +3118,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4a7bd93e-0c34-413d-a8c3-8db6ce280ef2
+                    request_id: e0b404d5-dc3a-43df-8515-cef6e8091d99
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3152,7 +3152,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0bbe26abd017f5e8b1d05
+                    id: 65e1b335ba4d123be7717065
                     workspace_id: this_is_an_id237_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3167,9 +3167,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226978
-                    updated_at: 1709226978
-                    signed_up_at: 1709226978
+                    created_at: 1709290293
+                    updated_at: 1709290293
+                    signed_up_at: 1709290293
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3203,31 +3203,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe26abd017f5e8b1d05/tags"
+                      url: "/contacts/65e1b335ba4d123be7717065/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe26abd017f5e8b1d05/notes"
+                      url: "/contacts/65e1b335ba4d123be7717065/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe26abd017f5e8b1d05/companies"
+                      url: "/contacts/65e1b335ba4d123be7717065/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe26abd017f5e8b1d05/subscriptions"
+                      url: "/contacts/65e1b335ba4d123be7717065/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe26abd017f5e8b1d05/subscriptions"
+                      url: "/contacts/65e1b335ba4d123be7717065/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3246,7 +3246,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b6fb56ff-a28b-4595-a185-fb2444c254ad
+                    request_id: 1abb66de-ba45-48d1-abbf-9c10ae8ef029
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3291,7 +3291,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0bbe36abd017f5e8b1d06
+                    id: 65e1b336ba4d123be7717066
                     workspace_id: this_is_an_id241_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3306,9 +3306,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226979
-                    updated_at: 1709226979
-                    signed_up_at: 1709226979
+                    created_at: 1709290294
+                    updated_at: 1709290294
+                    signed_up_at: 1709290294
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3342,31 +3342,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe36abd017f5e8b1d06/tags"
+                      url: "/contacts/65e1b336ba4d123be7717066/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe36abd017f5e8b1d06/notes"
+                      url: "/contacts/65e1b336ba4d123be7717066/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe36abd017f5e8b1d06/companies"
+                      url: "/contacts/65e1b336ba4d123be7717066/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe36abd017f5e8b1d06/subscriptions"
+                      url: "/contacts/65e1b336ba4d123be7717066/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe36abd017f5e8b1d06/subscriptions"
+                      url: "/contacts/65e1b336ba4d123be7717066/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3385,7 +3385,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9108b733-05d3-45c9-9d60-451d0ee8450c
+                    request_id: ace91f2a-d710-4d89-ac13-56917fef61b1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3416,7 +3416,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0bbe46abd017f5e8b1d07
+                    id: 65e1b338ba4d123be7717067
                     external_id: '70'
                     type: contact
                     deleted: true
@@ -3430,7 +3430,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 39f90cee-d013-4270-bb7a-caa9197ff48c
+                    request_id: d4f980da-6637-4fec-bbfc-f2e1c9fd470c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3458,7 +3458,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0bbe66abd017f5e8b1d09
+                    id: 65e1b339ba4d123be7717069
                     workspace_id: this_is_an_id249_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3473,9 +3473,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226982
-                    updated_at: 1709226982
-                    signed_up_at: 1709226982
+                    created_at: 1709290297
+                    updated_at: 1709290297
+                    signed_up_at: 1709290297
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3509,31 +3509,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe66abd017f5e8b1d09/tags"
+                      url: "/contacts/65e1b339ba4d123be7717069/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe66abd017f5e8b1d09/notes"
+                      url: "/contacts/65e1b339ba4d123be7717069/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe66abd017f5e8b1d09/companies"
+                      url: "/contacts/65e1b339ba4d123be7717069/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe66abd017f5e8b1d09/subscriptions"
+                      url: "/contacts/65e1b339ba4d123be7717069/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbe66abd017f5e8b1d09/subscriptions"
+                      url: "/contacts/65e1b339ba4d123be7717069/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3552,7 +3552,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6e407882-9abb-4efc-b11c-46f87764c8f5
+                    request_id: 046c3986-86cc-4c68-8dcd-002a721a03b9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3567,8 +3567,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 65e0bbe66abd017f5e8b1d08
-                  into: 65e0bbe66abd017f5e8b1d09
+                  from: 65e1b339ba4d123be7717068
+                  into: 65e1b339ba4d123be7717069
   "/contacts/search":
     post:
       summary: Search contacts
@@ -3697,7 +3697,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: eefa42a6-876c-43db-af23-6a2e0d4ecb09
+                    request_id: 2326f1a0-71aa-417c-8dbe-d71e21261871
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3717,15 +3717,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: 65e0bbe86abd017f5e8b1d0c
+                      value: 65e1b33bba4d123be771706c
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: 65e0bbe86abd017f5e8b1d0c
+                        value: 65e1b33bba4d123be771706c
                       - field: id
                         operator: "="
-                        value: 65e0bbe86abd017f5e8b1d0c
+                        value: 65e1b33bba4d123be771706c
   "/contacts":
     get:
       summary: List all contacts
@@ -3764,7 +3764,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bd034244-574e-4c7e-b6d8-3a1cc3b847c4
+                    request_id: 8a85649f-55d9-4177-a4e8-0ffd047cf8da
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3790,7 +3790,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0bbea6abd017f5e8b1d0e
+                    id: 65e1b33eba4d123be771706e
                     workspace_id: this_is_an_id261_that_should_be_at_least_
                     external_id:
                     role: user
@@ -3805,8 +3805,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226986
-                    updated_at: 1709226986
+                    created_at: 1709290302
+                    updated_at: 1709290302
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -3841,31 +3841,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbea6abd017f5e8b1d0e/tags"
+                      url: "/contacts/65e1b33eba4d123be771706e/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbea6abd017f5e8b1d0e/notes"
+                      url: "/contacts/65e1b33eba4d123be771706e/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbea6abd017f5e8b1d0e/companies"
+                      url: "/contacts/65e1b33eba4d123be771706e/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbea6abd017f5e8b1d0e/subscriptions"
+                      url: "/contacts/65e1b33eba4d123be771706e/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bbea6abd017f5e8b1d0e/subscriptions"
+                      url: "/contacts/65e1b33eba4d123be771706e/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3884,7 +3884,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0b03115d-61f7-4bab-89e6-214baf716a01
+                    request_id: 1330dd14-50a0-4775-a1d0-9975d9fdbf36
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3928,7 +3928,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0bbeb6abd017f5e8b1d0f
+                    id: 65e1b33fba4d123be771706f
                     external_id: '70'
                     type: contact
                     archived: true
@@ -3961,7 +3961,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0bbec6abd017f5e8b1d10
+                    id: 65e1b340ba4d123be7717070
                     external_id: '70'
                     type: contact
                     archived: false
@@ -3997,7 +3997,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '130'
+                    id: '318'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4009,7 +4009,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 440b75c4-b905-47f6-99ad-a79ff5e70524
+                    request_id: c9248916-e516-4747-9f45-d17053897871
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4023,7 +4023,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9c73204a-1999-4d33-8d59-846a9c407324
+                    request_id: ee3de3e6-866e-4a3f-8d0e-74aab408aa9f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4052,13 +4052,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 130
-                  admin_id: 991267881
+                  id: 318
+                  admin_id: 991270243
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 131
-                  admin_id: 991267883
+                  id: 319
+                  admin_id: 991270245
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4096,7 +4096,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '133'
+                    id: '321'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4108,14 +4108,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: d85c0a71-73bb-4644-ace6-36a48e99adf7
+                    request_id: 4124dc16-2063-4c1b-a450-9b142407a65a
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 4a614343-ddd8-4ed7-96fe-01221306b6d7
+                    request_id: b08b3cee-b506-45b5-9ed5-0b3d5d010944
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4129,7 +4129,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9a8e7f98-8071-4cf9-978d-18fc7de8c072
+                    request_id: 35382cf8-31ba-4408-968f-49c2dce50a76
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4152,15 +4152,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991267885
+                  admin_id: 991270247
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991267887
+                  admin_id: 991270249
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991267888
+                  admin_id: 991270250
   "/conversations":
     get:
       summary: List all conversations
@@ -4207,20 +4207,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '423'
-                      created_at: 1709226995
-                      updated_at: 1709226995
+                      id: '1021'
+                      created_at: 1709290313
+                      updated_at: 1709290313
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918309'
+                        id: '403918656'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991267891'
+                          id: '991270253'
                           name: Ciaran143 Lee
                           email: admin143@email.com
                         attachments: []
@@ -4230,7 +4230,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0bbf36abd017f5e8b1d14
+                          id: 65e1b349ba4d123be7717074
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -4265,7 +4265,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fb96da81-a7dc-4311-b093-ae21599c775e
+                    request_id: bc60bb02-695d-485e-8cdd-e90459f53cd1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4279,7 +4279,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: b163b990-8d50-410b-813a-86773cb6683a
+                    request_id: aef229a6-5e16-4718-bdc9-20fb09274224
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4315,11 +4315,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918319'
-                    created_at: 1709227017
+                    id: '403918666'
+                    created_at: 1709290349
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '448'
+                    conversation_id: '1046'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -4330,7 +4330,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: dce90210-d88f-4c08-bb5d-647fc1406740
+                    request_id: 667068d1-f89d-4792-80bd-fa9af5412131
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -4344,7 +4344,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7134971d-e494-48a6-a4b5-a10117d6abe4
+                    request_id: 34609d82-8576-4c2f-bb2d-102fcd6ba027
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4358,7 +4358,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 984d350a-ddb3-469c-8e67-b70a571551be
+                    request_id: 02d3ab57-4099-4257-a1d5-f96d778e0716
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4375,7 +4375,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65e0bc086abd017f5e8b1d29
+                    id: 65e1b36bba4d123be7717089
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -4433,20 +4433,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '452'
-                    created_at: 1709227022
-                    updated_at: 1709227022
+                    id: '1050'
+                    created_at: 1709290358
+                    updated_at: 1709290358
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918323'
+                      id: '403918670'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267905'
+                        id: '991270267'
                         name: Ciaran150 Lee
                         email: admin150@email.com
                       attachments: []
@@ -4456,7 +4456,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc0d6abd017f5e8b1d2d
+                        id: 65e1b375ba4d123be771708d
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -4495,7 +4495,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: ff72c245-8adc-453b-a154-96cd4e6af4e6
+                    request_id: 8987843c-af8e-4c78-93f6-449a60236305
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4509,7 +4509,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 64544f40-1641-45b2-945e-12f554d7060a
+                    request_id: badebb0e-387b-4920-b078-1b45e3927dd5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4523,7 +4523,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: d0bf4d14-a8cc-435d-b9b6-7ea82fe39cd9
+                    request_id: a90f6500-62e7-4342-94da-3b5ec31e17bb
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4570,20 +4570,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '456'
-                    created_at: 1709227028
-                    updated_at: 1709227029
+                    id: '1054'
+                    created_at: 1709290367
+                    updated_at: 1709290369
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918327'
+                      id: '403918674'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267913'
+                        id: '991270275'
                         name: Ciaran154 Lee
                         email: admin154@email.com
                       attachments: []
@@ -4593,7 +4593,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc146abd017f5e8b1d31
+                        id: 65e1b37eba4d123be7717091
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -4624,15 +4624,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '93'
+                        id: '254'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709227029
-                        updated_at: 1709227029
-                        notified_at: 1709227029
+                        created_at: 1709290369
+                        updated_at: 1709290369
+                        notified_at: 1709290369
                         assigned_to:
                         author:
-                          id: '991267914'
+                          id: '991270276'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id305_that_should_be_at_least_@intercom.io
@@ -4640,15 +4640,15 @@ paths:
                         external_id:
                         redacted: false
                       - type: conversation_part
-                        id: '94'
+                        id: '255'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709227029
-                        updated_at: 1709227029
-                        notified_at: 1709227029
+                        created_at: 1709290369
+                        updated_at: 1709290369
+                        notified_at: 1709290369
                         assigned_to:
                         author:
-                          id: '991267914'
+                          id: '991270276'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id305_that_should_be_at_least_@intercom.io
@@ -4666,7 +4666,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 573eca45-e843-4b15-9f8b-2c32d116dca1
+                    request_id: fb7c73f1-d463-4b3c-a2df-e5872b2227d5
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4680,7 +4680,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 234cb124-841c-47a3-a6d3-379edf330b19
+                    request_id: 4558830e-7918-4683-a44a-0efbe67bcad7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4694,7 +4694,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 5b528481-8996-4dd1-9f0c-a4844ad20fb5
+                    request_id: 51d32e3d-d124-4e63-af72-c5f2eccb3d4a
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4749,57 +4749,57 @@ paths:
 
         Most keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `"foorbar"`).
 
-        | Field                                     | Type                                                                                     |
-        | :---------------------------------------- | :--------------------------------------------------------------------------------------- |
-        | id                                        | String                                                                                   |
-        | created_at                                | Date (UNIX timestamp)                                                                    |
-        | updated_at                                | Date (UNIX timestamp)                                                                    |
-        | source.type                               | String<br>Accepted fields are `conversation`, `push`, `facebook`, `twitter` and `email`. |
-        | source.id                                 | String                                                                                   |
-        | source.delivered_as                       | String                                                                                   |
-        | source.subject                            | String                                                                                   |
-        | source.body                               | String                                                                                   |
-        | source.author.id                          | String                                                                                   |
-        | source.author.type                        | String                                                                                   |
-        | source.author.name                        | String                                                                                   |
-        | source.author.email                       | String                                                                                   |
-        | source.url                                | String                                                                                   |
-        | contact_ids                               | String                                                                                   |
-        | teammate_ids                              | String                                                                                   |
-        | admin_assignee_id                         | String                                                                                   |
-        | team_assignee_id                          | String                                                                                   |
-        | channel_initiated                         | String                                                                                   |
-        | open                                      | Boolean                                                                                  |
-        | read                                      | Boolean                                                                                  |
-        | state                                     | String                                                                                   |
-        | waiting_since                             | Date (UNIX timestamp)                                                                    |
-        | snoozed_until                             | Date (UNIX timestamp)                                                                    |
-        | tag_ids                                   | String                                                                                   |
-        | priority                                  | String                                                                                   |
-        | statistics.time_to_assignment             | Integer                                                                                  |
-        | statistics.time_to_admin_reply            | Integer                                                                                  |
-        | statistics.time_to_first_close            | Integer                                                                                  |
-        | statistics.time_to_last_close             | Integer                                                                                  |
-        | statistics.median_time_to_reply           | Integer                                                                                  |
-        | statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                    |
-        | statistics.first_assignment_at            | Date (UNIX timestamp)                                                                    |
-        | statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                    |
-        | statistics.first_close_at                 | Date (UNIX timestamp)                                                                    |
-        | statistics.last_assignment_at             | Date (UNIX timestamp)                                                                    |
-        | statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                    |
-        | statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                    |
-        | statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                    |
-        | statistics.last_close_at                  | Date (UNIX timestamp)                                                                    |
-        | statistics.last_closed_by_id              | String                                                                                   |
-        | statistics.count_reopens                  | Integer                                                                                  |
-        | statistics.count_assignments              | Integer                                                                                  |
-        | statistics.count_conversation_parts       | Integer                                                                                  |
-        | conversation_rating.requested_at          | Date (UNIX timestamp)                                                                    |
-        | conversation_rating.replied_at            | Date (UNIX timestamp)                                                                    |
-        | conversation_rating.score                 | Integer                                                                                  |
-        | conversation_rating.remark                | String                                                                                   |
-        | conversation_rating.contact_id            | String                                                                                   |
-        | conversation_rating.admin_d               | String                                                                                   |
+        | Field                                     | Type                                                                                                                                                   |
+        | :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
+        | id                                        | String                                                                                                                                                 |
+        | created_at                                | Date (UNIX timestamp)                                                                                                                                  |
+        | updated_at                                | Date (UNIX timestamp)                                                                                                                                  |
+        | source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |
+        | source.id                                 | String                                                                                                                                                 |
+        | source.delivered_as                       | String                                                                                                                                                 |
+        | source.subject                            | String                                                                                                                                                 |
+        | source.body                               | String                                                                                                                                                 |
+        | source.author.id                          | String                                                                                                                                                 |
+        | source.author.type                        | String                                                                                                                                                 |
+        | source.author.name                        | String                                                                                                                                                 |
+        | source.author.email                       | String                                                                                                                                                 |
+        | source.url                                | String                                                                                                                                                 |
+        | contact_ids                               | String                                                                                                                                                 |
+        | teammate_ids                              | String                                                                                                                                                 |
+        | admin_assignee_id                         | String                                                                                                                                                 |
+        | team_assignee_id                          | String                                                                                                                                                 |
+        | channel_initiated                         | String                                                                                                                                                 |
+        | open                                      | Boolean                                                                                                                                                |
+        | read                                      | Boolean                                                                                                                                                |
+        | state                                     | String                                                                                                                                                 |
+        | waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |
+        | snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |
+        | tag_ids                                   | String                                                                                                                                                 |
+        | priority                                  | String                                                                                                                                                 |
+        | statistics.time_to_assignment             | Integer                                                                                                                                                |
+        | statistics.time_to_admin_reply            | Integer                                                                                                                                                |
+        | statistics.time_to_first_close            | Integer                                                                                                                                                |
+        | statistics.time_to_last_close             | Integer                                                                                                                                                |
+        | statistics.median_time_to_reply           | Integer                                                                                                                                                |
+        | statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_closed_by_id              | String                                                                                                                                                 |
+        | statistics.count_reopens                  | Integer                                                                                                                                                |
+        | statistics.count_assignments              | Integer                                                                                                                                                |
+        | statistics.count_conversation_parts       | Integer                                                                                                                                                |
+        | conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |
+        | conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | conversation_rating.score                 | Integer                                                                                                                                                |
+        | conversation_rating.remark                | String                                                                                                                                                 |
+        | conversation_rating.contact_id            | String                                                                                                                                                 |
+        | conversation_rating.admin_d               | String                                                                                                                                                 |
 
         ### Accepted Operators
 
@@ -4834,20 +4834,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '463'
-                      created_at: 1709227039
-                      updated_at: 1709227039
+                      id: '1061'
+                      created_at: 1709290385
+                      updated_at: 1709290385
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918334'
+                        id: '403918681'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991267943'
+                          id: '991270305'
                           name: Ciaran177 Lee
                           email: admin177@email.com
                         attachments: []
@@ -4857,7 +4857,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0bc1f6abd017f5e8b1d38
+                          id: 65e1b391ba4d123be7717098
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -4898,15 +4898,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '463'
+                      value: '1061'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '463'
+                        value: '1061'
                       - field: id
                         operator: "="
-                        value: '463'
+                        value: '1061'
   "/conversations/{id}/reply":
     post:
       summary: Reply to a conversation
@@ -4937,20 +4937,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '471'
-                    created_at: 1709227047
-                    updated_at: 1709227048
-                    waiting_since: 1709227048
+                    id: '1069'
+                    created_at: 1709290397
+                    updated_at: 1709290399
+                    waiting_since: 1709290399
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918337'
+                      id: '403918684'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267945'
+                        id: '991270307'
                         name: Ciaran178 Lee
                         email: admin178@email.com
                       attachments: []
@@ -4960,10 +4960,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc276abd017f5e8b1d3f
+                        id: 65e1b39dba4d123be771709f
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709227048
+                      created_at: 1709290399
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -4992,15 +4992,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '96'
+                        id: '257'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709227048
-                        updated_at: 1709227048
-                        notified_at: 1709227048
+                        created_at: 1709290399
+                        updated_at: 1709290399
+                        notified_at: 1709290399
                         assigned_to:
                         author:
-                          id: 65e0bc276abd017f5e8b1d3f
+                          id: 65e1b39dba4d123be771709f
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5011,20 +5011,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '472'
-                    created_at: 1709227049
-                    updated_at: 1709227050
+                    id: '1070'
+                    created_at: 1709290400
+                    updated_at: 1709290402
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918338'
+                      id: '403918685'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267947'
+                        id: '991270309'
                         name: Ciaran179 Lee
                         email: admin179@email.com
                       attachments: []
@@ -5034,7 +5034,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc296abd017f5e8b1d40
+                        id: 65e1b3a0ba4d123be77170a0
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5063,7 +5063,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '97'
+                        id: '258'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5078,12 +5078,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1709227050
-                        updated_at: 1709227050
-                        notified_at: 1709227050
+                        created_at: 1709290402
+                        updated_at: 1709290402
+                        notified_at: 1709290402
                         assigned_to:
                         author:
-                          id: '991267947'
+                          id: '991270309'
                           type: admin
                           name: Ciaran179 Lee
                           email: admin179@email.com
@@ -5094,20 +5094,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '474'
-                    created_at: 1709227052
-                    updated_at: 1709227053
-                    waiting_since: 1709227053
+                    id: '1072'
+                    created_at: 1709290405
+                    updated_at: 1709290406
+                    waiting_since: 1709290406
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918340'
+                      id: '403918687'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267951'
+                        id: '991270313'
                         name: Ciaran181 Lee
                         email: admin181@email.com
                       attachments: []
@@ -5117,10 +5117,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc2c6abd017f5e8b1d42
+                        id: 65e1b3a5ba4d123be77170a2
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709227053
+                      created_at: 1709290406
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5149,15 +5149,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '98'
+                        id: '259'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709227053
-                        updated_at: 1709227053
-                        notified_at: 1709227053
+                        created_at: 1709290406
+                        updated_at: 1709290406
+                        notified_at: 1709290406
                         assigned_to:
                         author:
-                          id: 65e0bc2c6abd017f5e8b1d42
+                          id: 65e1b3a5ba4d123be77170a2
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5175,7 +5175,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 9cd975bc-d2fd-4c81-873f-6903a1c29eb1
+                    request_id: 8ed8a13f-a4f8-4737-8ad9-ad120785b7f1
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5189,7 +5189,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b4336a2f-a35a-4075-94b8-f129b1a39a06
+                    request_id: 125ffe1c-05bc-4651-9df5-0a74e66e7d30
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5203,7 +5203,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: a4c20f07-a9c8-471b-8c30-eadd0db3e380
+                    request_id: 678aefdc-800e-4c8f-8ce0-57c2961bcbc8
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5220,14 +5220,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bc276abd017f5e8b1d3f
+                  intercom_user_id: 65e1b39dba4d123be771709f
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991267947
+                  admin_id: 991270309
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -5237,14 +5237,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bc2c6abd017f5e8b1d42
+                  intercom_user_id: 65e1b3a5ba4d123be77170a2
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bc2e6abd017f5e8b1d43
+                  intercom_user_id: 65e1b3a7ba4d123be77170a3
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -5279,20 +5279,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '478'
-                    created_at: 1709227058
-                    updated_at: 1709227059
+                    id: '1076'
+                    created_at: 1709290415
+                    updated_at: 1709290416
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918344'
+                      id: '403918691'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267959'
+                        id: '991270321'
                         name: Ciaran185 Lee
                         email: admin185@email.com
                       attachments: []
@@ -5302,7 +5302,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc326abd017f5e8b1d46
+                        id: 65e1b3aeba4d123be77170a6
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5331,15 +5331,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '99'
+                        id: '260'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1709227059
-                        updated_at: 1709227059
-                        notified_at: 1709227059
+                        created_at: 1709290416
+                        updated_at: 1709290416
+                        notified_at: 1709290416
                         assigned_to:
                         author:
-                          id: '991267959'
+                          id: '991270321'
                           type: admin
                           name: Ciaran185 Lee
                           email: admin185@email.com
@@ -5350,20 +5350,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '479'
-                    created_at: 1709227060
-                    updated_at: 1709227061
+                    id: '1077'
+                    created_at: 1709290417
+                    updated_at: 1709290419
                     waiting_since:
-                    snoozed_until: 1709230661
+                    snoozed_until: 1709294019
                     source:
                       type: conversation
-                      id: '403918345'
+                      id: '403918692'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267961'
+                        id: '991270323'
                         name: Ciaran186 Lee
                         email: admin186@email.com
                       attachments: []
@@ -5373,7 +5373,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc346abd017f5e8b1d47
+                        id: 65e1b3b1ba4d123be77170a7
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5402,15 +5402,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '100'
+                        id: '261'
                         part_type: snoozed
                         body:
-                        created_at: 1709227061
-                        updated_at: 1709227061
-                        notified_at: 1709227061
+                        created_at: 1709290419
+                        updated_at: 1709290419
+                        notified_at: 1709290419
                         assigned_to:
                         author:
-                          id: '991267961'
+                          id: '991270323'
                           type: admin
                           name: Ciaran186 Lee
                           email: admin186@email.com
@@ -5421,20 +5421,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '484'
-                    created_at: 1709227060
-                    updated_at: 1709227068
+                    id: '1082'
+                    created_at: 1709290418
+                    updated_at: 1709290432
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918346'
+                      id: '403918693'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267963'
+                        id: '991270325'
                         name: Ciaran187 Lee
                         email: admin187@email.com
                       attachments: []
@@ -5444,7 +5444,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc386abd017f5e8b1d4c
+                        id: 65e1b3b9ba4d123be77170ac
                         external_id: '74'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5473,15 +5473,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '102'
+                        id: '263'
                         part_type: open
                         body:
-                        created_at: 1709227068
-                        updated_at: 1709227068
-                        notified_at: 1709227068
+                        created_at: 1709290432
+                        updated_at: 1709290432
+                        notified_at: 1709290432
                         assigned_to:
                         author:
-                          id: '991267963'
+                          id: '991270325'
                           type: admin
                           name: Ciaran187 Lee
                           email: admin187@email.com
@@ -5492,20 +5492,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '488'
-                    created_at: 1709227069
-                    updated_at: 1709227070
+                    id: '1086'
+                    created_at: 1709290433
+                    updated_at: 1709290434
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918349'
+                      id: '403918696'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267965'
+                        id: '991270327'
                         name: Ciaran188 Lee
                         email: admin188@email.com
                       attachments: []
@@ -5515,10 +5515,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc3d6abd017f5e8b1d4f
+                        id: 65e1b3c1ba4d123be77170af
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267965
+                    admin_assignee_id: 991270327
                     team_assignee_id:
                     open: true
                     state: open
@@ -5544,17 +5544,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '103'
+                        id: '264'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1709227070
-                        updated_at: 1709227070
-                        notified_at: 1709227070
+                        created_at: 1709290434
+                        updated_at: 1709290434
+                        notified_at: 1709290434
                         assigned_to:
                           type: admin
-                          id: '991267965'
+                          id: '991270327'
                         author:
-                          id: '991267965'
+                          id: '991270327'
                           type: admin
                           name: Ciaran188 Lee
                           email: admin188@email.com
@@ -5572,7 +5572,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 1be29ddf-4e60-40dc-99d2-4f2333958a12
+                    request_id: d5c01a4d-6556-4c4d-a12d-ced2b1704dcb
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5586,7 +5586,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 33622903-93e1-476a-b011-81c72c9287e5
+                    request_id: 5690a73d-d88b-4332-a00f-f3c39dad6284
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5600,7 +5600,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 6a09f49a-d0ff-4c19-959d-098000a49cb5
+                    request_id: 740e0a1a-543d-494d-a2bd-e53a94794fd2
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5621,32 +5621,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991267959
+                  admin_id: 991270321
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991267961
-                  snoozed_until: 1709230661
+                  admin_id: 991270323
+                  snoozed_until: 1709294019
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991267963
+                  admin_id: 991270325
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991267965
-                  assignee_id: 991267965
+                  admin_id: 991270327
+                  assignee_id: 991270327
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991267967
+                  admin_id: 991270329
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -5677,20 +5677,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '492'
-                    created_at: 1709227075
-                    updated_at: 1709227076
+                    id: '1090'
+                    created_at: 1709290442
+                    updated_at: 1709290443
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918353'
+                      id: '403918700'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267973'
+                        id: '991270335'
                         name: Ciaran192 Lee
                         email: admin192@email.com
                       attachments: []
@@ -5700,7 +5700,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc436abd017f5e8b1d53
+                        id: 65e1b3c9ba4d123be77170b3
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5729,17 +5729,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '104'
+                        id: '265'
                         part_type: default_assignment
                         body:
-                        created_at: 1709227076
-                        updated_at: 1709227076
-                        notified_at: 1709227076
+                        created_at: 1709290443
+                        updated_at: 1709290443
+                        notified_at: 1709290443
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991267974'
+                          id: '991270336'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id346_that_should_be_at_least_@intercom.io
@@ -5757,7 +5757,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 5c62b90a-e006-4e71-85d3-c26ec1b50e21
+                    request_id: fce8685d-7e3f-4c65-a255-3aae1b7e96d7
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5771,7 +5771,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d97926b1-cc73-40fa-9da4-f1bb96ac37f0
+                    request_id: de748d6a-e651-4308-9e2f-95297eef513b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5785,7 +5785,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: c2b87f95-f601-4c36-8d6e-7c539dbcd29f
+                    request_id: b5f28c8b-c1e7-42fe-ba2f-3dda49c64acc
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5826,7 +5826,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65e0bc496abd017f5e8b1d57
+                      id: 65e1b3d3ba4d123be77170b7
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -5837,7 +5837,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: e6439b35-3b38-4798-bad3-7ac2c6818691
+                    request_id: aac5b42f-ded5-4e39-9fc2-598fa4c11493
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5851,7 +5851,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9acda9ff-5595-43f8-9152-661596b42580
+                    request_id: 2c1beadf-d8ff-4fb3-855c-5e246e544bc6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5865,7 +5865,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: baf954ef-4887-48b3-a293-e651902a31ab
+                    request_id: 9b22bbd1-01db-4244-9235-1a6c0306fe07
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5880,15 +5880,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991267981
+                  admin_id: 991270343
                   customer:
-                    intercom_user_id: 65e0bc496abd017f5e8b1d57
+                    intercom_user_id: 65e1b3d3ba4d123be77170b7
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991267983
+                  admin_id: 991270345
                   customer:
-                    intercom_user_id: 65e0bc4a6abd017f5e8b1d58
+                    intercom_user_id: 65e1b3d6ba4d123be77170b8
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -5931,7 +5931,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65e0bc556abd017f5e8b1d62
+                      id: 65e1b3e9ba4d123be77170c2
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -5942,14 +5942,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: d32e0065-d12a-4dc6-9800-771ad2ae4a76
+                    request_id: 06336d62-0fbf-4811-9594-e5561815a511
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 49d34e88-6ed8-4fe3-8031-ea0d64af717e
+                    request_id: 0575673b-3cf9-49b7-a333-3d1986485fb4
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -5963,7 +5963,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: cecd600e-6372-4669-b40b-38380c9640de
+                    request_id: 85300fb2-cc4a-484a-be4e-fdc816349d59
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -5977,7 +5977,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fcc64c1f-e463-4e1f-84ec-40cf102717df
+                    request_id: 7ad2991d-01d3-4d0a-bfbf-db67e85f0d27
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5991,7 +5991,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: c5e91558-d6c5-439d-92d5-7c6e4483f046
+                    request_id: e286b678-a483-49b6-9a60-9127016c192c
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6006,27 +6006,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991267989
+                  admin_id: 991270351
                   customer:
-                    intercom_user_id: 65e0bc4e6abd017f5e8b1d5b
+                    intercom_user_id: 65e1b3ddba4d123be77170bb
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991267991
+                  admin_id: 991270353
                   customer:
-                    intercom_user_id: 65e0bc566abd017f5e8b1d63
+                    intercom_user_id: 65e1b3ebba4d123be77170c3
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991267993
+                  admin_id: 991270355
                   customer:
-                    intercom_user_id: 65e0bc5d6abd017f5e8b1d6a
+                    intercom_user_id: 65e1b3f7ba4d123be77170ca
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991267995
+                  admin_id: 991270357
                   customer:
-                    intercom_user_id: 65e0bc646abd017f5e8b1d71
+                    intercom_user_id: 65e1b404ba4d123be77170d1
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6054,20 +6054,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '548'
-                    created_at: 1709227130
-                    updated_at: 1709227132
-                    waiting_since: 1709227131
+                    id: '1146'
+                    created_at: 1709290538
+                    updated_at: 1709290540
+                    waiting_since: 1709290539
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918379'
+                      id: '403918726'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268001'
+                        id: '991270363'
                         name: Ciaran206 Lee
                         email: admin206@email.com
                       attachments: []
@@ -6077,10 +6077,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc7a6abd017f5e8b1d86
+                        id: 65e1b429ba4d123be77170e6
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1709227131
+                      created_at: 1709290539
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6109,15 +6109,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '112'
+                        id: '273'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1709227131
-                        updated_at: 1709227132
-                        notified_at: 1709227131
+                        created_at: 1709290539
+                        updated_at: 1709290540
+                        notified_at: 1709290539
                         assigned_to:
                         author:
-                          id: 65e0bc7a6abd017f5e8b1d86
+                          id: 65e1b429ba4d123be77170e6
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6135,7 +6135,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: a766bcf8-478e-4c5f-81cc-a8d194376ce5
+                    request_id: c3174481-6f2e-49cc-b534-2fe723ec0907
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -6149,7 +6149,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6304270a-1297-400b-9df6-2d8dbb9e8b9a
+                    request_id: 5f9988b8-395b-4fa0-9d3b-53b23d728b80
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6165,8 +6165,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 548
-                  conversation_part_id: 112
+                  conversation_id: 1146
+                  conversation_part_id: 273
               not_found:
                 summary: Not found
                 value:
@@ -6201,20 +6201,20 @@ paths:
                 successful:
                   value:
                     type: ticket
-                    id: '551'
-                    ticket_id: '7'
+                    id: '1149'
+                    ticket_id: '58'
                     ticket_attributes: {}
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '72'
+                      id: '202'
                       name: my-ticket-type-1
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id380_that_should_be_at_least_
                       archived: false
-                      created_at: 1709227139
-                      updated_at: 1709227139
+                      created_at: 1709290550
+                      updated_at: 1709290550
                       is_internal: false
                       ticket_type_attributes:
                         type: list
@@ -6224,37 +6224,37 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bc806abd017f5e8b1d89
+                        id: 65e1b432ba4d123be77170e9
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709227136
-                    updated_at: 1709227139
+                    created_at: 1709290546
+                    updated_at: 1709290551
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '114'
+                        id: '275'
                         part_type: comment
                         body: "<p>Comment for message</p>"
-                        created_at: 1709227136
-                        updated_at: 1709227136
+                        created_at: 1709290546
+                        updated_at: 1709290546
                         author:
-                          id: 65e0bc806abd017f5e8b1d89
+                          id: 65e1b432ba4d123be77170e9
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '115'
+                        id: '276'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709227139
-                        updated_at: 1709227139
+                        created_at: 1709290551
+                        updated_at: 1709290551
                         author:
-                          id: '991268011'
+                          id: '991270373'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id380_that_should_be_at_least_@intercom.io
@@ -6279,7 +6279,7 @@ paths:
                 Bad request:
                   value:
                     type: error.list
-                    request_id: 49df80b5-797f-44aa-8758-fb3ab5565f88
+                    request_id: 59bf6aad-a6f6-492c-880b-5c30516a34ee
                     errors:
                     - code: parameter_invalid
                       message: Ticket type is not a customer ticket type
@@ -6294,11 +6294,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  ticket_type_id: '72'
+                  ticket_type_id: '202'
               bad_request:
                 summary: Bad request
                 value:
-                  ticket_type_id: '73'
+                  ticket_type_id: '203'
   "/data_attributes":
     get:
       summary: List all data attributes
@@ -6479,7 +6479,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 50
+                    - id: 115
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -6492,9 +6492,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991268028'
-                      created_at: 1709227146
-                      updated_at: 1709227146
+                      admin_id: '991270390'
+                      created_at: 1709290560
+                      updated_at: 1709290560
                       model: company
                     - type: data_attribute
                       name: id
@@ -6566,7 +6566,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1858f7bc-9b35-4569-bdd0-57c4c190be3e
+                    request_id: 4fe78a09-78bb-46f9-8a9b-ef738498b70a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6591,7 +6591,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 53
+                    id: 118
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -6602,9 +6602,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991268030'
-                    created_at: 1709227147
-                    updated_at: 1709227147
+                    admin_id: '991270392'
+                    created_at: 1709290562
+                    updated_at: 1709290562
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6616,7 +6616,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: b4191980-4b01-4088-837c-b3c0461e843d
+                    request_id: 67f9a6dc-a0c5-493b-a78b-0175f2c7e51e
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6624,7 +6624,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: 76de463d-66be-429b-982f-95be4d2998bd
+                    request_id: 516881f0-1fae-4d1f-ae61-25b0c00c4a92
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -6632,7 +6632,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: 733a9ffa-251a-4d0c-b883-a5f455c273d1
+                    request_id: 68c67494-861e-4afa-bddc-84ae67078f89
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6640,14 +6640,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: 3d91b7ea-98b1-4216-a06e-341fe23a80e5
+                    request_id: d6c770ce-5b5c-4fcd-a6d3-1fe2fb499242
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: 2c4a99d4-9755-4946-ac67-51da9e7471ac
+                    request_id: 31be1957-a1a2-485b-bc12-8d6313fef825
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -6662,7 +6662,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 91f3a31a-d634-46f5-b3bd-bd325bdf00d9
+                    request_id: debc42b6-f6c4-482d-b3e3-c4b09c8588f0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6741,7 +6741,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 60
+                    id: 125
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -6756,9 +6756,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991268037'
-                    created_at: 1709227150
-                    updated_at: 1709227150
+                    admin_id: '991270399'
+                    created_at: 1709290565
+                    updated_at: 1709290565
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6770,7 +6770,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: 4c7a16ae-05a4-47c1-a836-e0b15b412586
+                    request_id: 8d1f8aa2-2f1f-4954-8196-f3f597081cae
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -6784,7 +6784,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: b0c9b7cf-3528-49c4-bb0e-758f9a6b6438
+                    request_id: 7ac5f521-c159-4bef-b874-30bac536dfb7
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -6798,7 +6798,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: e10959e3-fa38-44fc-9e1a-1ec0b4fd0faa
+                    request_id: 8adecd1a-4e52-4af0-aeeb-8839243f43d0
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -6813,7 +6813,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6b1d6846-f634-4c9a-a657-12ef3030ee26
+                    request_id: 4c2040cf-fd2d-4eea-ba8b-17c050d9e195
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6918,7 +6918,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4943fdff-2a08-434f-9bc3-a3d621379eef
+                    request_id: 7a8e8d74-311e-420b-aebb-38b87e9d393b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7005,7 +7005,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 65e0bc936abd017f5e8b1d8f
+                    intercom_user_id: 65e1b44aba4d123be77170ef
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -7017,7 +7017,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ef0e8bfc-9a47-4866-8653-111224e8d603
+                    request_id: 88fb6ddb-4018-497d-9ef1-2f3877cd50eb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7048,7 +7048,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b1c0cdd0-615d-441b-bf73-1767517ef966
+                    request_id: 4ae6b604-5013-4eb0-803d-f5ec936383b2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7092,7 +7092,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: esyqm003bj18c28i
+                    job_identifier: 99en9by788j1eeu7
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7107,8 +7107,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1709209157
-                  created_at_before: 1709227157
+                  created_at_after: 1709272572
+                  created_at_before: 1709290572
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -7142,7 +7142,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: 5vqtmyiobty6dfyy
+                    job_identifier: 4j840yy7okidtp5n
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7174,7 +7174,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: 91qnzmx1wib1t5q3
+                    job_identifier: xsy79gm0uw83bqt4
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -7235,30 +7235,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918384'
-                    created_at: 1709227160
+                    id: '403918731'
+                    created_at: 1709290575
                     body: heyy
                     message_type: inapp
-                    conversation_id: '553'
+                    conversation_id: '1151'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918385'
-                    created_at: 1709227161
+                    id: '403918732'
+                    created_at: 1709290576
                     body: heyy
                     message_type: inapp
-                    conversation_id: '554'
+                    conversation_id: '1152'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '20'
-                    created_at: 1709227162
+                    id: '40'
+                    created_at: 1709290577
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991268060'
+                      id: '991270422'
                       name: Ciaran258 Lee
                       email: admin258@email.com
                       away_mode_enabled: false
@@ -7273,14 +7273,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: e652929a-0604-43d6-90b0-155c335a0c69
+                    request_id: ba294322-00ec-4338-b180-735a080d40c9
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: 3cd97535-5ebe-4002-97f1-529df56a55ba
+                    request_id: 3e5fb96c-5e4f-48f0-9e3b-821e6c819963
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -7294,7 +7294,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: e16bac74-8abc-431e-82ac-302989e2f014
+                    request_id: 56387377-f461-4442-af6f-40bb9f184dc5
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -7308,7 +7308,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f260b9ad-57f0-40c1-bef6-3e60fd92c9af
+                    request_id: 61f5d0a7-3c74-4546-a272-3b675ecc1735
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7322,7 +7322,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 1f4cc0b9-b494-406b-8017-97f9bdd41bd9
+                    request_id: '0081408d-790c-4f2e-9723-7d215b7c5249'
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -7339,7 +7339,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65e0bc976abd017f5e8b1d94
+                    id: 65e1b44fba4d123be77170f4
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -7347,7 +7347,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 65e0bc986abd017f5e8b1d95
+                    id: 65e1b450ba4d123be77170f5
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -7355,10 +7355,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268060'
+                    id: '991270422'
                   to:
                     type: user
-                    id: 65e0bc9a6abd017f5e8b1d96
+                    id: 65e1b451ba4d123be77170f6
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -7366,10 +7366,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268062'
+                    id: '991270424'
                   to:
                     type: user
-                    id: 65e0bc9a6abd017f5e8b1d97
+                    id: 65e1b452ba4d123be77170f7
                   message_type: inapp
                   body:
                   subject: heyy
@@ -7378,7 +7378,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268063'
+                    id: '991270425'
                   to:
                     type: user
                     user_id: '70'
@@ -7389,10 +7389,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268064'
+                    id: '991270426'
                   to:
                     type: user
-                    id: 65e0bc9b6abd017f5e8b1d99
+                    id: 65e1b453ba4d123be77170f9
                   message_type: email
                   body:
                   subject: heyy
@@ -7423,12 +7423,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '43'
+                    - id: '99'
                       type: news-item
                       workspace_id: this_is_an_id470_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991268069
+                      sender_id: 991270431
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7438,15 +7438,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709227165
-                      updated_at: 1709227165
+                      created_at: 1709290581
+                      updated_at: 1709290581
                       newsfeed_assignments: []
-                    - id: '44'
+                    - id: '100'
                       type: news-item
                       workspace_id: this_is_an_id470_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991268071
+                      sender_id: 991270433
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7456,8 +7456,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709227165
-                      updated_at: 1709227165
+                      created_at: 1709290581
+                      updated_at: 1709290581
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -7470,7 +7470,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 23c4180d-329e-49c6-8ca0-3ae2f8f658cf
+                    request_id: c788b480-7605-498c-84fd-81f96e2b1186
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7495,12 +7495,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '47'
+                    id: '103'
                     type: news-item
                     workspace_id: this_is_an_id474_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991268078
+                    sender_id: 991270440
                     state: live
                     labels:
                     - New
@@ -7511,10 +7511,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1709227167
-                    updated_at: 1709227167
+                    created_at: 1709290583
+                    updated_at: 1709290583
                     newsfeed_assignments:
-                    - newsfeed_id: 78
+                    - newsfeed_id: 178
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7526,7 +7526,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1901475c-da26-4915-8d03-bbf34f5011e1
+                    request_id: 76d713ee-338d-4fab-ada1-fef42617f722
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7547,14 +7547,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991268078
+                  sender_id: 991270440
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 78
+                  - newsfeed_id: 178
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -7583,12 +7583,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '48'
+                    id: '104'
                     type: news-item
                     workspace_id: this_is_an_id478_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991268081
+                    sender_id: 991270443
                     state: live
                     labels: []
                     cover_image_url:
@@ -7598,11 +7598,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1709227168
-                    updated_at: 1709227168
+                    created_at: 1709290585
+                    updated_at: 1709290585
                     newsfeed_assignments:
-                    - newsfeed_id: 80
-                      published_at: 1709227168
+                    - newsfeed_id: 180
+                      published_at: 1709290585
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -7613,7 +7613,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: fb1337ec-c776-4715-8648-86fd1cc0666b
+                    request_id: 74e06e88-e68f-4a92-8047-3eb275cfc590
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7627,7 +7627,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8bb53ae3-0cdc-4378-a87e-3372ee69f1f0
+                    request_id: 6ea1d533-f0ec-4416-88c9-35842b9426b7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7658,12 +7658,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '51'
+                    id: '107'
                     type: news-item
                     workspace_id: this_is_an_id484_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991268089
+                    sender_id: 991270451
                     state: live
                     labels: []
                     cover_image_url:
@@ -7671,8 +7671,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1709227170
-                    updated_at: 1709227170
+                    created_at: 1709290587
+                    updated_at: 1709290587
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7684,7 +7684,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: d4f45ee7-e098-4766-ab6b-3e83891a4a03
+                    request_id: 993c7067-519f-474d-8765-b4e331beba61
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7698,7 +7698,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: de3b7aa7-79d7-493a-b62c-283ac07de5c9
+                    request_id: 0e53385b-7ca1-4374-ae6c-c34998d2d4d9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7715,7 +7715,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991268089
+                  sender_id: 991270451
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7724,7 +7724,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991268092
+                  sender_id: 991270454
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7754,7 +7754,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '54'
+                    id: '110'
                     object: news-item
                     deleted: true
               schema:
@@ -7767,7 +7767,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: fdca9c26-5421-4a1f-8bf6-dfc65aabf1a9
+                    request_id: 57e3920d-a20f-45fb-b133-c25f3873adaa
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7781,7 +7781,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c9d3e6b5-e490-4ebc-b42a-ae8bcf9dde04
+                    request_id: f24c3805-8b2d-4c8a-8bcd-a7cb24989a54
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7834,7 +7834,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5ffe384e-95b7-4b76-937f-5e877b75e9ce
+                    request_id: c20cc7e5-c181-4362-b8a8-0dc8ce4e6bb7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7867,16 +7867,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '93'
+                    - id: '193'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709227175
-                      updated_at: 1709227175
-                    - id: '94'
+                      created_at: 1709290593
+                      updated_at: 1709290593
+                    - id: '194'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709227175
-                      updated_at: 1709227175
+                      created_at: 1709290593
+                      updated_at: 1709290593
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -7888,7 +7888,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2ed4631c-c291-4d38-afd0-079ed2e1205a
+                    request_id: d91accd0-7a1b-4cf8-9118-aabb1e506f3a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7922,11 +7922,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '97'
+                    id: '197'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1709227176
-                    updated_at: 1709227176
+                    created_at: 1709290594
+                    updated_at: 1709290594
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -7937,7 +7937,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f2fc2a2f-b952-43c0-bb0f-b90175453c94
+                    request_id: 13289821-d7cc-4a62-acae-94b3b6ad6426
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7971,14 +7971,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '50'
-                    created_at: 1708535977
+                    id: '112'
+                    created_at: 1708599395
                     contact:
                       type: contact
-                      id: 65e0bca96abd017f5e8b1d9c
+                      id: 65e1b463ba4d123be77170fc
                     author:
                       type: admin
-                      id: '991268108'
+                      id: '991270470'
                       name: Ciaran305 Lee
                       email: admin305@email.com
                       away_mode_enabled: false
@@ -7994,7 +7994,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: cc73a727-65fc-4ae7-b8cc-9f41f1af4b6a
+                    request_id: a3bccedb-79c0-44f2-902c-64b2f75f50a8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8008,7 +8008,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 06ff4266-c527-4313-899a-7f611913f5df
+                    request_id: 6f64e144-0f9c-49b7-a1d9-d51fc018bc2d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8044,16 +8044,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 65e0bcaa6abd017f5e8b1d9f
+                      id: 65e1b464ba4d123be77170ff
                       name: John segment
-                      created_at: 1709227178
-                      updated_at: 1709227178
+                      created_at: 1709290596
+                      updated_at: 1709290596
                       person_type: user
                     - type: segment
-                      id: 65e0bcaa6abd017f5e8b1da0
+                      id: 65e1b464ba4d123be7717100
                       name: Jane segment
-                      created_at: 1709227178
-                      updated_at: 1709227178
+                      created_at: 1709290596
+                      updated_at: 1709290596
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -8065,7 +8065,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: abd6fe52-3e86-4f29-9bfb-7e9d70e60970
+                    request_id: 9b174a8f-b072-4f2e-a035-e70bec4129f2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8099,10 +8099,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 65e0bcab6abd017f5e8b1da3
+                    id: 65e1b465ba4d123be7717103
                     name: John segment
-                    created_at: 1709227179
-                    updated_at: 1709227179
+                    created_at: 1709290597
+                    updated_at: 1709290597
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -8114,7 +8114,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: 0b62c8d2-61e3-4517-b2ad-3a6134e76d29
+                    request_id: d6afbb51-f0bf-4062-8e65-12cb7eab5ddb
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8128,7 +8128,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9f42ef01-58d8-4d5c-8a7e-c164efc14fb5
+                    request_id: 5c0d3c58-f3e7-4c86-8659-a8ad0c433298
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8158,7 +8158,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '183'
+                      id: '411'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -8181,7 +8181,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4d6c1cc7-8955-4dbc-b92a-fd2d5a4200c9
+                    request_id: 1902e797-5ece-40c8-a84a-672f97247912
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8211,7 +8211,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/5ce7a322-e2cf-456b-a809-dd3bf7cb85d9
+                    url: http://via.intercom.io/msgr/522aa45e-29cb-4210-8246-10d2f532bbbe
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -8244,7 +8244,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b72d1a91-b2d5-458c-97e2-1ff8d7223d56
+                    request_id: 2b34f3fd-e39f-402c-859f-550fa92ebd97
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8307,7 +8307,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '146'
+                      id: '334'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -8319,7 +8319,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 669e9942-5f07-41f6-b64f-1b4055a5804e
+                    request_id: 9e66b0b7-01d4-439e-869e-681335129a01
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8358,7 +8358,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '149'
+                    id: '337'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8370,7 +8370,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: 815a79e2-0216-4b86-bad3-5cca932278f2
+                    request_id: c65cb583-8ffa-4cbe-bd22-bfd22a5c0f43
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -8384,14 +8384,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: b74ebdda-5c0e-41f6-988e-7a716a3af3c3
+                    request_id: 3ece5764-2dcb-47a2-9b06-8290fb76e7fb
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: 1f4895e6-11db-4893-aecc-8ce2bdfe4f44
+                    request_id: 66cd6f5a-f2f5-4fb9-a998-e6412afcbefa
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -8405,7 +8405,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8afe5491-588d-4296-99ca-7f3b33fb5b26
+                    request_id: 023035d4-d1bc-41a2-9b22-b47e37d4ebf8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8471,7 +8471,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '157'
+                    id: '345'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8483,7 +8483,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: bd2d2a80-d811-4745-b78b-716ab9996401
+                    request_id: 8dc00924-ba6a-4b13-b0c1-f5caea530406
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8497,7 +8497,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ac8ebc44-e11f-4bc8-bcdc-d832fe7b78f8
+                    request_id: 9b9718d4-76b0-49dc-9f7f-83911533d810
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8533,7 +8533,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: c6631264-a63e-4dcb-8845-60655a47195e
+                    request_id: cfae5bff-fcb9-4c04-91e0-f796e3dd2b7c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8547,7 +8547,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: 15ba1e69-1f84-45c0-afa7-ca9dbe29affc
+                    request_id: 82204e85-0f7b-40ff-9722-5f9614df1602
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -8562,7 +8562,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 61fd329f-a9b4-4d95-8541-064eb2fb68a1
+                    request_id: 89910c94-930d-455b-950e-0810054bec34
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8600,7 +8600,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 69427588-5cc7-44e5-8961-a65fccc09460
+                    request_id: 9524522a-e806-4895-8375-8fa91c3919ae
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8635,7 +8635,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991268146'
+                    id: '991270508'
                     name: team 1
                     admin_ids: []
               schema:
@@ -8648,7 +8648,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: e90496ca-c9f4-4627-b79f-4a0ee4cd1161
+                    request_id: 87a5aef8-fd58-432f-9f7a-0870a9ca2ce9
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -8662,7 +8662,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9ceac5bd-03f4-4cad-b17f-53cbb416ad4f
+                    request_id: a16b64a5-7297-4da4-90b1-918194693fb9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8695,7 +8695,7 @@ paths:
                 Ticket Type Attribute created:
                   value:
                     type: ticket_type_attribute
-                    id: '235'
+                    id: '561'
                     workspace_id: this_is_an_id576_that_should_be_at_least_
                     name: Attribute Title
                     description: Attribute Description
@@ -8708,10 +8708,10 @@ paths:
                     visible_on_create: true
                     visible_to_contacts: true
                     default: false
-                    ticket_type_id: 74
+                    ticket_type_id: 204
                     archived: false
-                    created_at: 1709227196
-                    updated_at: 1709227196
+                    created_at: 1709290617
+                    updated_at: 1709290617
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -8722,7 +8722,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d74228d8-c3a6-4bd6-9ea8-3597fb23f29e
+                    request_id: 0b56d8f2-705b-4b26-9d89-bfe3fa339051
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8775,7 +8775,7 @@ paths:
                 Ticket Type Attribute updated:
                   value:
                     type: ticket_type_attribute
-                    id: '240'
+                    id: '566'
                     workspace_id: this_is_an_id580_that_should_be_at_least_
                     name: name
                     description: New Attribute Description
@@ -8786,10 +8786,10 @@ paths:
                     visible_on_create: false
                     visible_to_contacts: false
                     default: false
-                    ticket_type_id: 76
+                    ticket_type_id: 206
                     archived: false
-                    created_at: 1709227197
-                    updated_at: 1709227198
+                    created_at: 1709290618
+                    updated_at: 1709290618
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -8800,7 +8800,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7b5405e3-31b2-4c53-bba6-b485b60d8e04
+                    request_id: 01f4ce2b-e09f-4640-94b7-cfe6855ac14f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8839,20 +8839,20 @@ paths:
                     type: list
                     data:
                     - type: ticket_type
-                      id: '78'
+                      id: '208'
                       name: Bug Report
                       description: Bug Report Template
                       icon: "\U0001F39F️"
                       workspace_id: this_is_an_id584_that_should_be_at_least_
                       archived: false
-                      created_at: 1709227198
-                      updated_at: 1709227198
+                      created_at: 1709290619
+                      updated_at: 1709290619
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '243'
+                          id: '569'
                           workspace_id: this_is_an_id584_that_should_be_at_least_
                           name: _default_title_
                           description: ''
@@ -8865,12 +8865,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 78
+                          ticket_type_id: 208
                           archived: false
-                          created_at: 1709227198
-                          updated_at: 1709227198
+                          created_at: 1709290619
+                          updated_at: 1709290619
                         - type: ticket_type_attribute
-                          id: '245'
+                          id: '571'
                           workspace_id: this_is_an_id584_that_should_be_at_least_
                           name: name
                           description: description
@@ -8882,12 +8882,12 @@ paths:
                           visible_on_create: false
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 78
+                          ticket_type_id: 208
                           archived: false
-                          created_at: 1709227198
-                          updated_at: 1709227198
+                          created_at: 1709290619
+                          updated_at: 1709290619
                         - type: ticket_type_attribute
-                          id: '244'
+                          id: '570'
                           workspace_id: this_is_an_id584_that_should_be_at_least_
                           name: _default_description_
                           description: ''
@@ -8900,10 +8900,10 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 78
+                          ticket_type_id: 208
                           archived: false
-                          created_at: 1709227198
-                          updated_at: 1709227198
+                          created_at: 1709290619
+                          updated_at: 1709290619
                       category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type_list"
@@ -8915,7 +8915,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 66f97eb1-3833-43ac-bc87-dd342090032a
+                    request_id: 78f73a28-1bb3-4b6f-8b08-0b1c7d7a20ff
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8944,20 +8944,20 @@ paths:
                 Ticket type created:
                   value:
                     type: ticket_type
-                    id: '81'
+                    id: '211'
                     name: Customer Issue
                     description: Customer Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id588_that_should_be_at_least_
                     archived: false
-                    created_at: 1709227200
-                    updated_at: 1709227200
+                    created_at: 1709290621
+                    updated_at: 1709290621
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '252'
+                        id: '578'
                         workspace_id: this_is_an_id588_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -8970,12 +8970,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 81
+                        ticket_type_id: 211
                         archived: false
-                        created_at: 1709227200
-                        updated_at: 1709227200
+                        created_at: 1709290621
+                        updated_at: 1709290621
                       - type: ticket_type_attribute
-                        id: '253'
+                        id: '579'
                         workspace_id: this_is_an_id588_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -8988,10 +8988,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 81
+                        ticket_type_id: 211
                         archived: false
-                        created_at: 1709227200
-                        updated_at: 1709227200
+                        created_at: 1709290621
+                        updated_at: 1709290621
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -9003,7 +9003,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3a24b627-c80d-410a-a09e-c3d7f953f712
+                    request_id: 18c08640-4f1b-410e-8dfa-474f5a9f94b0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9049,20 +9049,20 @@ paths:
                 Ticket type found:
                   value:
                     type: ticket_type
-                    id: '83'
+                    id: '213'
                     name: Bug Report
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id592_that_should_be_at_least_
                     archived: false
-                    created_at: 1709227201
-                    updated_at: 1709227201
+                    created_at: 1709290621
+                    updated_at: 1709290621
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '257'
+                        id: '583'
                         workspace_id: this_is_an_id592_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -9075,12 +9075,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 83
+                        ticket_type_id: 213
                         archived: false
-                        created_at: 1709227201
-                        updated_at: 1709227201
+                        created_at: 1709290621
+                        updated_at: 1709290621
                       - type: ticket_type_attribute
-                        id: '259'
+                        id: '585'
                         workspace_id: this_is_an_id592_that_should_be_at_least_
                         name: name
                         description: description
@@ -9092,12 +9092,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 83
+                        ticket_type_id: 213
                         archived: false
-                        created_at: 1709227201
-                        updated_at: 1709227201
+                        created_at: 1709290622
+                        updated_at: 1709290622
                       - type: ticket_type_attribute
-                        id: '258'
+                        id: '584'
                         workspace_id: this_is_an_id592_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -9110,10 +9110,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 83
+                        ticket_type_id: 213
                         archived: false
-                        created_at: 1709227201
-                        updated_at: 1709227201
+                        created_at: 1709290621
+                        updated_at: 1709290621
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -9125,7 +9125,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bc86862e-ee87-406d-9e4b-f71a615beb76
+                    request_id: 36513ba5-a0f1-46b0-86bc-fbda9570e87c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9158,20 +9158,20 @@ paths:
                 Ticket type updated:
                   value:
                     type: ticket_type
-                    id: '85'
+                    id: '215'
                     name: Bug Report 2
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id596_that_should_be_at_least_
                     archived: false
-                    created_at: 1709227202
-                    updated_at: 1709227203
+                    created_at: 1709290623
+                    updated_at: 1709290623
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '263'
+                        id: '589'
                         workspace_id: this_is_an_id596_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -9184,12 +9184,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 85
+                        ticket_type_id: 215
                         archived: false
-                        created_at: 1709227202
-                        updated_at: 1709227202
+                        created_at: 1709290623
+                        updated_at: 1709290623
                       - type: ticket_type_attribute
-                        id: '265'
+                        id: '591'
                         workspace_id: this_is_an_id596_that_should_be_at_least_
                         name: name
                         description: description
@@ -9201,12 +9201,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 85
+                        ticket_type_id: 215
                         archived: false
-                        created_at: 1709227202
-                        updated_at: 1709227202
+                        created_at: 1709290623
+                        updated_at: 1709290623
                       - type: ticket_type_attribute
-                        id: '264'
+                        id: '590'
                         workspace_id: this_is_an_id596_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -9219,10 +9219,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 85
+                        ticket_type_id: 215
                         archived: false
-                        created_at: 1709227202
-                        updated_at: 1709227202
+                        created_at: 1709290623
+                        updated_at: 1709290623
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -9234,7 +9234,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ecd1ad0d-5292-4551-a1cf-f3ea0d030e9f
+                    request_id: 4d171807-9248-43d8-9491-ddfb8385518b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9280,13 +9280,13 @@ paths:
                 User reply:
                   value:
                     type: ticket_part
-                    id: '118'
+                    id: '279'
                     part_type: comment
                     body: "<p>Thanks again :)</p>"
-                    created_at: 1709227205
-                    updated_at: 1709227205
+                    created_at: 1709290627
+                    updated_at: 1709290627
                     author:
-                      id: 65e0bcc56abd017f5e8b1dc6
+                      id: 65e1b482ba4d123be7717126
                       type: user
                       name:
                       email: user30@email.com
@@ -9295,7 +9295,7 @@ paths:
                 Admin note reply:
                   value:
                     type: ticket_part
-                    id: '120'
+                    id: '281'
                     part_type: note
                     body: |-
                       <h2>An Unordered HTML List</h2>
@@ -9310,10 +9310,10 @@ paths:
                       <li>Tea</li>
                       <li>Milk</li>
                       </ol>
-                    created_at: 1709227207
-                    updated_at: 1709227207
+                    created_at: 1709290631
+                    updated_at: 1709290631
                     author:
-                      id: '991268173'
+                      id: '991270535'
                       type: admin
                       name: Ciaran364 Lee
                       email: admin364@email.com
@@ -9322,12 +9322,12 @@ paths:
                 Admin quick_reply reply:
                   value:
                     type: ticket_part
-                    id: '122'
+                    id: '283'
                     part_type: quick_reply
-                    created_at: 1709227210
-                    updated_at: 1709227210
+                    created_at: 1709290634
+                    updated_at: 1709290634
                     author:
-                      id: '991268178'
+                      id: '991270540'
                       type: admin
                       name: Ciaran368 Lee
                       email: admin368@email.com
@@ -9343,7 +9343,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 05a4c8fc-882c-4c6e-a1b8-7789e79b3335
+                    request_id: cb458f00-d715-4ead-969e-019b71f4ff3b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9357,7 +9357,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 23f3c4bb-86e6-4c3c-803f-021fce5750ad
+                    request_id: c0c035cb-55a8-43f6-a724-34d7a1431194
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9374,14 +9374,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bcc56abd017f5e8b1dc6
+                  intercom_user_id: 65e1b482ba4d123be7717126
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991268173
+                  admin_id: 991270535
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -9391,18 +9391,18 @@ paths:
                 value:
                   message_type: quick_reply
                   type: admin
-                  admin_id: 991268178
+                  admin_id: 991270540
                   reply_options:
                   - text: 'Yes'
-                    uuid: 7835e161-274e-42fb-9742-7d8f7fa1d4e9
+                    uuid: c1894a1c-bced-4c7f-91da-848a3029bb4b
                   - text: 'No'
-                    uuid: f79091ab-b086-40d8-81fe-514313df98f5
+                    uuid: 16bee1b7-8a25-466c-8adf-ba960f3b4e71
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bccb6abd017f5e8b1dc9
+                  intercom_user_id: 65e1b48bba4d123be7717129
                   body: Thanks again :)
   "/tickets/{ticket_id}/tags":
     post:
@@ -9434,7 +9434,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '165'
+                    id: '353'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9446,7 +9446,7 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: 0332171a-9a0c-49d2-bc0f-ab9a4bef15d1
+                    request_id: ce823b69-9682-481c-a544-b7008fb13c6b
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
@@ -9460,7 +9460,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 98c3ea8a-9874-4c79-9b7f-a978e7fa6dd6
+                    request_id: 77bdf33e-1966-42b8-9715-64019b457a50
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9489,13 +9489,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 165
-                  admin_id: 991268188
+                  id: 353
+                  admin_id: 991270550
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  id: 166
-                  admin_id: 991268191
+                  id: 354
+                  admin_id: 991270553
   "/tickets/{ticket_id}/tags/{id}":
     delete:
       summary: Remove tag from a ticket
@@ -9533,7 +9533,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '168'
+                    id: '356'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9545,14 +9545,14 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: 73626a6e-0a87-41e8-959b-f301abd0ee27
+                    request_id: 965267f3-861b-4c16-b5f2-2f479a66cb86
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 076f5a61-c53d-4c06-b8e2-caa9114ae523
+                    request_id: ff10a76e-f355-4850-8550-ec0abd0c238e
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -9566,7 +9566,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: da3e1793-6492-42eb-a47c-632c0af7e571
+                    request_id: 15366cfd-e9d2-4f63-b559-f5c79c783ddc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9589,15 +9589,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991268197
+                  admin_id: 991270559
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  admin_id: 991268200
+                  admin_id: 991270562
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991268203
+                  admin_id: 991270565
   "/tickets":
     post:
       summary: Create a ticket
@@ -9619,28 +9619,28 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '566'
-                    ticket_id: '18'
+                    id: '1164'
+                    ticket_id: '69'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '99'
+                      id: '229'
                       name: my-ticket-type-15
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id624_that_should_be_at_least_
                       archived: false
-                      created_at: 1709227224
-                      updated_at: 1709227224
+                      created_at: 1709290655
+                      updated_at: 1709290655
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '277'
+                          id: '603'
                           workspace_id: this_is_an_id624_that_should_be_at_least_
                           name: title
                           description: ola
@@ -9652,12 +9652,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 99
+                          ticket_type_id: 229
                           archived: false
-                          created_at: 1709227225
-                          updated_at: 1709227225
+                          created_at: 1709290655
+                          updated_at: 1709290655
                         - type: ticket_type_attribute
-                          id: '278'
+                          id: '604'
                           workspace_id: this_is_an_id624_that_should_be_at_least_
                           name: description
                           description: ola
@@ -9669,33 +9669,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 99
+                          ticket_type_id: 229
                           archived: false
-                          created_at: 1709227225
-                          updated_at: 1709227225
+                          created_at: 1709290656
+                          updated_at: 1709290656
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bcd96abd017f5e8b1dd1
+                        id: 65e1b4a0ba4d123be7717131
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709227225
-                    updated_at: 1709227226
+                    created_at: 1709290656
+                    updated_at: 1709290657
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '123'
+                        id: '284'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709227226
-                        updated_at: 1709227226
+                        created_at: 1709290657
+                        updated_at: 1709290657
                         author:
-                          id: '991268215'
+                          id: '991270577'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id624_that_should_be_at_least_@intercom.io
@@ -9720,7 +9720,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 71ff7891-44a1-4742-a98d-c2906dee6763
+                    request_id: 67ede3e0-46a0-4b78-9255-f11771737bc0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9735,9 +9735,9 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  ticket_type_id: 99
+                  ticket_type_id: 229
                   contacts:
-                  - id: 65e0bcd96abd017f5e8b1dd1
+                  - id: 65e1b4a0ba4d123be7717131
                   ticket_attributes:
                     title: example
                     description: there is a problem
@@ -9768,28 +9768,28 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '567'
-                    ticket_id: '19'
+                    id: '1165'
+                    ticket_id: '70'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: in_progress
                     ticket_type:
                       type: ticket_type
-                      id: '101'
+                      id: '231'
                       name: my-ticket-type-17
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id628_that_should_be_at_least_
                       archived: false
-                      created_at: 1709227227
-                      updated_at: 1709227227
+                      created_at: 1709290658
+                      updated_at: 1709290658
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '282'
+                          id: '608'
                           workspace_id: this_is_an_id628_that_should_be_at_least_
                           name: title
                           description: ola
@@ -9801,12 +9801,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 101
+                          ticket_type_id: 231
                           archived: false
-                          created_at: 1709227227
-                          updated_at: 1709227227
+                          created_at: 1709290658
+                          updated_at: 1709290658
                         - type: ticket_type_attribute
-                          id: '283'
+                          id: '609'
                           workspace_id: this_is_an_id628_that_should_be_at_least_
                           name: description
                           description: ola
@@ -9818,98 +9818,98 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 101
+                          ticket_type_id: 231
                           archived: false
-                          created_at: 1709227227
-                          updated_at: 1709227227
+                          created_at: 1709290658
+                          updated_at: 1709290658
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bcdb6abd017f5e8b1dd2
-                        external_id: 860beef7-731e-4075-9ecc-263180af3f0d
-                    admin_assignee_id: '991268229'
+                        id: 65e1b4a3ba4d123be7717132
+                        external_id: 8187c10e-414b-4902-a204-d4ac96f0c1eb
+                    admin_assignee_id: '991270591'
                     team_assignee_id: '0'
-                    created_at: 1709227227
-                    updated_at: 1709227230
+                    created_at: 1709290659
+                    updated_at: 1709290662
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '124'
+                        id: '285'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709227228
-                        updated_at: 1709227228
+                        created_at: 1709290660
+                        updated_at: 1709290660
                         author:
-                          id: '991268227'
+                          id: '991270589'
                           type: admin
                           name: Ciaran408 Lee
                           email: admin408@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '125'
+                        id: '286'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709227229
-                        updated_at: 1709227229
+                        created_at: 1709290661
+                        updated_at: 1709290661
                         author:
-                          id: '991268228'
+                          id: '991270590'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id628_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '126'
+                        id: '287'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709227229
-                        updated_at: 1709227229
+                        created_at: 1709290661
+                        updated_at: 1709290661
                         author:
-                          id: '991268228'
+                          id: '991270590'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id628_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '127'
+                        id: '288'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: in_progress
                         previous_ticket_state: submitted
-                        created_at: 1709227229
-                        updated_at: 1709227229
+                        created_at: 1709290662
+                        updated_at: 1709290662
                         author:
-                          id: '991268228'
+                          id: '991270590'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id628_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '128'
+                        id: '289'
                         part_type: assignment
-                        created_at: 1709227230
-                        updated_at: 1709227230
+                        created_at: 1709290662
+                        updated_at: 1709290662
                         assigned_to:
                           type: admin
-                          id: '991268229'
+                          id: '991270591'
                         author:
-                          id: '991268227'
+                          id: '991270589'
                           type: admin
                           name: Ciaran408 Lee
                           email: admin408@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '129'
+                        id: '290'
                         part_type: snoozed
-                        created_at: 1709227230
-                        updated_at: 1709227230
+                        created_at: 1709290662
+                        updated_at: 1709290662
                         author:
-                          id: '991268228'
+                          id: '991270590'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id628_that_should_be_at_least_@intercom.io
@@ -9917,7 +9917,7 @@ paths:
                         redacted: false
                       total_count: 6
                     open: true
-                    snoozed_until: 1709312400
+                    snoozed_until: 1709398800
                     linked_objects:
                       type: list
                       data: []
@@ -9935,14 +9935,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: e69db6e4-39c0-414e-bea9-567b5683f77c
+                    request_id: 3f18213d-03d0-401d-b024-0a6fa8e7c05e
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
                 Assignee not found:
                   value:
                     type: error.list
-                    request_id: dc7ef4c0-5199-40f0-923b-4ca688202120
+                    request_id: dc4a1291-2140-4e44-be82-00442797e77c
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
@@ -9954,7 +9954,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7d3165c3-3014-49bd-9eb1-1b2254637b21
+                    request_id: 7afb96df-546c-4c9a-8fed-7af9a5752275
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9974,8 +9974,8 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991268227'
-                    assignee_id: '991268229'
+                    admin_id: '991270589'
+                    assignee_id: '991270591'
                   open: true
                   snoozed_until: 1673609604
               admin_not_found:
@@ -9987,7 +9987,7 @@ paths:
                   state: in_progress
                   assignment:
                     admin_id: '123'
-                    assignee_id: '991268237'
+                    assignee_id: '991270599'
               assignee_not_found:
                 summary: Assignee not found
                 value:
@@ -9996,7 +9996,7 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991268243'
+                    admin_id: '991270605'
                     assignee_id: '456'
     get:
       summary: Retrieve a ticket
@@ -10024,28 +10024,28 @@ paths:
                 Ticket found:
                   value:
                     type: ticket
-                    id: '570'
-                    ticket_id: '22'
+                    id: '1168'
+                    ticket_id: '73'
                     ticket_attributes:
                       title: attribute_value
                       description:
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '105'
+                      id: '235'
                       name: my-ticket-type-21
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id636_that_should_be_at_least_
                       archived: false
-                      created_at: 1709227235
-                      updated_at: 1709227235
+                      created_at: 1709290670
+                      updated_at: 1709290670
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '293'
+                          id: '619'
                           workspace_id: this_is_an_id636_that_should_be_at_least_
                           name: title
                           description: ola
@@ -10057,12 +10057,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 105
+                          ticket_type_id: 235
                           archived: false
-                          created_at: 1709227236
-                          updated_at: 1709227236
+                          created_at: 1709290671
+                          updated_at: 1709290671
                         - type: ticket_type_attribute
-                          id: '294'
+                          id: '620'
                           workspace_id: this_is_an_id636_that_should_be_at_least_
                           name: description
                           description: ola
@@ -10074,33 +10074,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 105
+                          ticket_type_id: 235
                           archived: false
-                          created_at: 1709227236
-                          updated_at: 1709227236
+                          created_at: 1709290671
+                          updated_at: 1709290671
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bce46abd017f5e8b1dd5
-                        external_id: 1acbc940-9927-4a6c-9368-544d1c6baf71
+                        id: 65e1b4afba4d123be7717135
+                        external_id: '06249210-f4d4-401f-925c-6a6a8c4a497b'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709227236
-                    updated_at: 1709227236
+                    created_at: 1709290671
+                    updated_at: 1709290672
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '132'
+                        id: '293'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709227236
-                        updated_at: 1709227236
+                        created_at: 1709290672
+                        updated_at: 1709290672
                         author:
-                          id: '991268256'
+                          id: '991270618'
                           type: admin
                           name: Ciaran434 Lee
                           email: admin434@email.com
@@ -10125,7 +10125,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5ad0ec9b-d634-46fd-8d4b-d6cb0d14500b
+                    request_id: e8abc13a-ed13-408f-aa3c-5f5dfbe585e0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10211,28 +10211,28 @@ paths:
                     total_count: 1
                     tickets:
                     - type: ticket
-                      id: '571'
-                      ticket_id: '23'
+                      id: '1169'
+                      ticket_id: '74'
                       ticket_attributes:
                         title: attribute_value
                         description:
                       ticket_state: submitted
                       ticket_type:
                         type: ticket_type
-                        id: '107'
+                        id: '237'
                         name: my-ticket-type-23
                         description: my ticket type description is awesome.
                         icon: "\U0001F981"
                         workspace_id: this_is_an_id640_that_should_be_at_least_
                         archived: false
-                        created_at: 1709227238
-                        updated_at: 1709227238
+                        created_at: 1709290675
+                        updated_at: 1709290675
                         is_internal: false
                         ticket_type_attributes:
                           type: list
                           data:
                           - type: ticket_type_attribute
-                            id: '298'
+                            id: '624'
                             workspace_id: this_is_an_id640_that_should_be_at_least_
                             name: title
                             description: ola
@@ -10244,12 +10244,12 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 107
+                            ticket_type_id: 237
                             archived: false
-                            created_at: 1709227238
-                            updated_at: 1709227238
+                            created_at: 1709290675
+                            updated_at: 1709290675
                           - type: ticket_type_attribute
-                            id: '299'
+                            id: '625'
                             workspace_id: this_is_an_id640_that_should_be_at_least_
                             name: description
                             description: ola
@@ -10261,33 +10261,33 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 107
+                            ticket_type_id: 237
                             archived: false
-                            created_at: 1709227238
-                            updated_at: 1709227238
+                            created_at: 1709290675
+                            updated_at: 1709290675
                         category: Back-office
                       contacts:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0bce76abd017f5e8b1dd6
-                          external_id: 98408b19-faca-471b-b302-3836ca7584c4
+                          id: 65e1b4b4ba4d123be7717136
+                          external_id: 52ba630b-2672-4e8c-99fd-207e0e91fb30
                       admin_assignee_id: '0'
                       team_assignee_id: '0'
-                      created_at: 1709227239
-                      updated_at: 1709227239
+                      created_at: 1709290676
+                      updated_at: 1709290676
                       ticket_parts:
                         type: ticket_part.list
                         ticket_parts:
                         - type: ticket_part
-                          id: '133'
+                          id: '294'
                           part_type: ticket_state_updated_by_admin
                           ticket_state: submitted
                           previous_ticket_state: submitted
-                          created_at: 1709227239
-                          updated_at: 1709227239
+                          created_at: 1709290676
+                          updated_at: 1709290676
                           author:
-                            id: '991268269'
+                            id: '991270631'
                             type: admin
                             name: Ciaran446 Lee
                             email: admin446@email.com
@@ -10318,15 +10318,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '571'
+                      value: '1169'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '571'
+                        value: '1169'
                       - field: id
                         operator: "="
-                        value: '571'
+                        value: '1169'
   "/visitors":
     put:
       summary: Update a visitor
@@ -10353,26 +10353,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0bce96abd017f5e8b1dd9
+                    id: 65e1b4b7ba4d123be7717139
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Violet Cloud
+                    pseudonym: Pink Sunshine
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/violet-cloud.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/pink-sunshine.png
                     app_id: this_is_an_id644_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709227241
-                    remote_created_at: 1709227241
-                    signed_up_at: 1709227241
-                    updated_at: 1709227241
+                    created_at: 1709290679
+                    remote_created_at: 1709290679
+                    signed_up_at: 1709290679
+                    updated_at: 1709290679
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10405,7 +10405,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 0ff4c877-f49f-4fe6-87a3-c4da1346cde6
+                    request_id: d4dcf5ea-a9c4-4982-baf1-071759e9199d
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -10419,7 +10419,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b12f83cd-891a-4a0f-bb8c-4ba9291ea29b
+                    request_id: b546d26e-08db-44b4-8471-e06d0896e7fd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10434,7 +10434,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 65e0bce96abd017f5e8b1dd9
+                  id: 65e1b4b7ba4d123be7717139
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -10467,7 +10467,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0bcea6abd017f5e8b1ddf
+                    id: 65e1b4b9ba4d123be771713f
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -10483,10 +10483,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709227242
-                    remote_created_at: 1709227242
-                    signed_up_at: 1709227242
-                    updated_at: 1709227242
+                    created_at: 1709290681
+                    remote_created_at: 1709290681
+                    signed_up_at: 1709290681
+                    updated_at: 1709290681
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10519,7 +10519,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: 95c6dba5-7133-43ca-9f1e-b20b4d2d308f
+                    request_id: 3bad4eab-2349-4c6d-b496-f9c88243f1a2
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -10533,7 +10533,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 119af3b0-6b41-4744-ae6b-c85cb323eb13
+                    request_id: e6a458fb-e66c-4223-9cc5-ae1138194e25
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10567,7 +10567,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0bcec6abd017f5e8b1de5
+                    id: 65e1b4bbba4d123be7717145
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -10583,10 +10583,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709227244
-                    remote_created_at: 1709227244
-                    signed_up_at: 1709227244
-                    updated_at: 1709227244
+                    created_at: 1709290683
+                    remote_created_at: 1709290683
+                    signed_up_at: 1709290683
+                    updated_at: 1709290683
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10619,7 +10619,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: 362d0196-2d18-40dc-9c80-537892f651cf
+                    request_id: e618281b-f8de-4de6-a8ea-ec16afda5689
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -10633,7 +10633,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cc885ebb-a991-4cce-8d1b-6ca079a2ae4c
+                    request_id: bc0ae9a0-7055-4080-9277-d95548e76739
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10666,7 +10666,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0bcee6abd017f5e8b1deb
+                    id: 65e1b4bdba4d123be771714b
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -10682,10 +10682,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709227246
-                    remote_created_at: 1709227246
-                    signed_up_at: 1709227246
-                    updated_at: 1709227246
+                    created_at: 1709290685
+                    remote_created_at: 1709290685
+                    signed_up_at: 1709290685
+                    updated_at: 1709290685
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10718,7 +10718,7 @@ paths:
                 Visitor Not Found:
                   value:
                     type: error.list
-                    request_id: f12425a2-fcc6-4c19-83c6-11d8fa692456
+                    request_id: 173a2beb-8506-4f20-a78f-09360de6ec3a
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -10732,7 +10732,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 77e33125-5c4b-4286-ace9-ad06f4e2e7f9
+                    request_id: 838ad8a3-5b88-4449-a159-079f3fbabb98
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10763,7 +10763,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0bcef6abd017f5e8b1df2
+                    id: 65e1b4beba4d123be7717152
                     workspace_id: this_is_an_id668_that_should_be_at_least_
                     external_id:
                     role: user
@@ -10778,9 +10778,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709227247
-                    updated_at: 1709227248
-                    signed_up_at: 1709227247
+                    created_at: 1709290686
+                    updated_at: 1709290687
+                    signed_up_at: 1709290686
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -10814,31 +10814,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0bcef6abd017f5e8b1df2/tags"
+                      url: "/contacts/65e1b4beba4d123be7717152/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0bcef6abd017f5e8b1df2/notes"
+                      url: "/contacts/65e1b4beba4d123be7717152/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0bcef6abd017f5e8b1df2/companies"
+                      url: "/contacts/65e1b4beba4d123be7717152/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bcef6abd017f5e8b1df2/subscriptions"
+                      url: "/contacts/65e1b4beba4d123be7717152/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bcef6abd017f5e8b1df2/subscriptions"
+                      url: "/contacts/65e1b4beba4d123be7717152/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -10857,7 +10857,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 98286161-2cd1-4927-b628-452f4efd293d
+                    request_id: f241003f-d954-4626-a2e8-54b4a7422e26
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -13218,7 +13218,8 @@ components:
       properties:
         type:
           type: string
-          description: This includes conversation, push, facebook, twitter and email.
+          description: This includes conversation, email, facebook, instagram, phone_call,
+            phone_switch, push, sms, twitter and whatsapp.
           example: conversation
         id:
           type: string

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991266234'
+                    id: '991266214'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1709225759
+                      created_at: 1709310459
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991266235'
+                    id: '991266215'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 63706cc7-a664-401b-b84d-c5d4ecf0ad65
+                    request_id: f6bc4b9e-3797-4cc2-b404-a55936ef5d01
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 11be56f5-3ba8-4083-9b9b-f98c94b80285
+                    request_id: c852cda0-4720-47ee-a458-bcf6bd6c76f8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: 73dbdc9e-7e33-4539-9d82-647def9b21fa
+                    - id: 675556b1-10f0-49e9-a970-8b8f98bc0f0b
                       performed_by:
                         type: admin
-                        id: '991266239'
+                        id: '991266219'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1709225765
+                      created_at: 1709310465
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: b0e3a8c8-1039-433f-8c38-5d590764e4aa
+                    - id: 683bdba9-7fd1-4668-87d0-5dc0b595a4d6
                       performed_by:
                         type: admin
-                        id: '991266239'
+                        id: '991266219'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1709225765
+                      created_at: 1709310465
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2d1201f1-f40d-4e7b-9728-2534a381c560
+                    request_id: cd47821b-1216-4ade-833f-e972b1359a0c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991266241'
+                      id: '991266221'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dfb686cb-2e86-4e2e-a318-c7df3418f555
+                    request_id: bdf610e4-c510-4c5d-b582-499d0f4c9402
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991266243'
+                    id: '991266223'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: d637e8f5-9b27-46da-a15d-c09cc8b01fb8
+                    request_id: 731ccb3c-11d5-4ea3-a0dc-c9ae0e3de989
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e86e86d2-02f8-4d31-880d-aad6f98948f4
+                    request_id: 4a8b5547-66d8-486c-8796-18ce079c6303
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -390,20 +390,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '6'
+                    - id: '1'
                       type: article
                       workspace_id: this_is_an_id22_that_should_be_at_least_4
-                      parent_id: 5
+                      parent_id: 1
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991266246
+                      author_id: 991266226
                       state: published
-                      created_at: 1709225769
-                      updated_at: 1709225769
-                      url: http://help-center.test/myapp-22/en/articles/6-this-is-the-article-title
+                      created_at: 1709310470
+                      updated_at: 1709310470
+                      url: http://help-center.test/myapp-22/en/articles/1-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -414,7 +414,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c7580e9a-eb52-4386-a017-3bea121551a0
+                    request_id: 7082d922-812f-449d-9362-c39f57bafdf4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -439,10 +439,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '9'
+                    id: '4'
                     type: article
                     workspace_id: this_is_an_id26_that_should_be_at_least_4
-                    parent_id: 7
+                    parent_id: 3
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -456,11 +456,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991266251
+                    author_id: 991266231
                     state: published
-                    created_at: 1709225772
-                    updated_at: 1709225772
-                    url: http://help-center.test/myapp-26/en/articles/9-thanks-for-everything
+                    created_at: 1709310472
+                    updated_at: 1709310472
+                    url: http://help-center.test/myapp-26/en/articles/4-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -471,7 +471,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 9bf16f78-e504-4b8c-b048-1207283ea262
+                    request_id: 390c56b6-9a9c-475e-9572-c609cd813ad6
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -486,7 +486,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 56e72466-bd71-421b-a393-0ce92fd3a8b0
+                    request_id: e5ef195a-251f-4ac6-9615-ffda5e93342f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -504,16 +504,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991266251
+                  author_id: 991266231
                   state: published
-                  parent_id: 7
+                  parent_id: 3
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991266251
+                      author_id: 991266231
                       state: published
               bad_request:
                 summary: Bad Request
@@ -550,10 +550,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '12'
+                    id: '7'
                     type: article
                     workspace_id: this_is_an_id32_that_should_be_at_least_4
-                    parent_id: 10
+                    parent_id: 6
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -567,11 +567,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991266256
+                    author_id: 991266236
                     state: published
-                    created_at: 1709225773
-                    updated_at: 1709225773
-                    url: http://help-center.test/myapp-32/en/articles/12-this-is-the-article-title
+                    created_at: 1709310474
+                    updated_at: 1709310474
+                    url: http://help-center.test/myapp-32/en/articles/7-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -582,7 +582,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: be767cd2-7582-475f-b0a0-1bc5c3a0cfaf
+                    request_id: b6f5ae4b-6dc3-43d7-9a66-529695fa5245
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -596,7 +596,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 15bcf214-c62b-49f7-8c71-d9528368d24c
+                    request_id: a1cc54aa-622c-4805-80ab-5f555a03c603
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -629,10 +629,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '15'
+                    id: '10'
                     type: article
                     workspace_id: this_is_an_id38_that_should_be_at_least_4
-                    parent_id: 13
+                    parent_id: 9
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -646,11 +646,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991266262
+                    author_id: 991266242
                     state: published
-                    created_at: 1709225775
-                    updated_at: 1709225776
-                    url: http://help-center.test/myapp-38/en/articles/15-christmas-is-here
+                    created_at: 1709310476
+                    updated_at: 1709310476
+                    url: http://help-center.test/myapp-38/en/articles/10-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -661,7 +661,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: e69e297d-ebc9-4b24-bdaf-a1e47e131af2
+                    request_id: bcaec271-f049-4d1a-8c3f-fbd3986efe39
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -675,7 +675,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1e36b88b-12fd-434b-9d1b-270b368ae1ef
+                    request_id: b8b7b512-3f3a-4ad2-8a2b-21efd9aca306
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -723,7 +723,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '18'
+                    id: '13'
                     object: article
                     deleted: true
               schema:
@@ -736,7 +736,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: c06c4c0d-36c5-4993-bd83-b63370e6c826
+                    request_id: b7f0e031-da53-41e5-8b01-87f04497ace0
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -750,7 +750,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6529835a-ea14-4835-812a-8a0161808833
+                    request_id: 007fb1dc-a337-4a6b-984e-f9d4df48c5c2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -781,16 +781,16 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '21'
+                    - id: '17'
                       workspace_id: this_is_an_id52_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-52/collection-17
                       order: 17
-                      created_at: 1709225781
-                      updated_at: 1709225781
+                      created_at: 1709310481
+                      updated_at: 1709310481
                       description: english collection description
                       icon: bookmark
-                      help_center_id: 21
+                      help_center_id: 17
                       type: collection
                     total_count: 1
                     pages:
@@ -808,7 +808,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e9b8183f-59ff-47c3-9dec-d5c564c07a2c
+                    request_id: 7658c201-9dc6-4a3c-813b-8d180c21d88f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -833,16 +833,16 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '27'
+                    id: '23'
                     workspace_id: this_is_an_id56_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-56/
                     order: 1
-                    created_at: 1709225782
-                    updated_at: 1709225782
+                    created_at: 1709310483
+                    updated_at: 1709310483
                     description: ''
                     icon: book-bookmark
-                    help_center_id: 23
+                    help_center_id: 19
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -854,7 +854,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 9a17022d-1fd4-4bb0-8e50-a12898bd48ed
+                    request_id: 9f5e72ce-dbfa-4142-8109-d074026dc67e
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -868,7 +868,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fa343ca2-935e-4a3c-aea5-292d77127c19
+                    request_id: b0f3d18e-84b2-4116-bc13-e361a7de812a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -916,16 +916,16 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '32'
+                    id: '28'
                     workspace_id: this_is_an_id62_that_should_be_at_least_4
                     name: English collection title
                     url: http://help-center.test/myapp-62/collection-22
                     order: 22
-                    created_at: 1709225784
-                    updated_at: 1709225784
+                    created_at: 1709310484
+                    updated_at: 1709310484
                     description: english collection description
                     icon: bookmark
-                    help_center_id: 26
+                    help_center_id: 22
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -937,7 +937,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 79ea836e-5c59-420a-8adb-22a5ad72874d
+                    request_id: 56cd76cc-6e93-4ba2-bb9d-c67811ace7af
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -951,7 +951,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '08ff11bd-ab08-44e7-8cc5-f1064212cb87'
+                    request_id: 18fe2026-d20e-461f-adad-2c624b788c90
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -984,16 +984,16 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '38'
+                    id: '34'
                     workspace_id: this_is_an_id68_that_should_be_at_least_4
                     name: Update collection name
                     url: http://help-center.test/myapp-68/collection-25
                     order: 25
-                    created_at: 1709225785
-                    updated_at: 1709225786
+                    created_at: 1709310485
+                    updated_at: 1709310485
                     description: english collection description
                     icon: folder
-                    help_center_id: 29
+                    help_center_id: 25
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -1005,7 +1005,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: 1a9c38b5-d2af-4585-9326-bdaebdfcbdb7
+                    request_id: 9f5dd0bc-6d07-42e2-888b-12b4ff4e2d72
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1019,7 +1019,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cdbd8a9f-4e72-47c4-baac-9b3a13555ba7
+                    request_id: e22208fc-df98-4d3b-ab37-615a4440e78a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1066,7 +1066,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '44'
+                    id: '40'
                     object: collection
                     deleted: true
               schema:
@@ -1079,7 +1079,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: 35bfc48b-0e74-474e-a3fd-a7793909287b
+                    request_id: 55921551-57ff-4c0d-9559-d9473cd0201c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1093,7 +1093,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3d8fa38e-7917-4df9-8438-0c99cc3ee3b6
+                    request_id: '08da95f4-d8b6-4101-8c6c-98cd1b24d21f'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1127,10 +1127,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '35'
+                    id: '31'
                     workspace_id: this_is_an_id80_that_should_be_at_least_4
-                    created_at: 1709225789
-                    updated_at: 1709225789
+                    created_at: 1709310488
+                    updated_at: 1709310488
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1144,7 +1144,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 273e6bff-4ed0-4492-9858-f9003c2df964
+                    request_id: 4a259b64-24a2-44f1-a58f-8bb5765c4b8e
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1158,7 +1158,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 43ea75e2-ee8d-4e15-8965-6590bb8b13ba
+                    request_id: fb31e71b-1a47-4dd2-87d5-a0c9b5a35ac4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1196,7 +1196,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '068016fb-1924-49d2-9796-7c3290cc256b'
+                    request_id: a5fea6e0-7830-45d6-8c72-1a604615a961
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1228,15 +1228,15 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '51'
+                    - id: '47'
                       workspace_id: this_is_an_id90_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-90/section-15
                       order: 15
-                      created_at: 1709225791
-                      updated_at: 1709225791
+                      created_at: 1709310490
+                      updated_at: 1709310490
                       type: section
-                      parent_id: 50
+                      parent_id: 46
                     total_count: 1
                     pages:
                       type: pages
@@ -1253,7 +1253,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f3bc9c18-8a12-4f4f-8fc4-757f4186f344
+                    request_id: 74f17813-360d-44af-bacf-19c412840c2c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1278,15 +1278,15 @@ paths:
               examples:
                 section created:
                   value:
-                    id: '56'
+                    id: '52'
                     workspace_id: this_is_an_id94_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-94/
                     order: 1
-                    created_at: 1709225792
-                    updated_at: 1709225792
+                    created_at: 1709310491
+                    updated_at: 1709310491
                     type: section
-                    parent_id: '54'
+                    parent_id: '50'
               schema:
                 "$ref": "#/components/schemas/section"
         '401':
@@ -1297,7 +1297,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d9b08ae4-5727-4d34-9cc7-71e83c1eff00
+                    request_id: d8f16177-7ee5-4b9c-8bd3-5ed3e139ca9f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1313,7 +1313,7 @@ paths:
                 summary: section created
                 value:
                   name: Thanks for everything
-                  parent_id: 54
+                  parent_id: 50
   "/help_center/sections/{id}":
     get:
       summary: Retrieve a section
@@ -1342,15 +1342,15 @@ paths:
               examples:
                 Section found:
                   value:
-                    id: '60'
+                    id: '56'
                     workspace_id: this_is_an_id98_that_should_be_at_least_4
                     name: English section title
                     url: http://help-center.test/myapp-98/section-19
                     order: 19
-                    created_at: 1709225793
-                    updated_at: 1709225793
+                    created_at: 1709310492
+                    updated_at: 1709310492
                     type: section
-                    parent_id: 59
+                    parent_id: 55
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1361,7 +1361,7 @@ paths:
                 Section not found:
                   value:
                     type: error.list
-                    request_id: 82096166-c675-45d3-a23c-a196d4e6cce6
+                    request_id: 19d0a86d-9eb1-4195-9931-08ec0b0c11ee
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1375,7 +1375,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ce5891d6-af49-430f-af10-b28532f1e22d
+                    request_id: 643ee34e-359d-40a1-8995-a257613a8da6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1408,15 +1408,15 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '66'
+                    id: '62'
                     workspace_id: this_is_an_id104_that_should_be_at_least_
                     name: Update section name
                     url: http://help-center.test/myapp-104/section-22
                     order: 22
-                    created_at: 1709225794
-                    updated_at: 1709225795
+                    created_at: 1709310493
+                    updated_at: 1709310494
                     type: section
-                    parent_id: '65'
+                    parent_id: '61'
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1427,7 +1427,7 @@ paths:
                 Section Not Found:
                   value:
                     type: error.list
-                    request_id: 1707bd75-53e6-42f1-92b4-f276d332ae92
+                    request_id: 8567c20e-5993-48d8-bfa9-a6c0f7aa8e93
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1441,7 +1441,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7968e987-076d-4396-9d1d-367f3dd13068
+                    request_id: 9fd8d1b8-16f7-429e-aed7-fd55ef8d5cf2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1457,12 +1457,12 @@ paths:
                 summary: successful
                 value:
                   name: Update section name
-                  parent_id: 65
+                  parent_id: 61
               section_not_found:
                 summary: Section Not Found
                 value:
                   name: Update section name
-                  parent_id: 67
+                  parent_id: 63
     delete:
       summary: Delete a section
       parameters:
@@ -1489,7 +1489,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '72'
+                    id: '68'
                     object: section
                     deleted: true
               schema:
@@ -1502,7 +1502,7 @@ paths:
                 section Not Found:
                   value:
                     type: error.list
-                    request_id: ddccbc45-4f0d-4c4b-87bb-50dfa97fb476
+                    request_id: 941c388e-4427-45b9-9672-e6be9965153b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1516,7 +1516,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 198f75a0-04ef-4d52-a797-c39631b0d79e
+                    request_id: 13c78a18-edbb-44e1-8891-27a91925769f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1549,12 +1549,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 65e0b7466abd01780bbd191c
+                    id: 65e202216abd01149508b36e
                     app_id: this_is_an_id116_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1709225798
-                    updated_at: 1709225798
+                    created_at: 1709310497
+                    updated_at: 1709310497
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1591,7 +1591,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 65ccbfbd-6ec4-4b71-b714-493eb3033c70
+                    request_id: 7f9e2d37-4117-467c-a6e4-c78ca1932466
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1689,12 +1689,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0b7486abd01780bbd1924
+                      id: 65e202236abd01149508b376
                       app_id: this_is_an_id122_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709225800
-                      created_at: 1709225800
-                      updated_at: 1709225800
+                      remote_created_at: 1709310499
+                      created_at: 1709310499
+                      updated_at: 1709310499
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -1723,7 +1723,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 39d7395c-b818-4b2b-84e7-cf065c313046
+                    request_id: 61bdde3e-6e97-4da6-96c0-a45428401110
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1737,7 +1737,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a37810c8-2eb3-4cc7-b63c-0c1cf4eb03fa
+                    request_id: b524046d-eb16-4988-99d9-04f6202cf897
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1772,12 +1772,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0b74a6abd01780bbd192f
+                    id: 65e202266abd01149508b381
                     app_id: this_is_an_id128_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1709225802
-                    created_at: 1709225802
-                    updated_at: 1709225802
+                    remote_created_at: 1709310502
+                    created_at: 1709310502
+                    updated_at: 1709310502
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1799,7 +1799,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: b4de277e-6fb7-47dd-a76f-3646daec4013
+                    request_id: bb61a150-fde7-450b-9d93-9e78a508a60c
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1813,7 +1813,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8c0c20ed-e2bc-4dd8-9acb-060f880ff7a7
+                    request_id: 2a234e87-b256-494c-9453-5b3fded90735
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1847,12 +1847,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0b74c6abd01780bbd1939
+                    id: 65e202286abd01149508b38b
                     app_id: this_is_an_id134_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1709225804
-                    created_at: 1709225804
-                    updated_at: 1709225804
+                    remote_created_at: 1709310504
+                    created_at: 1709310504
+                    updated_at: 1709310504
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1874,7 +1874,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 735b8c46-0c0c-4d7e-b095-c365c20e0f19
+                    request_id: 5b206ad9-83e7-4b1a-aad1-8d5aa521a1e3
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1888,7 +1888,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8c6dd975-b246-4fb4-8b09-dea9f9a582d8
+                    request_id: af5f5381-b8ac-4646-a363-dd408cf4fd3e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1920,7 +1920,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 65e0b74e6abd01780bbd1943
+                    id: 65e2022a6abd01149508b395
                     object: company
                     deleted: true
               schema:
@@ -1933,7 +1933,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: c1f121ae-f243-4ea6-9501-d9cc707a4105
+                    request_id: 0f2c371a-a5e4-423e-9325-55460be84d6c
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1947,7 +1947,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b6865339-eed0-48f8-b573-20394d0073d5
+                    request_id: 1eeb2d4d-9866-44d4-815f-ac855c11952a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1999,7 +1999,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: f5712f28-b56e-449b-93c0-ed93b2baf1bb
+                    request_id: deb9481a-9bfa-4479-9029-03476ef69556
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2013,7 +2013,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6097f8ed-1d67-41c1-ad96-c1c8c69497ad
+                    request_id: e0ca91c8-e31f-4c4b-9d09-de71ca403bf1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2058,7 +2058,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 53c65e3a-4d35-4317-b5b9-2ccd7433ff6b
+                    request_id: a7b313ab-fd93-4fd6-ae00-3648ebaeb3f0
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2072,7 +2072,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b148b9b3-4a42-4ddc-9a22-a721d7f9fdc4
+                    request_id: c32f4a99-719e-40b4-bdd6-bbaa5a0d2207
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2129,12 +2129,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0b7546abd01780bbd195f
+                      id: 65e202316abd01149508b3b1
                       app_id: this_is_an_id158_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709225812
-                      created_at: 1709225812
-                      updated_at: 1709225812
+                      remote_created_at: 1709310513
+                      created_at: 1709310513
+                      updated_at: 1709310513
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2163,7 +2163,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 17db0283-7e4c-4d58-a636-1e72c26dced0
+                    request_id: 5ec81ebc-f9d5-4f6b-ae7b-a010d41c0b40
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2215,12 +2215,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0b7566abd01780bbd1965
+                      id: 65e202326abd01149508b3b7
                       app_id: this_is_an_id162_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709225814
-                      created_at: 1709225814
-                      updated_at: 1709225814
+                      remote_created_at: 1709310514
+                      created_at: 1709310514
+                      updated_at: 1709310514
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2234,7 +2234,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: 74fd2571-3d14-4568-b3b8-e579c13b87d9
+                    scroll_param: c3bd27c5-cfd7-4e71-ac79-82acad619ffb
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2245,7 +2245,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: db497aa6-b288-4999-841e-aaaa9c481b3d
+                    request_id: 16e0ac36-0722-420d-bcea-ceb702c98807
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2280,12 +2280,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0b7576abd01780bbd196e
+                    id: 65e202346abd01149508b3c0
                     app_id: this_is_an_id166_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1709225815
-                    created_at: 1709225815
-                    updated_at: 1709225815
+                    remote_created_at: 1709310516
+                    created_at: 1709310516
+                    updated_at: 1709310516
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2307,7 +2307,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: c338a116-8c9d-4cb5-9fe5-f63ee54c305b
+                    request_id: a6e72cb1-3fc4-4ec9-8b17-ff226fdc20a0
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2321,7 +2321,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 1bf1369b-4b68-4b22-9112-ef4548af8d07
+                    request_id: 6adf16fc-d4c4-49a1-a633-1626eed05243
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2335,7 +2335,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 411d6f87-1c7d-4f25-8c6d-97bf1fc16846
+                    request_id: 8e243bbd-ae1b-4981-965b-140fa49c5b04
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2358,7 +2358,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 65e0b7576abd01780bbd196e
+                  id: 65e202346abd01149508b3c0
               bad_request:
                 summary: Bad Request
                 value:
@@ -2397,13 +2397,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 65e0b75d6abd01780bbd198f
+                      id: 65e2023a6abd01149508b3e1
                       app_id: this_is_an_id182_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1709225821
-                      created_at: 1709225821
-                      updated_at: 1709225821
-                      last_request_at: 1709053021
+                      remote_created_at: 1709310522
+                      created_at: 1709310522
+                      updated_at: 1709310522
+                      last_request_at: 1709137722
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2432,7 +2432,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 8a6262c0-8058-49e7-a1a3-9a89afae5ec4
+                    request_id: a5ffde13-9c5c-4650-b456-4d0a05d3956e
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2446,7 +2446,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b8409fc8-5bea-4546-a126-2aa928aa763d
+                    request_id: 24c8c3b3-05b5-4448-abb6-ef02930e1907
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2489,12 +2489,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0b75a6abd01780bbd197e
+                    id: 65e202376abd01149508b3d0
                     app_id: this_is_an_id174_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1709225818
-                    created_at: 1709225818
-                    updated_at: 1709225819
+                    remote_created_at: 1709310519
+                    created_at: 1709310519
+                    updated_at: 1709310519
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2516,14 +2516,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: ec0e88c7-f6bc-4361-883e-7e02637af0c2
+                    request_id: 10b19bd6-e2f5-4f29-ad57-bed40ce80b20
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 82dedc45-fbfc-4e71-aef1-6c22430d6265
+                    request_id: 47ed0466-16bc-455d-92bf-464fbd2f013f
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2537,7 +2537,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0174f7c3-5521-4ed7-a8e6-30bac1ecff6b
+                    request_id: 26f2767b-a03e-446c-92ee-6ff154d8adc9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2574,13 +2574,13 @@ paths:
                     data:
                     - type: note
                       id: '3'
-                      created_at: 1708621024
+                      created_at: 1708705724
                       contact:
                         type: contact
-                        id: 65e0b7606abd01780bbd199a
+                        id: 65e2023c6abd01149508b3ec
                       author:
                         type: admin
-                        id: '991266344'
+                        id: '991266324'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
@@ -2588,13 +2588,13 @@ paths:
                       body: "<p>This is a note.</p>"
                     - type: note
                       id: '2'
-                      created_at: 1708534624
+                      created_at: 1708619324
                       contact:
                         type: contact
-                        id: 65e0b7606abd01780bbd199a
+                        id: 65e2023c6abd01149508b3ec
                       author:
                         type: admin
-                        id: '991266344'
+                        id: '991266324'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
@@ -2602,13 +2602,13 @@ paths:
                       body: "<p>This is a note.</p>"
                     - type: note
                       id: '1'
-                      created_at: 1708534624
+                      created_at: 1708619324
                       contact:
                         type: contact
-                        id: 65e0b7606abd01780bbd199a
+                        id: 65e2023c6abd01149508b3ec
                       author:
                         type: admin
-                        id: '991266344'
+                        id: '991266324'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
@@ -2631,7 +2631,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 90a107d3-a99e-4c5c-81a6-c18782fe7ff5
+                    request_id: 26512dee-8d11-450e-bdfe-da15b2ec1e19
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2666,13 +2666,13 @@ paths:
                   value:
                     type: note
                     id: '8'
-                    created_at: 1709225825
+                    created_at: 1709310526
                     contact:
                       type: contact
-                      id: 65e0b7616abd01780bbd199c
+                      id: 65e2023e6abd01149508b3ee
                     author:
                       type: admin
-                      id: '991266346'
+                      id: '991266326'
                       name: Ciaran112 Lee
                       email: admin112@email.com
                       away_mode_enabled: false
@@ -2688,14 +2688,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: e2731ecd-f798-4563-b981-d3d4a7ff2b8a
+                    request_id: 1a4c0393-355a-414a-a2a8-7979007f8285
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: bf22ae9c-be1e-4b57-b682-5aa69653028d
+                    request_id: 59e76ecb-9b75-44a9-a41b-4d60fb2da7d5
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2725,20 +2725,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 65e0b7616abd01780bbd199c
-                  admin_id: 991266346
+                  contact_id: 65e2023e6abd01149508b3ee
+                  admin_id: 991266326
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 65e0b7616abd01780bbd199d
+                  contact_id: 65e2023e6abd01149508b3ef
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991266348
+                  admin_id: 991266328
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -2771,10 +2771,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 65e0b7636abd01780bbd199f
+                      id: 65e2023f6abd01149508b3f1
                       name: segment
-                      created_at: 1709225827
-                      updated_at: 1709225827
+                      created_at: 1709310527
+                      updated_at: 1709310527
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -2786,7 +2786,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: b2d6fd5c-7b0a-4399-96a9-623acc3a08f6
+                    request_id: 12b40627-e629-4c70-b3d7-5973d0e44abe
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2800,7 +2800,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c381189e-9a16-4e26-925f-4db0a4a28a09
+                    request_id: 4c0e01de-7535-46eb-ac23-92c68a16166c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2881,7 +2881,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 19ca8841-91ea-4710-867f-87c91097f833
+                    request_id: 6d1b2f26-e91e-4ce1-a0f6-35546a969823
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2895,7 +2895,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ca023745-6f72-4b18-a8fa-9c9d08b28e37
+                    request_id: 5dc425ca-cbd9-4f99-97fb-1b2491684f96
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2959,14 +2959,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 432e2588-3372-4e35-b7fb-b8b490774a30
+                    request_id: 97efdc3f-b34c-4401-8ace-40d63e2753bb
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 28e903eb-1dd3-4d46-bd4e-950509651039
+                    request_id: adc8b7fc-3b90-4cbc-bdf6-8584f4d72704
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -2980,7 +2980,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b16cecee-0f86-458b-9575-765d0190442b
+                    request_id: f453b6f7-3a7c-441a-a343-dc277071d293
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3082,14 +3082,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 2afe1e9d-6490-4416-a3e8-544b205f75f3
+                    request_id: 6bd888fd-5e7a-4a36-9af7-9a4461efc1fe
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: d99c5c1f-0f5a-4735-986f-e825b648fe79
+                    request_id: 75502f14-f16d-4b92-9c7d-4b2cde0ec919
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3103,7 +3103,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 10940f8c-af70-4410-a95a-5e8575dd69fd
+                    request_id: 05b6dfff-a86c-439a-ab44-2a07ed721f3b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3153,7 +3153,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 78425383-66e4-4560-b628-b9cf8a72a990
+                    request_id: 4bd7379a-a700-4661-8402-19804f549afe
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3167,7 +3167,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 043c561f-afa5-4f0f-8ff9-68c9cc2168a7
+                    request_id: 970f0e47-623f-487a-91df-1fadc78e9ed0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3214,14 +3214,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 765250a0-6dac-4b17-ad75-7ed82f48b2f2
+                    request_id: a8602c8b-5a9a-4f00-ba73-4de47187c499
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 8453cc2a-b5f7-48ab-8b2e-1be85bf28cb1
+                    request_id: 75fef22f-2d0e-4ef8-953c-a3eb7e6cade7
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3235,7 +3235,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7a6882fe-976a-44ba-b83c-4b61b3f6188c
+                    request_id: 33c272c1-c620-4b29-934c-29100f10adf9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3316,14 +3316,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 30e14bea-7c39-41e7-b8c4-364b46789a35
+                    request_id: 1a21cc15-f212-4fde-b42a-545a19c564af
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: f5ba069d-410b-415d-9d16-f95340f0828c
+                    request_id: f6ab39e4-315c-496c-805d-26238876a3cb
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3337,7 +3337,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e6cbef9f-3f73-4bdf-8fe2-bda0d17162a2
+                    request_id: 53df9791-3a6b-4749-afd0-cb6ba1c59161
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3371,7 +3371,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0b7716abd01780bbd19b6
+                    id: 65e2024e6abd01149508b408
                     workspace_id: this_is_an_id248_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3386,9 +3386,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709225841
-                    updated_at: 1709225841
-                    signed_up_at: 1709225841
+                    created_at: 1709310542
+                    updated_at: 1709310542
+                    signed_up_at: 1709310542
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3422,31 +3422,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7716abd01780bbd19b6/tags"
+                      url: "/contacts/65e2024e6abd01149508b408/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7716abd01780bbd19b6/notes"
+                      url: "/contacts/65e2024e6abd01149508b408/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7716abd01780bbd19b6/companies"
+                      url: "/contacts/65e2024e6abd01149508b408/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7716abd01780bbd19b6/subscriptions"
+                      url: "/contacts/65e2024e6abd01149508b408/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7716abd01780bbd19b6/subscriptions"
+                      url: "/contacts/65e2024e6abd01149508b408/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3465,7 +3465,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 64641f6c-0051-4332-b86d-6d223592933e
+                    request_id: 5d552325-61ec-43e3-9ea8-af015c92720d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3510,7 +3510,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0b7726abd01780bbd19b7
+                    id: 65e2024f6abd01149508b409
                     workspace_id: this_is_an_id252_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3525,9 +3525,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709225842
-                    updated_at: 1709225842
-                    signed_up_at: 1709225842
+                    created_at: 1709310543
+                    updated_at: 1709310543
+                    signed_up_at: 1709310543
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3561,31 +3561,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7726abd01780bbd19b7/tags"
+                      url: "/contacts/65e2024f6abd01149508b409/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7726abd01780bbd19b7/notes"
+                      url: "/contacts/65e2024f6abd01149508b409/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7726abd01780bbd19b7/companies"
+                      url: "/contacts/65e2024f6abd01149508b409/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7726abd01780bbd19b7/subscriptions"
+                      url: "/contacts/65e2024f6abd01149508b409/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7726abd01780bbd19b7/subscriptions"
+                      url: "/contacts/65e2024f6abd01149508b409/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3604,7 +3604,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f78ddc20-ce46-4d0b-a271-9493520706ab
+                    request_id: ef04c91d-45a5-489a-9a69-06f3fa262930
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3635,7 +3635,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0b7746abd01780bbd19b8
+                    id: 65e202506abd01149508b40a
                     object: contact
                     deleted: true
               schema:
@@ -3648,7 +3648,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5de07750-993e-42d3-8394-32754ec7d150
+                    request_id: 47e5d410-ce80-4409-bce8-1fea0ecbc9ad
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3676,7 +3676,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0b7756abd01780bbd19ba
+                    id: 65e202516abd01149508b40c
                     workspace_id: this_is_an_id260_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3691,9 +3691,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709225845
-                    updated_at: 1709225845
-                    signed_up_at: 1709225845
+                    created_at: 1709310545
+                    updated_at: 1709310546
+                    signed_up_at: 1709310545
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3727,31 +3727,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7756abd01780bbd19ba/tags"
+                      url: "/contacts/65e202516abd01149508b40c/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7756abd01780bbd19ba/notes"
+                      url: "/contacts/65e202516abd01149508b40c/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7756abd01780bbd19ba/companies"
+                      url: "/contacts/65e202516abd01149508b40c/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7756abd01780bbd19ba/subscriptions"
+                      url: "/contacts/65e202516abd01149508b40c/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7756abd01780bbd19ba/subscriptions"
+                      url: "/contacts/65e202516abd01149508b40c/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3770,7 +3770,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0d336534-8ef0-4906-9d4e-74d5617083d9
+                    request_id: 78001497-bb59-4497-8fc6-997ae6c9a505
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3785,8 +3785,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 65e0b7756abd01780bbd19b9
-                  into: 65e0b7756abd01780bbd19ba
+                  from: 65e202516abd01149508b40b
+                  into: 65e202516abd01149508b40c
   "/contacts/search":
     post:
       summary: Search contacts
@@ -3915,7 +3915,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1a2a0fe4-6a40-4b45-8bd6-1d0e33ad87f6
+                    request_id: 739318d6-f8ce-4e50-96eb-6b791f045f47
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3935,15 +3935,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: 65e0b7766abd01780bbd19bd
+                      value: 65e202536abd01149508b40f
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: 65e0b7766abd01780bbd19bd
+                        value: 65e202536abd01149508b40f
                       - field: id
                         operator: "="
-                        value: 65e0b7766abd01780bbd19bd
+                        value: 65e202536abd01149508b40f
   "/contacts":
     get:
       summary: List all contacts
@@ -3982,7 +3982,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e4d0a5ea-9b50-440c-afdd-f84e7df51d1e
+                    request_id: 5034bbbc-0c85-47b5-8ede-a216eba7eb12
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4008,7 +4008,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0b7796abd01780bbd19bf
+                    id: 65e202566abd01149508b411
                     workspace_id: this_is_an_id272_that_should_be_at_least_
                     external_id:
                     role: user
@@ -4023,8 +4023,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709225849
-                    updated_at: 1709225849
+                    created_at: 1709310550
+                    updated_at: 1709310550
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -4059,31 +4059,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7796abd01780bbd19bf/tags"
+                      url: "/contacts/65e202566abd01149508b411/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7796abd01780bbd19bf/notes"
+                      url: "/contacts/65e202566abd01149508b411/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7796abd01780bbd19bf/companies"
+                      url: "/contacts/65e202566abd01149508b411/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7796abd01780bbd19bf/subscriptions"
+                      url: "/contacts/65e202566abd01149508b411/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b7796abd01780bbd19bf/subscriptions"
+                      url: "/contacts/65e202566abd01149508b411/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4102,7 +4102,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0d767be6-b448-4034-9177-ad7244120881
+                    request_id: bbbb7b2e-dca8-4c96-9504-341f1929f571
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4146,7 +4146,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0b77a6abd01780bbd19c0
+                    id: 65e202576abd01149508b412
                     object: contact
                     archived: true
               schema:
@@ -4178,7 +4178,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0b77b6abd01780bbd19c1
+                    id: 65e202586abd01149508b413
                     object: contact
                     archived: false
               schema:
@@ -4225,7 +4225,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: b834a4c5-fa3f-4dff-b90c-9c951d39a843
+                    request_id: dd3ef7b6-8985-488a-b762-71b94accb6d5
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4239,7 +4239,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c4d0d462-5a85-41a1-b1df-658a9d5843dc
+                    request_id: 4f5ce54a-fe76-48d4-97de-4d0b529320b7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4269,12 +4269,12 @@ paths:
                 summary: successful
                 value:
                   id: 7
-                  admin_id: 991266379
+                  admin_id: 991266359
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   id: 8
-                  admin_id: 991266381
+                  admin_id: 991266361
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4324,14 +4324,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 04d95c87-3932-4712-a5f9-480c506a446a
+                    request_id: 88d31e68-f0d4-4746-9d13-7b9b19e12105
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 4007ec5c-764a-42df-9951-1ffe4d4b738e
+                    request_id: 998877fd-b1b9-4674-a160-584aad8d3177
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4345,7 +4345,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f4065fe7-5ccb-4144-9923-c5438b8335f7
+                    request_id: '08f0fe64-1ad0-43c0-b10f-805867e640c2'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4368,15 +4368,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991266383
+                  admin_id: 991266363
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991266385
+                  admin_id: 991266365
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991266386
+                  admin_id: 991266366
   "/conversations":
     get:
       summary: List all conversations
@@ -4423,20 +4423,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '6'
-                      created_at: 1709225859
-                      updated_at: 1709225859
+                      id: '5'
+                      created_at: 1709310560
+                      updated_at: 1709310560
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918066'
+                        id: '403918065'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991266389'
+                          id: '991266369'
                           name: Ciaran152 Lee
                           email: admin152@email.com
                         attachments: []
@@ -4446,7 +4446,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0b7826abd01780bbd19c5
+                          id: 65e202606abd01149508b417
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -4474,7 +4474,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5f5b64fc-2945-4dd8-b7bc-83ee7b6fd743
+                    request_id: 19eb2800-fcd7-4638-9909-e2fddbcc183f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4488,7 +4488,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: e5844c7c-36df-4292-a03c-22a4af0520bf
+                    request_id: d61d483b-a372-4bb3-9c0f-890a1ffc389c
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4524,11 +4524,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918076'
-                    created_at: 1709225883
+                    id: '403918075'
+                    created_at: 1709310586
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '31'
+                    conversation_id: '30'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -4539,7 +4539,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: b73c6b47-462b-498c-9dca-b0677e575810
+                    request_id: 1e11e512-9c29-49c3-a5c0-1184fd56d586
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -4553,7 +4553,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9b6e4f32-5edd-490f-8864-07bea0f25895
+                    request_id: a9bb3526-7a2d-4528-a30f-d80cfe5f018a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4567,7 +4567,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 4fde8882-1fc3-4cfd-96e6-0060f1f81a28
+                    request_id: 05b13d0a-b052-440f-b5ef-2f362f7877da
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4584,7 +4584,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65e0b79a6abd01780bbd19da
+                    id: 65e202796abd01149508b42c
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -4642,20 +4642,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '35'
-                    created_at: 1709225889
-                    updated_at: 1709225889
+                    id: '34'
+                    created_at: 1709310593
+                    updated_at: 1709310593
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918080'
+                      id: '403918079'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266403'
+                        id: '991266383'
                         name: Ciaran159 Lee
                         email: admin159@email.com
                       attachments: []
@@ -4665,7 +4665,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b7a16abd01780bbd19de
+                        id: 65e202816abd01149508b430
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4697,7 +4697,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 4ac4a36b-ceb2-4489-8342-6b6391d95eb0
+                    request_id: 389e6351-f390-45b9-acc7-362c4f5d1440
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4711,7 +4711,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2899097a-f3fe-4736-aca3-b73ac4c87723
+                    request_id: 2f77bd63-859b-4ef3-a846-efd22b73fa05
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4725,7 +4725,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: e8112b3f-9b39-4b97-8609-5173251060a5
+                    request_id: 33df5781-29a8-4a68-8bfd-0e8d18cc6784
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4772,20 +4772,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '39'
-                    created_at: 1709225896
-                    updated_at: 1709225898
+                    id: '38'
+                    created_at: 1709310600
+                    updated_at: 1709310601
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918084'
+                      id: '403918083'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266411'
+                        id: '991266391'
                         name: Ciaran163 Lee
                         email: admin163@email.com
                       attachments: []
@@ -4795,7 +4795,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b7a86abd01780bbd19e2
+                        id: 65e202876abd01149508b434
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4822,12 +4822,12 @@ paths:
                         id: '4'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709225898
-                        updated_at: 1709225898
-                        notified_at: 1709225898
+                        created_at: 1709310601
+                        updated_at: 1709310601
+                        notified_at: 1709310601
                         assigned_to:
                         author:
-                          id: '991266412'
+                          id: '991266392'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4838,12 +4838,12 @@ paths:
                         id: '5'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709225898
-                        updated_at: 1709225898
-                        notified_at: 1709225898
+                        created_at: 1709310601
+                        updated_at: 1709310601
+                        notified_at: 1709310601
                         assigned_to:
                         author:
-                          id: '991266412'
+                          id: '991266392'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4861,7 +4861,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: a6e6fa82-7455-4635-b758-387144296abe
+                    request_id: a2abcd31-d145-4438-b367-210b7399c257
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4875,7 +4875,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '048a8420-74fa-4f4e-8914-71810c474d23'
+                    request_id: e8e76ff2-5174-4a6a-92ac-b42ff904342a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4889,7 +4889,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 6a5732f9-c214-4972-8056-27c27d3da18b
+                    request_id: bd1ce382-ec58-45a4-9f02-ae013a951893
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4944,57 +4944,57 @@ paths:
 
         Most keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `"foorbar"`).
 
-        | Field                                     | Type                                                                                     |
-        | :---------------------------------------- | :--------------------------------------------------------------------------------------- |
-        | id                                        | String                                                                                   |
-        | created_at                                | Date (UNIX timestamp)                                                                    |
-        | updated_at                                | Date (UNIX timestamp)                                                                    |
-        | source.type                               | String<br>Accepted fields are `conversation`, `push`, `facebook`, `twitter` and `email`. |
-        | source.id                                 | String                                                                                   |
-        | source.delivered_as                       | String                                                                                   |
-        | source.subject                            | String                                                                                   |
-        | source.body                               | String                                                                                   |
-        | source.author.id                          | String                                                                                   |
-        | source.author.type                        | String                                                                                   |
-        | source.author.name                        | String                                                                                   |
-        | source.author.email                       | String                                                                                   |
-        | source.url                                | String                                                                                   |
-        | contact_ids                               | String                                                                                   |
-        | teammate_ids                              | String                                                                                   |
-        | admin_assignee_id                         | String                                                                                   |
-        | team_assignee_id                          | String                                                                                   |
-        | channel_initiated                         | String                                                                                   |
-        | open                                      | Boolean                                                                                  |
-        | read                                      | Boolean                                                                                  |
-        | state                                     | String                                                                                   |
-        | waiting_since                             | Date (UNIX timestamp)                                                                    |
-        | snoozed_until                             | Date (UNIX timestamp)                                                                    |
-        | tag_ids                                   | String                                                                                   |
-        | priority                                  | String                                                                                   |
-        | statistics.time_to_assignment             | Integer                                                                                  |
-        | statistics.time_to_admin_reply            | Integer                                                                                  |
-        | statistics.time_to_first_close            | Integer                                                                                  |
-        | statistics.time_to_last_close             | Integer                                                                                  |
-        | statistics.median_time_to_reply           | Integer                                                                                  |
-        | statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                    |
-        | statistics.first_assignment_at            | Date (UNIX timestamp)                                                                    |
-        | statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                    |
-        | statistics.first_close_at                 | Date (UNIX timestamp)                                                                    |
-        | statistics.last_assignment_at             | Date (UNIX timestamp)                                                                    |
-        | statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                    |
-        | statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                    |
-        | statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                    |
-        | statistics.last_close_at                  | Date (UNIX timestamp)                                                                    |
-        | statistics.last_closed_by_id              | String                                                                                   |
-        | statistics.count_reopens                  | Integer                                                                                  |
-        | statistics.count_assignments              | Integer                                                                                  |
-        | statistics.count_conversation_parts       | Integer                                                                                  |
-        | conversation_rating.requested_at          | Date (UNIX timestamp)                                                                    |
-        | conversation_rating.replied_at            | Date (UNIX timestamp)                                                                    |
-        | conversation_rating.score                 | Integer                                                                                  |
-        | conversation_rating.remark                | String                                                                                   |
-        | conversation_rating.contact_id            | String                                                                                   |
-        | conversation_rating.admin_d               | String                                                                                   |
+        | Field                                     | Type                                                                                                                                                   |
+        | :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
+        | id                                        | String                                                                                                                                                 |
+        | created_at                                | Date (UNIX timestamp)                                                                                                                                  |
+        | updated_at                                | Date (UNIX timestamp)                                                                                                                                  |
+        | source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |
+        | source.id                                 | String                                                                                                                                                 |
+        | source.delivered_as                       | String                                                                                                                                                 |
+        | source.subject                            | String                                                                                                                                                 |
+        | source.body                               | String                                                                                                                                                 |
+        | source.author.id                          | String                                                                                                                                                 |
+        | source.author.type                        | String                                                                                                                                                 |
+        | source.author.name                        | String                                                                                                                                                 |
+        | source.author.email                       | String                                                                                                                                                 |
+        | source.url                                | String                                                                                                                                                 |
+        | contact_ids                               | String                                                                                                                                                 |
+        | teammate_ids                              | String                                                                                                                                                 |
+        | admin_assignee_id                         | String                                                                                                                                                 |
+        | team_assignee_id                          | String                                                                                                                                                 |
+        | channel_initiated                         | String                                                                                                                                                 |
+        | open                                      | Boolean                                                                                                                                                |
+        | read                                      | Boolean                                                                                                                                                |
+        | state                                     | String                                                                                                                                                 |
+        | waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |
+        | snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |
+        | tag_ids                                   | String                                                                                                                                                 |
+        | priority                                  | String                                                                                                                                                 |
+        | statistics.time_to_assignment             | Integer                                                                                                                                                |
+        | statistics.time_to_admin_reply            | Integer                                                                                                                                                |
+        | statistics.time_to_first_close            | Integer                                                                                                                                                |
+        | statistics.time_to_last_close             | Integer                                                                                                                                                |
+        | statistics.median_time_to_reply           | Integer                                                                                                                                                |
+        | statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_closed_by_id              | String                                                                                                                                                 |
+        | statistics.count_reopens                  | Integer                                                                                                                                                |
+        | statistics.count_assignments              | Integer                                                                                                                                                |
+        | statistics.count_conversation_parts       | Integer                                                                                                                                                |
+        | conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |
+        | conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | conversation_rating.score                 | Integer                                                                                                                                                |
+        | conversation_rating.remark                | String                                                                                                                                                 |
+        | conversation_rating.contact_id            | String                                                                                                                                                 |
+        | conversation_rating.admin_d               | String                                                                                                                                                 |
 
         ### Accepted Operators
 
@@ -5029,20 +5029,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '46'
-                      created_at: 1709225908
-                      updated_at: 1709225908
+                      id: '45'
+                      created_at: 1709310611
+                      updated_at: 1709310611
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918091'
+                        id: '403918090'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991266441'
+                          id: '991266421'
                           name: Ciaran186 Lee
                           email: admin186@email.com
                         attachments: []
@@ -5052,7 +5052,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0b7b46abd01780bbd19e9
+                          id: 65e202936abd01149508b43b
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -5086,15 +5086,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '46'
+                      value: '45'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '46'
+                        value: '45'
                       - field: id
                         operator: "="
-                        value: '46'
+                        value: '45'
   "/conversations/{id}/reply":
     post:
       summary: Reply to a conversation
@@ -5125,20 +5125,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '54'
-                    created_at: 1709225914
-                    updated_at: 1709225915
-                    waiting_since: 1709225915
+                    id: '53'
+                    created_at: 1709310620
+                    updated_at: 1709310622
+                    waiting_since: 1709310622
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918094'
+                      id: '403918093'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266443'
+                        id: '991266423'
                         name: Ciaran187 Lee
                         email: admin187@email.com
                       attachments: []
@@ -5148,9 +5148,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b7ba6abd01780bbd19f0
+                        id: 65e2029c6abd01149508b442
                     first_contact_reply:
-                      created_at: 1709225915
+                      created_at: 1709310622
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5176,12 +5176,12 @@ paths:
                         id: '7'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709225915
-                        updated_at: 1709225915
-                        notified_at: 1709225915
+                        created_at: 1709310622
+                        updated_at: 1709310622
+                        notified_at: 1709310622
                         assigned_to:
                         author:
-                          id: 65e0b7ba6abd01780bbd19f0
+                          id: 65e2029c6abd01149508b442
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5192,20 +5192,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '55'
-                    created_at: 1709225917
-                    updated_at: 1709225918
+                    id: '54'
+                    created_at: 1709310623
+                    updated_at: 1709310625
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918095'
+                      id: '403918094'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266445'
+                        id: '991266425'
                         name: Ciaran188 Lee
                         email: admin188@email.com
                       attachments: []
@@ -5215,7 +5215,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b7bd6abd01780bbd19f1
+                        id: 65e2029f6abd01149508b443
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5252,12 +5252,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1709225918
-                        updated_at: 1709225918
-                        notified_at: 1709225918
+                        created_at: 1709310625
+                        updated_at: 1709310625
+                        notified_at: 1709310625
                         assigned_to:
                         author:
-                          id: '991266445'
+                          id: '991266425'
                           type: admin
                           name: Ciaran188 Lee
                           email: admin188@email.com
@@ -5268,20 +5268,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '57'
-                    created_at: 1709225921
-                    updated_at: 1709225922
-                    waiting_since: 1709225922
+                    id: '56'
+                    created_at: 1709310627
+                    updated_at: 1709310628
+                    waiting_since: 1709310628
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918097'
+                      id: '403918096'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266449'
+                        id: '991266429'
                         name: Ciaran190 Lee
                         email: admin190@email.com
                       attachments: []
@@ -5291,9 +5291,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b7c16abd01780bbd19f3
+                        id: 65e202a36abd01149508b445
                     first_contact_reply:
-                      created_at: 1709225922
+                      created_at: 1709310628
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5319,12 +5319,12 @@ paths:
                         id: '9'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709225922
-                        updated_at: 1709225922
-                        notified_at: 1709225922
+                        created_at: 1709310628
+                        updated_at: 1709310628
+                        notified_at: 1709310628
                         assigned_to:
                         author:
-                          id: 65e0b7c16abd01780bbd19f3
+                          id: 65e202a36abd01149508b445
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5342,7 +5342,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: a4b3b086-7e06-4cea-ac82-192f3252aa27
+                    request_id: 4acbb284-3ab1-404f-8198-55976dd418ac
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5356,7 +5356,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3f64c744-95b0-46ab-9aab-f3ecb0641dd8
+                    request_id: a007de64-4f5d-426b-a8b6-ac4d38b9d4b9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5370,7 +5370,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: d939dd30-4c19-4e0c-8bef-4b9be0b6c988
+                    request_id: 3a89237c-7062-4c7f-b274-4f292fd4cb0a
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5387,14 +5387,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0b7ba6abd01780bbd19f0
+                  intercom_user_id: 65e2029c6abd01149508b442
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991266445
+                  admin_id: 991266425
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -5404,14 +5404,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0b7c16abd01780bbd19f3
+                  intercom_user_id: 65e202a36abd01149508b445
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0b7c36abd01780bbd19f4
+                  intercom_user_id: 65e202a56abd01149508b446
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -5446,20 +5446,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '61'
-                    created_at: 1709225928
-                    updated_at: 1709225929
+                    id: '60'
+                    created_at: 1709310634
+                    updated_at: 1709310635
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918101'
+                      id: '403918100'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266457'
+                        id: '991266437'
                         name: Ciaran194 Lee
                         email: admin194@email.com
                       attachments: []
@@ -5469,7 +5469,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b7c86abd01780bbd19f7
+                        id: 65e202aa6abd01149508b449
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5494,12 +5494,12 @@ paths:
                         id: '10'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1709225929
-                        updated_at: 1709225929
-                        notified_at: 1709225929
+                        created_at: 1709310635
+                        updated_at: 1709310635
+                        notified_at: 1709310635
                         assigned_to:
                         author:
-                          id: '991266457'
+                          id: '991266437'
                           type: admin
                           name: Ciaran194 Lee
                           email: admin194@email.com
@@ -5510,20 +5510,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '62'
-                    created_at: 1709225930
-                    updated_at: 1709225932
+                    id: '61'
+                    created_at: 1709310637
+                    updated_at: 1709310638
                     waiting_since:
-                    snoozed_until: 1709229531
+                    snoozed_until: 1709314238
                     source:
                       type: conversation
-                      id: '403918102'
+                      id: '403918101'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266459'
+                        id: '991266439'
                         name: Ciaran195 Lee
                         email: admin195@email.com
                       attachments: []
@@ -5533,7 +5533,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b7ca6abd01780bbd19f8
+                        id: 65e202ac6abd01149508b44a
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5558,12 +5558,12 @@ paths:
                         id: '11'
                         part_type: snoozed
                         body:
-                        created_at: 1709225932
-                        updated_at: 1709225932
-                        notified_at: 1709225932
+                        created_at: 1709310638
+                        updated_at: 1709310638
+                        notified_at: 1709310638
                         assigned_to:
                         author:
-                          id: '991266459'
+                          id: '991266439'
                           type: admin
                           name: Ciaran195 Lee
                           email: admin195@email.com
@@ -5574,20 +5574,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '67'
-                    created_at: 1709225930
-                    updated_at: 1709225939
+                    id: '66'
+                    created_at: 1709310637
+                    updated_at: 1709310647
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918103'
+                      id: '403918102'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266461'
+                        id: '991266441'
                         name: Ciaran196 Lee
                         email: admin196@email.com
                       attachments: []
@@ -5597,7 +5597,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b7cf6abd01780bbd19fd
+                        id: 65e202b36abd01149508b44f
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5622,12 +5622,12 @@ paths:
                         id: '13'
                         part_type: open
                         body:
-                        created_at: 1709225939
-                        updated_at: 1709225939
-                        notified_at: 1709225939
+                        created_at: 1709310647
+                        updated_at: 1709310647
+                        notified_at: 1709310647
                         assigned_to:
                         author:
-                          id: '991266461'
+                          id: '991266441'
                           type: admin
                           name: Ciaran196 Lee
                           email: admin196@email.com
@@ -5638,20 +5638,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '71'
-                    created_at: 1709225941
-                    updated_at: 1709225942
+                    id: '70'
+                    created_at: 1709310648
+                    updated_at: 1709310649
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918106'
+                      id: '403918105'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266463'
+                        id: '991266443'
                         name: Ciaran197 Lee
                         email: admin197@email.com
                       attachments: []
@@ -5661,9 +5661,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b7d46abd01780bbd1a00
+                        id: 65e202b76abd01149508b452
                     first_contact_reply:
-                    admin_assignee_id: 991266463
+                    admin_assignee_id: 991266443
                     team_assignee_id:
                     open: true
                     state: open
@@ -5686,14 +5686,14 @@ paths:
                         id: '14'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1709225942
-                        updated_at: 1709225942
-                        notified_at: 1709225942
+                        created_at: 1709310649
+                        updated_at: 1709310649
+                        notified_at: 1709310649
                         assigned_to:
                           type: admin
-                          id: '991266463'
+                          id: '991266443'
                         author:
-                          id: '991266463'
+                          id: '991266443'
                           type: admin
                           name: Ciaran197 Lee
                           email: admin197@email.com
@@ -5711,7 +5711,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: f3cd2515-fa7e-4a9e-bcbc-0cce62dbdfb1
+                    request_id: d9a926fd-f364-4d67-b4e1-c1d28fc490f4
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5725,7 +5725,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 31074189-f181-423f-8968-031bd386533d
+                    request_id: 6472de77-a125-472c-b42f-f11d1543c529
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5739,7 +5739,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 4c21fa16-479c-485d-8e94-9afbfa0e2695
+                    request_id: 1d9723e7-15c3-470a-b6d9-e8c062dcaad5
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5760,32 +5760,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991266457
+                  admin_id: 991266437
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991266459
-                  snoozed_until: 1709229531
+                  admin_id: 991266439
+                  snoozed_until: 1709314238
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991266461
+                  admin_id: 991266441
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991266463
-                  assignee_id: 991266463
+                  admin_id: 991266443
+                  assignee_id: 991266443
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991266465
+                  admin_id: 991266445
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -5816,20 +5816,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '75'
-                    created_at: 1709225948
-                    updated_at: 1709225948
+                    id: '74'
+                    created_at: 1709310655
+                    updated_at: 1709310656
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918110'
+                      id: '403918109'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266471'
+                        id: '991266451'
                         name: Ciaran201 Lee
                         email: admin201@email.com
                       attachments: []
@@ -5839,7 +5839,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b7db6abd01780bbd1a04
+                        id: 65e202bf6abd01149508b456
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5864,14 +5864,14 @@ paths:
                         id: '15'
                         part_type: default_assignment
                         body:
-                        created_at: 1709225948
-                        updated_at: 1709225948
-                        notified_at: 1709225948
+                        created_at: 1709310656
+                        updated_at: 1709310656
+                        notified_at: 1709310656
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991266472'
+                          id: '991266452'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id357_that_should_be_at_least_@intercom.io
@@ -5889,7 +5889,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 9c1f543d-44d1-4d23-9813-b18603885519
+                    request_id: f0ad6b3d-f0e2-48cd-aad4-24d0993c14b5
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5903,7 +5903,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9f07fd6b-1962-4a8b-a7c8-b830e470a6d6
+                    request_id: 8921bb57-b922-41ed-a687-4376b580c019
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5917,7 +5917,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: e45f9d60-dca1-41a9-ad45-a8129d82dec8
+                    request_id: 5a536904-6b02-41ca-9df7-0cc405aecf52
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5958,7 +5958,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65e0b7e26abd01780bbd1a08
+                      id: 65e202c66abd01149508b45a
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -5969,7 +5969,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 46d6e70c-b62d-4459-8197-a777f219c37f
+                    request_id: 1b506adb-514d-41a7-a190-c640abeffded
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5983,7 +5983,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 124560f8-88b1-4488-9715-48710e5bdde2
+                    request_id: d8e1fd0d-a635-4056-9883-b705d143229e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5997,7 +5997,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 8d9bbbeb-ec62-4d06-b479-8e6535439984
+                    request_id: dae1cf79-4db9-46ea-bfdf-ac81f1378834
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6012,15 +6012,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991266479
+                  admin_id: 991266459
                   customer:
-                    intercom_user_id: 65e0b7e26abd01780bbd1a08
+                    intercom_user_id: 65e202c66abd01149508b45a
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991266481
+                  admin_id: 991266461
                   customer:
-                    intercom_user_id: 65e0b7e46abd01780bbd1a09
+                    intercom_user_id: 65e202c86abd01149508b45b
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -6063,7 +6063,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65e0b7f16abd01780bbd1a13
+                      id: 65e202d56abd01149508b465
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6074,14 +6074,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 45f38dbf-f892-4a73-bc71-c92d65a7e99b
+                    request_id: a9281c7a-148d-4d11-9a6e-81a52158885f
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: d8f86bed-e3e5-49a4-a414-8d6d7becb73b
+                    request_id: 6ad960ab-5cc8-4877-853c-09ec44674bd4
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -6095,7 +6095,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: 07e95fe0-f8c1-417e-8579-60e4b2da8323
+                    request_id: 3cb7bba2-c302-41c4-a8e8-85c92ccd1caf
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -6109,7 +6109,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bfff6e48-4d72-4c03-89d4-1b63cc537a5f
+                    request_id: 3ac7a78b-191e-45e3-bccb-909172f7e61d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6123,7 +6123,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 855d3fb7-a8db-45b3-9e9b-2c1c46ce0953
+                    request_id: 9d85161e-dad7-4684-b8aa-3e1f2b5fd883
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6138,27 +6138,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991266487
+                  admin_id: 991266467
                   customer:
-                    intercom_user_id: 65e0b7e96abd01780bbd1a0c
+                    intercom_user_id: 65e202cd6abd01149508b45e
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991266489
+                  admin_id: 991266469
                   customer:
-                    intercom_user_id: 65e0b7f26abd01780bbd1a14
+                    intercom_user_id: 65e202d66abd01149508b466
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991266491
+                  admin_id: 991266471
                   customer:
-                    intercom_user_id: 65e0b7fa6abd01780bbd1a1b
+                    intercom_user_id: 65e202de6abd01149508b46d
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991266493
+                  admin_id: 991266473
                   customer:
-                    intercom_user_id: 65e0b8026abd01780bbd1a22
+                    intercom_user_id: 65e202e76abd01149508b474
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6186,20 +6186,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '131'
-                    created_at: 1709226011
-                    updated_at: 1709226013
-                    waiting_since: 1709226012
+                    id: '130'
+                    created_at: 1709310720
+                    updated_at: 1709310722
+                    waiting_since: 1709310721
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918136'
+                      id: '403918135'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266499'
+                        id: '991266479'
                         name: Ciaran215 Lee
                         email: admin215@email.com
                       attachments: []
@@ -6209,9 +6209,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b81b6abd01780bbd1a37
+                        id: 65e203006abd01149508b489
                     first_contact_reply:
-                      created_at: 1709226012
+                      created_at: 1709310721
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6237,12 +6237,12 @@ paths:
                         id: '23'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1709226012
-                        updated_at: 1709226013
-                        notified_at: 1709226012
+                        created_at: 1709310721
+                        updated_at: 1709310722
+                        notified_at: 1709310721
                         assigned_to:
                         author:
-                          id: 65e0b81b6abd01780bbd1a37
+                          id: 65e203006abd01149508b489
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6260,7 +6260,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 13c10542-aa3d-4fd3-9b5b-e01ca550eb60
+                    request_id: 9c559b44-f5b7-4803-b836-2b5e3fbb13c9
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -6274,7 +6274,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 77b4c369-0530-4586-849e-53b976e7bf43
+                    request_id: f64d1e6a-5371-4afd-beea-0553e9bf4d14
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6290,7 +6290,7 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 131
+                  conversation_id: 130
                   conversation_part_id: 23
               not_found:
                 summary: Not found
@@ -6491,9 +6491,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991266524'
-                      created_at: 1709226025
-                      updated_at: 1709226025
+                      admin_id: '991266504'
+                      created_at: 1709310736
+                      updated_at: 1709310736
                       model: company
                     - type: data_attribute
                       name: id
@@ -6565,7 +6565,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 43c44629-ae2f-43ff-ac1e-57a232a9d606
+                    request_id: b0f01242-3901-4b0b-8bd2-0b0e0c8242ba
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6601,9 +6601,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991266526'
-                    created_at: 1709226026
-                    updated_at: 1709226026
+                    admin_id: '991266506'
+                    created_at: 1709310737
+                    updated_at: 1709310737
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6615,7 +6615,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: 4def5e8a-babb-49e1-92ac-88a04211d653
+                    request_id: 5424ccc5-e95c-41a1-bdf1-4b1e5fdf7861
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6623,7 +6623,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: e3d42743-936e-487c-b5e0-98126ba22433
+                    request_id: 15b4907f-f9eb-401f-802c-8bffe7630f16
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -6631,7 +6631,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: 4ea27434-2387-4a6d-940a-07670525196b
+                    request_id: 2957c9ac-3a03-4908-9fdc-b69ff95e4f04
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6639,14 +6639,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: 68adb27a-0b11-4585-9b88-d76b3a1c92d2
+                    request_id: 4ba10980-426d-414c-bb18-e1f660cd3b02
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: c50303ca-8c77-4bd6-96d8-56462fe0c78d
+                    request_id: 2ca7f931-09eb-4737-be4a-9c92857ed913
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -6661,7 +6661,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 38239f56-2a33-4e21-93a2-8542f5ac7fdb
+                    request_id: 393b81e4-44d7-4d8f-9a38-9d34c17a2f3d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6755,9 +6755,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991266533'
-                    created_at: 1709226029
-                    updated_at: 1709226030
+                    admin_id: '991266513'
+                    created_at: 1709310740
+                    updated_at: 1709310740
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6769,7 +6769,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: 9641e3b3-4fbc-4df1-9f1a-cd7c27771271
+                    request_id: 8a734d59-7cf1-49dd-b155-1dc365c49347
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -6783,7 +6783,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: 65374b59-a083-441b-8be8-a9c4b1543f19
+                    request_id: 1677b420-3631-47b6-bb7b-8fba02978c6e
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -6797,7 +6797,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: e715f394-012a-4a09-8d0e-a27c9499d895
+                    request_id: 728a3762-2543-41d0-9551-27520455871f
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -6812,7 +6812,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fdda5347-a809-4c4f-ad76-daaf9fc4b17d
+                    request_id: fea29adb-d7aa-4977-b710-4304af8fd589
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6917,7 +6917,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7de27288-56dc-4b26-8f0b-c188c7072150
+                    request_id: 118a0cc5-2dee-491c-944a-5c27ebc4eac0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7004,7 +7004,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 65e0b8326abd01780bbd1a40
+                    intercom_user_id: 65e203186abd01149508b492
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -7016,7 +7016,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d1d700b4-e37c-41cc-9782-1fe696fd1d34
+                    request_id: 60f5b974-e9e6-40e5-aa5f-6433cc3f21a0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7047,7 +7047,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 67c98ed3-56ca-479a-a6ca-147bed37e8b7
+                    request_id: 2ebc045f-ae08-4e99-abff-1d6cd1e3d43f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7091,7 +7091,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: 94faed5gh8jd7k1n
+                    job_identifier: nuab1e9t3l57f93r
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7106,8 +7106,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1709208036
-                  created_at_before: 1709226036
+                  created_at_after: 1709292747
+                  created_at_before: 1709310747
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -7141,7 +7141,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: yp0bnq2jotg8gpyg
+                    job_identifier: xhqov8qq6qjl37j3
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7173,7 +7173,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: fmmuapt5pvgaryko
+                    job_identifier: qnofzvzzu0yipjkl
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -7234,30 +7234,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918141'
-                    created_at: 1709226039
+                    id: '403918140'
+                    created_at: 1709310749
                     body: heyy
                     message_type: inapp
-                    conversation_id: '136'
+                    conversation_id: '135'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918142'
-                    created_at: 1709226040
+                    id: '403918141'
+                    created_at: 1709310750
                     body: heyy
                     message_type: inapp
-                    conversation_id: '137'
+                    conversation_id: '136'
                 admin message created:
                   value:
                     type: admin_message
                     id: '5'
-                    created_at: 1709226041
+                    created_at: 1709310752
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991266556'
+                      id: '991266536'
                       name: Ciaran265 Lee
                       email: admin265@email.com
                       away_mode_enabled: false
@@ -7272,14 +7272,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: 66d784f6-ed48-4e72-9e1e-f179178cff9e
+                    request_id: 410bcf20-c1b1-4a9b-a54b-a78787d21b1d
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: ea54cb2e-a826-40d6-ba87-78825f3c8dd0
+                    request_id: 98554402-6721-475a-8916-c3cb9586ecff
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -7293,7 +7293,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: 7a70a037-72d1-4af2-a8cf-683cac513ea2
+                    request_id: 9cfe4972-7ced-4815-b5e1-68fdfe3d1366
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -7307,7 +7307,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 45516366-27b7-414f-a3cb-410c7a163328
+                    request_id: b1316f15-2b00-4813-90f2-eccd1d025a40
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7321,7 +7321,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 967eecdd-e474-4637-a883-7cd96c6fe895
+                    request_id: 9cd57a42-5153-4d90-bfed-360aaa1e8776
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -7338,7 +7338,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65e0b8376abd01780bbd1a45
+                    id: 65e2031d6abd01149508b497
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -7346,7 +7346,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 65e0b8386abd01780bbd1a46
+                    id: 65e2031e6abd01149508b498
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -7354,10 +7354,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991266556'
+                    id: '991266536'
                   to:
                     type: user
-                    id: 65e0b8396abd01780bbd1a47
+                    id: 65e2031f6abd01149508b499
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -7365,10 +7365,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991266558'
+                    id: '991266538'
                   to:
                     type: user
-                    id: 65e0b83a6abd01780bbd1a48
+                    id: 65e203206abd01149508b49a
                   message_type: inapp
                   body:
                   subject: heyy
@@ -7377,7 +7377,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991266559'
+                    id: '991266539'
                   to:
                     type: user
                     user_id: '70'
@@ -7388,10 +7388,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991266560'
+                    id: '991266540'
                   to:
                     type: user
-                    id: 65e0b83b6abd01780bbd1a4a
+                    id: 65e203216abd01149508b49c
                   message_type: email
                   body:
                   subject: heyy
@@ -7427,7 +7427,7 @@ paths:
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991266565
+                      sender_id: 991266545
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7437,15 +7437,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709226045
-                      updated_at: 1709226045
+                      created_at: 1709310755
+                      updated_at: 1709310755
                       newsfeed_assignments: []
                     - id: '2'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991266567
+                      sender_id: 991266547
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7455,8 +7455,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709226045
-                      updated_at: 1709226045
+                      created_at: 1709310755
+                      updated_at: 1709310755
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -7469,7 +7469,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 180240a0-e1e4-4096-9645-dd403295fdf7
+                    request_id: b16b7cfd-998c-4f01-8b73-5fc56eac4d7e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7499,7 +7499,7 @@ paths:
                     workspace_id: this_is_an_id483_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991266574
+                    sender_id: 991266554
                     state: live
                     labels:
                     - New
@@ -7510,8 +7510,8 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1709226047
-                    updated_at: 1709226047
+                    created_at: 1709310757
+                    updated_at: 1709310757
                     newsfeed_assignments:
                     - newsfeed_id: 3
                       published_at: 1664638214
@@ -7525,7 +7525,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ee0616d2-30df-4cb4-a5b4-2370f0fa78d1
+                    request_id: a6765eea-31bc-4b03-b5a3-4a939c815821
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7546,7 +7546,7 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991266574
+                  sender_id: 991266554
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
@@ -7587,7 +7587,7 @@ paths:
                     workspace_id: this_is_an_id487_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991266577
+                    sender_id: 991266557
                     state: live
                     labels: []
                     cover_image_url:
@@ -7597,11 +7597,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1709226048
-                    updated_at: 1709226048
+                    created_at: 1709310758
+                    updated_at: 1709310758
                     newsfeed_assignments:
                     - newsfeed_id: 5
-                      published_at: 1709226048
+                      published_at: 1709310758
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -7612,7 +7612,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: d96fa3d2-45be-4694-91d4-6157439645c3
+                    request_id: 4b94c4a3-0237-444a-b8ae-e4d300adb76f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7626,7 +7626,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8ade289a-3359-4706-93d9-423017ae9ace
+                    request_id: 91a91fa6-f7e6-4d9d-8635-1ff61a0a8e4e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7662,7 +7662,7 @@ paths:
                     workspace_id: this_is_an_id493_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991266585
+                    sender_id: 991266565
                     state: live
                     labels: []
                     cover_image_url:
@@ -7670,8 +7670,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1709226050
-                    updated_at: 1709226050
+                    created_at: 1709310759
+                    updated_at: 1709310760
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7683,7 +7683,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 1d29f80a-e430-434f-8b6e-0a913746323b
+                    request_id: d0f5fc7b-a91c-4870-9db6-368b0a4abe7f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7697,7 +7697,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 07522f58-81fe-4acd-a5ec-6923b3cc30be
+                    request_id: 8b4e7e68-cb5a-4aa0-ab91-1dd44bf4878a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7714,7 +7714,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991266585
+                  sender_id: 991266565
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7723,7 +7723,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991266588
+                  sender_id: 991266568
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7766,7 +7766,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: f747d884-9d15-4196-9497-a89e27e66df5
+                    request_id: 41add27e-c959-478d-bb74-fb56b0cb803d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7780,7 +7780,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b89683d7-d8a1-4ee0-849b-98f931b4123e
+                    request_id: 03d3ef04-82a0-4165-bc03-5660a654181c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7833,7 +7833,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bf1ad2a3-7838-4d73-8cfc-42a7825a0eef
+                    request_id: a0214072-8b0e-4aef-b6f6-8e9ed35e9d36
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7869,13 +7869,13 @@ paths:
                     - id: '18'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709226055
-                      updated_at: 1709226055
+                      created_at: 1709310764
+                      updated_at: 1709310764
                     - id: '19'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709226055
-                      updated_at: 1709226055
+                      created_at: 1709310764
+                      updated_at: 1709310764
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -7887,7 +7887,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3c808f9f-16fd-4c0d-8270-8220f80db0e9
+                    request_id: 542be30b-3ccb-492d-971c-3c79fd02b580
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7924,8 +7924,8 @@ paths:
                     id: '22'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1709226056
-                    updated_at: 1709226056
+                    created_at: 1709310765
+                    updated_at: 1709310765
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -7936,7 +7936,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 63b8b07a-7c1c-45fb-8734-ee50d2c6db07
+                    request_id: f8c9d3d0-e460-43d1-8323-9dee637fedc9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7971,13 +7971,13 @@ paths:
                   value:
                     type: note
                     id: '11'
-                    created_at: 1708534857
+                    created_at: 1708619566
                     contact:
                       type: contact
-                      id: 65e0b8496abd01780bbd1a4d
+                      id: 65e2032e6abd01149508b49f
                     author:
                       type: admin
-                      id: '991266604'
+                      id: '991266584'
                       name: Ciaran312 Lee
                       email: admin312@email.com
                       away_mode_enabled: false
@@ -7993,7 +7993,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: 53e51d3e-e15b-4fbb-ab3e-aaa2c7b1c558
+                    request_id: 293008a7-569a-40f8-a40d-16b8c89bb4c8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8007,7 +8007,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 16443f9a-f3cd-41ac-b71c-ffd921e8fc0c
+                    request_id: a4ef9f54-1d01-41f6-a7db-9c8b6aa9fcf7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8043,16 +8043,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 65e0b84a6abd01780bbd1a50
+                      id: 65e2032f6abd01149508b4a2
                       name: John segment
-                      created_at: 1709226058
-                      updated_at: 1709226058
+                      created_at: 1709310767
+                      updated_at: 1709310767
                       person_type: user
                     - type: segment
-                      id: 65e0b84a6abd01780bbd1a51
+                      id: 65e2032f6abd01149508b4a3
                       name: Jane segment
-                      created_at: 1709226058
-                      updated_at: 1709226058
+                      created_at: 1709310767
+                      updated_at: 1709310767
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -8064,7 +8064,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a7c7ffe4-1c3c-4ef5-9871-f9b08c1e67bd
+                    request_id: d88617a5-8fd5-4ba2-ab59-335c35e3d1eb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8098,10 +8098,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 65e0b84b6abd01780bbd1a54
+                    id: 65e203306abd01149508b4a6
                     name: John segment
-                    created_at: 1709226059
-                    updated_at: 1709226059
+                    created_at: 1709310768
+                    updated_at: 1709310768
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -8113,7 +8113,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: 4e8d10c1-3ddd-44a6-a865-d83fd0c7a317
+                    request_id: c2200e9b-7678-4574-a875-8f160575af50
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8127,7 +8127,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7903a259-d1c3-489d-bab0-65ac56a607f7
+                    request_id: 77163a27-3eda-4f93-9a53-0f704ea4be6f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8180,7 +8180,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d52c7000-71ef-4539-9dd2-7e00b5e97ff7
+                    request_id: be796280-4e13-4cb3-ba5d-fad0501dd0f9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8210,7 +8210,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/572a54a1-f018-4695-9ce8-e242ea88ecb1
+                    url: http://via.intercom.io/msgr/f7c20ab7-2bca-4114-83b8-0eb55dfc29aa
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -8243,7 +8243,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ae5d3cfc-b968-4a7b-9d5f-b8cc02ddad13
+                    request_id: 7255a952-16a8-4180-a361-e76e2cae7bce
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8318,7 +8318,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: add3c89f-7046-4e87-a368-5e31faf518ed
+                    request_id: '084e9d18-c03e-4223-a490-7b1839fa56ab'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8369,7 +8369,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: 9bc03e77-e5ca-452a-a1dc-dd67a4d5179b
+                    request_id: dc3bb630-13ba-42c9-8335-a46a396a18ab
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -8383,14 +8383,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: ff4da227-ee3b-406e-8240-0a34c089ce99
+                    request_id: 87f3227e-3c2f-44d5-ad12-7a05b712cb7a
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: da09e7c4-7831-4e28-b5ef-265a3eef99de
+                    request_id: c5b39166-0eaa-438f-b703-bf57ef35c051
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -8404,7 +8404,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 44a51ad4-09a0-4bd0-9d0d-06b3c0598e3f
+                    request_id: 0cb8e86d-81d8-47d9-a032-96f6e2093271
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8482,7 +8482,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: aee06eaf-a4da-4512-b8ff-01b7529cda02
+                    request_id: 1a8a9275-7486-47fe-acc6-7e69402a7aeb
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8496,7 +8496,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 71334029-5219-413d-8740-3802e1ca6bbc
+                    request_id: 0c81a634-de75-426e-b9e8-e3e6af4edc59
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8532,7 +8532,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: d8bfd8b1-f269-4496-b8d5-dc18ddb1b3ff
+                    request_id: ee5e5dfc-6280-4eed-a1ef-a03e314ffa9d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8546,7 +8546,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: 2c8be2bd-0f81-473e-aa0d-6d395e9ad0d8
+                    request_id: 4c984ed6-33ff-4da3-9892-ce8fba354380
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -8561,7 +8561,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 45088660-6a24-4236-9f4f-779c92833cb1
+                    request_id: ecb7db59-ddb8-4cb0-bec8-8e881a75674c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8599,7 +8599,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 806768a3-a8ff-490f-9587-0e10817bef4d
+                    request_id: c336224e-0e9b-4164-bba1-f5ecba5c2ad6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8634,7 +8634,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991266642'
+                    id: '991266622'
                     name: team 1
                     admin_ids: []
               schema:
@@ -8647,7 +8647,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: b608cdb9-6e0b-4910-ad33-4f7453bccdb7
+                    request_id: 7a3b0ef3-787e-4257-baf5-bc86254dc539
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -8661,7 +8661,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 26f2e210-62b9-4e25-b3d8-0c39dce82193
+                    request_id: b495f3fc-a6e0-4d4c-957b-e3ef24495ecf
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8693,26 +8693,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0b8686abd01780bbd1a78
+                    id: 65e2034d6abd01149508b4ca
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Grey Deer
+                    pseudonym: Red Squirrel
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/grey-deer.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/red-squirrel.png
                     app_id: this_is_an_id609_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226088
-                    remote_created_at: 1709226088
-                    signed_up_at: 1709226088
-                    updated_at: 1709226088
+                    created_at: 1709310797
+                    remote_created_at: 1709310797
+                    signed_up_at: 1709310797
+                    updated_at: 1709310797
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8745,7 +8745,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 803f45eb-26ec-4599-be0d-84eb1c67ca95
+                    request_id: 3b328ea2-c52e-4efd-9991-bc90df4bec02
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8759,7 +8759,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5b297d94-166e-49a3-a89a-f74d34328d8f
+                    request_id: 64a0097d-8b48-4f7e-a365-739bbd131964
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8774,7 +8774,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 65e0b8686abd01780bbd1a78
+                  id: 65e2034d6abd01149508b4ca
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -8807,7 +8807,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0b8696abd01780bbd1a7e
+                    id: 65e2034e6abd01149508b4d0
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -8823,10 +8823,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226089
-                    remote_created_at: 1709226089
-                    signed_up_at: 1709226089
-                    updated_at: 1709226089
+                    created_at: 1709310798
+                    remote_created_at: 1709310798
+                    signed_up_at: 1709310798
+                    updated_at: 1709310798
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8859,7 +8859,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: ec1f858b-ccd2-40db-915c-7c65a47157e8
+                    request_id: 9574eaf9-6170-43ce-b9aa-3e0aadd6b0d8
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8873,7 +8873,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c8a4e5aa-c572-4b69-97ba-9298361b9873
+                    request_id: 80548fc9-243b-49c6-9bda-db7bf6f2bee4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8907,7 +8907,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0b86b6abd01780bbd1a84
+                    id: 65e203506abd01149508b4d6
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -8923,10 +8923,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226091
-                    remote_created_at: 1709226091
-                    signed_up_at: 1709226091
-                    updated_at: 1709226091
+                    created_at: 1709310800
+                    remote_created_at: 1709310800
+                    signed_up_at: 1709310800
+                    updated_at: 1709310800
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8959,7 +8959,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: 0bedf1e0-1b93-4da9-b353-d5849d751e62
+                    request_id: 3b4b81a7-43ed-420e-a386-f1dcd135b362
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8973,7 +8973,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7b7f3e10-99bc-46fb-9ca7-6ce7af0a5ae4
+                    request_id: eb5c923c-7347-4211-8f4f-c972ea498eae
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9006,7 +9006,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0b86d6abd01780bbd1a8a
+                    id: 65e203526abd01149508b4dc
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -9022,10 +9022,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226093
-                    remote_created_at: 1709226093
-                    signed_up_at: 1709226093
-                    updated_at: 1709226093
+                    created_at: 1709310802
+                    remote_created_at: 1709310802
+                    signed_up_at: 1709310802
+                    updated_at: 1709310802
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -9058,7 +9058,7 @@ paths:
                 Visitor Not Found:
                   value:
                     type: error.list
-                    request_id: f92c8d79-f2bd-4a7b-b28a-12fdf7178b49
+                    request_id: b81c98fd-b563-468e-a0e0-e8916dae3d61
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -9072,7 +9072,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2019606f-2403-4ded-ac71-8d26d7d6e5b4
+                    request_id: 9dada55d-aaf4-445b-b1f9-ffb06113ffea
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9103,7 +9103,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0b86f6abd01780bbd1a91
+                    id: 65e203546abd01149508b4e3
                     workspace_id: this_is_an_id633_that_should_be_at_least_
                     external_id:
                     role: user
@@ -9118,9 +9118,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226095
-                    updated_at: 1709226095
-                    signed_up_at: 1709226094
+                    created_at: 1709310804
+                    updated_at: 1709310804
+                    signed_up_at: 1709310804
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -9154,31 +9154,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0b86f6abd01780bbd1a91/tags"
+                      url: "/contacts/65e203546abd01149508b4e3/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0b86f6abd01780bbd1a91/notes"
+                      url: "/contacts/65e203546abd01149508b4e3/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0b86f6abd01780bbd1a91/companies"
+                      url: "/contacts/65e203546abd01149508b4e3/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b86f6abd01780bbd1a91/subscriptions"
+                      url: "/contacts/65e203546abd01149508b4e3/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b86f6abd01780bbd1a91/subscriptions"
+                      url: "/contacts/65e203546abd01149508b4e3/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -9197,7 +9197,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b9eb5918-e563-47c1-a2aa-90daaf2d1ad7
+                    request_id: 3d30a4ed-c71c-4e8d-98cc-4756d8eb15d6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9465,7 +9465,6 @@ components:
           description: The id of the admin who is authoring the comment.
           example: '3156780'
         attachment_urls:
-          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
@@ -9474,24 +9473,10 @@ components:
             format: uri
           maxItems: 5
         attachment_files:
-          title: Attachment Files
           type: array
-          description: A list of files that will be added as attachments. You can
-            include up to 5 files.
+          description: A list of files that will be added as attachments.
           items:
-            title: Attachment File
-            type: object
-            properties:
-              content-type:
-                type: string
-                description: The content type of the file.
-              data:
-                type: string
-                description: The base64 encoded file data.
-              name:
-                type: string
-                description: The name of the file.
-          maxItems: 5
+            "$ref": "#/components/schemas/conversation_attachment_files"
       required:
       - message_type
       - type
@@ -10828,7 +10813,6 @@ components:
           type: string
           description: The email you have defined for the user.
         attachment_urls:
-          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
@@ -10837,24 +10821,10 @@ components:
             format: uri
           maxItems: 5
         attachment_files:
-          title: Attachment Files
           type: array
-          description: A list of files that will be added as attachments. You can
-            include up to 5 files.
+          description: A list of files that will be added as attachments.
           items:
-            title: Attachment File
-            type: object
-            properties:
-              content-type:
-                type: string
-                description: The content type of the file.
-              data:
-                type: string
-                description: The base64 encoded file data.
-              name:
-                type: string
-                description: The name of the file.
-          maxItems: 5
+            "$ref": "#/components/schemas/conversation_attachment_files"
       required:
       - message_type
       - type
@@ -10890,24 +10860,10 @@ components:
             format: uri
           maxItems: 5
         attachment_files:
-          title: Attachment Files
           type: array
-          description: A list of files that will be added as attachments. You can
-            include up to 5 files.
+          description: A list of files that will be added as attachments.
           items:
-            title: Attachment File
-            type: object
-            properties:
-              content-type:
-                type: string
-                description: The content type of the file.
-              data:
-                type: string
-                description: The base64 encoded file data.
-              name:
-                type: string
-                description: The name of the file.
-          maxItems: 5
+            "$ref": "#/components/schemas/conversation_attachment_files"
       required:
       - message_type
       - type
@@ -11175,6 +11131,23 @@ components:
           "$ref": "#/components/schemas/conversation_statistics"
         conversation_parts:
           "$ref": "#/components/schemas/conversation_parts"
+    conversation_attachment_files:
+      title: Conversation attachment files
+      type: object
+      description: Properties of the attachment files in a conversation part
+      properties:
+        content_type:
+          type: string
+          description: The content type of the file
+          example: application/json
+        data:
+          type: string
+          description: The base64 encoded file data.
+          example: ewogICJ0ZXN0IjogMQp9
+        name:
+          type: string
+          description: The name of the file.
+          example: test.json
     conversation_contacts:
       title: Contacts
       type: object
@@ -11383,7 +11356,8 @@ components:
       properties:
         type:
           type: string
-          description: This includes conversation, push, facebook, twitter and email.
+          description: This includes conversation, email, facebook, instagram, phone_call,
+            phone_switch, push, sms, twitter and whatsapp.
           example: conversation
         id:
           type: string

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991267270'
+                    id: '991266234'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1709050205
+                      created_at: 1709225759
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991267271'
+                    id: '991266235'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 37bb1a73-22fa-4a98-b8a1-bc8d2fae0ef7
+                    request_id: 63706cc7-a664-401b-b84d-c5d4ecf0ad65
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b13706ac-816f-4818-bea9-322334a9330e
+                    request_id: 11be56f5-3ba8-4083-9b9b-f98c94b80285
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: 86c87b21-c72b-433a-aa19-230631257b19
+                    - id: 73dbdc9e-7e33-4539-9d82-647def9b21fa
                       performed_by:
                         type: admin
-                        id: '991267275'
+                        id: '991266239'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1709050211
+                      created_at: 1709225765
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: 036e84a5-5e06-4d06-9300-961a3170f084
+                    - id: b0e3a8c8-1039-433f-8c38-5d590764e4aa
                       performed_by:
                         type: admin
-                        id: '991267275'
+                        id: '991266239'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1709050211
+                      created_at: 1709225765
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 670af70a-a281-493d-8363-d76fc020be07
+                    request_id: 2d1201f1-f40d-4e7b-9728-2534a381c560
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991267277'
+                      id: '991266241'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5a8be9e5-1ed1-4609-9c74-3f9f31fe72f2
+                    request_id: dfb686cb-2e86-4e2e-a318-c7df3418f555
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991267279'
+                    id: '991266243'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: ca8089bd-4f9e-41c3-96a3-f7c57df043e3
+                    request_id: d637e8f5-9b27-46da-a15d-c09cc8b01fb8
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3d12fe38-a7ac-46f5-9d37-5b1a25511218
+                    request_id: e86e86d2-02f8-4d31-880d-aad6f98948f4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -390,20 +390,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '37'
+                    - id: '6'
                       type: article
                       workspace_id: this_is_an_id22_that_should_be_at_least_4
-                      parent_id: 144
+                      parent_id: 5
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991267282
+                      author_id: 991266246
                       state: published
-                      created_at: 1709050215
-                      updated_at: 1709050215
-                      url: http://help-center.test/myapp-22/en/articles/37-this-is-the-article-title
+                      created_at: 1709225769
+                      updated_at: 1709225769
+                      url: http://help-center.test/myapp-22/en/articles/6-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -414,7 +414,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 754245b4-4be2-45d5-a6e8-5d913a0beb82
+                    request_id: c7580e9a-eb52-4386-a017-3bea121551a0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -439,10 +439,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '40'
+                    id: '9'
                     type: article
                     workspace_id: this_is_an_id26_that_should_be_at_least_4
-                    parent_id: 146
+                    parent_id: 7
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -456,11 +456,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991267287
+                    author_id: 991266251
                     state: published
-                    created_at: 1709050217
-                    updated_at: 1709050217
-                    url: http://help-center.test/myapp-26/en/articles/40-thanks-for-everything
+                    created_at: 1709225772
+                    updated_at: 1709225772
+                    url: http://help-center.test/myapp-26/en/articles/9-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -471,7 +471,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 3be9a88b-d760-49d6-ab1a-8bdaddf51e5d
+                    request_id: 9bf16f78-e504-4b8c-b048-1207283ea262
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -486,7 +486,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1c458c5f-285a-41c1-8bb7-2b1f58c3eab3
+                    request_id: 56e72466-bd71-421b-a393-0ce92fd3a8b0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -504,16 +504,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991267287
+                  author_id: 991266251
                   state: published
-                  parent_id: 146
+                  parent_id: 7
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991267287
+                      author_id: 991266251
                       state: published
               bad_request:
                 summary: Bad Request
@@ -550,10 +550,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '43'
+                    id: '12'
                     type: article
                     workspace_id: this_is_an_id32_that_should_be_at_least_4
-                    parent_id: 149
+                    parent_id: 10
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -567,11 +567,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991267292
+                    author_id: 991266256
                     state: published
-                    created_at: 1709050219
-                    updated_at: 1709050219
-                    url: http://help-center.test/myapp-32/en/articles/43-this-is-the-article-title
+                    created_at: 1709225773
+                    updated_at: 1709225773
+                    url: http://help-center.test/myapp-32/en/articles/12-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -582,7 +582,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: fe5cf1cb-bf50-440b-bbe8-671af6dbceb8
+                    request_id: be767cd2-7582-475f-b0a0-1bc5c3a0cfaf
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -596,7 +596,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d2fb06c3-4cb8-45d8-9b1e-833e8b6cd8d5
+                    request_id: 15bcf214-c62b-49f7-8c71-d9528368d24c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -629,10 +629,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '46'
+                    id: '15'
                     type: article
                     workspace_id: this_is_an_id38_that_should_be_at_least_4
-                    parent_id: 152
+                    parent_id: 13
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -646,11 +646,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991267298
+                    author_id: 991266262
                     state: published
-                    created_at: 1709050221
-                    updated_at: 1709050222
-                    url: http://help-center.test/myapp-38/en/articles/46-christmas-is-here
+                    created_at: 1709225775
+                    updated_at: 1709225776
+                    url: http://help-center.test/myapp-38/en/articles/15-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -661,7 +661,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 17bd6f15-7538-4a45-be73-09ec96c3e8bd
+                    request_id: e69e297d-ebc9-4b24-bdaf-a1e47e131af2
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -675,7 +675,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 75fb61c4-5d65-4976-bb8a-545b60987cd9
+                    request_id: 1e36b88b-12fd-434b-9d1b-270b368ae1ef
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -723,7 +723,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '49'
+                    id: '18'
                     object: article
                     deleted: true
               schema:
@@ -736,7 +736,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 47093016-5503-400b-95f0-dfb4997065dd
+                    request_id: c06c4c0d-36c5-4993-bd83-b63370e6c826
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -750,7 +750,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c88490e9-3900-442e-b4f2-7cb97d3f1a55
+                    request_id: 6529835a-ea14-4835-812a-8a0161808833
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -781,16 +781,16 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '160'
+                    - id: '21'
                       workspace_id: this_is_an_id52_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-52/collection-17
                       order: 17
-                      created_at: 1709050226
-                      updated_at: 1709050226
+                      created_at: 1709225781
+                      updated_at: 1709225781
                       description: english collection description
                       icon: bookmark
-                      help_center_id: 84
+                      help_center_id: 21
                       type: collection
                     total_count: 1
                     pages:
@@ -808,7 +808,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c9fa6388-35b2-4db1-a522-8b508ec096f9
+                    request_id: e9b8183f-59ff-47c3-9dec-d5c564c07a2c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -833,16 +833,16 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '166'
+                    id: '27'
                     workspace_id: this_is_an_id56_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-56/
                     order: 1
-                    created_at: 1709050227
-                    updated_at: 1709050227
+                    created_at: 1709225782
+                    updated_at: 1709225782
                     description: ''
                     icon: book-bookmark
-                    help_center_id: 86
+                    help_center_id: 23
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -854,7 +854,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: a689a367-066b-4ed8-b61f-3007c16e8193
+                    request_id: 9a17022d-1fd4-4bb0-8e50-a12898bd48ed
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -868,7 +868,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0562a552-b099-4500-acc5-3789e1c6a635
+                    request_id: fa343ca2-935e-4a3c-aea5-292d77127c19
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -916,16 +916,16 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '171'
+                    id: '32'
                     workspace_id: this_is_an_id62_that_should_be_at_least_4
                     name: English collection title
                     url: http://help-center.test/myapp-62/collection-22
                     order: 22
-                    created_at: 1709050228
-                    updated_at: 1709050228
+                    created_at: 1709225784
+                    updated_at: 1709225784
                     description: english collection description
                     icon: bookmark
-                    help_center_id: 89
+                    help_center_id: 26
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -937,7 +937,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 98a317b6-8417-4697-82c1-59b66d36194b
+                    request_id: 79ea836e-5c59-420a-8adb-22a5ad72874d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -951,7 +951,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 26196fbc-1845-4487-84dd-95242d8399e1
+                    request_id: '08ff11bd-ab08-44e7-8cc5-f1064212cb87'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -984,16 +984,16 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '177'
+                    id: '38'
                     workspace_id: this_is_an_id68_that_should_be_at_least_4
                     name: Update collection name
                     url: http://help-center.test/myapp-68/collection-25
                     order: 25
-                    created_at: 1709050230
-                    updated_at: 1709050230
+                    created_at: 1709225785
+                    updated_at: 1709225786
                     description: english collection description
                     icon: folder
-                    help_center_id: 92
+                    help_center_id: 29
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -1005,7 +1005,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: d056744d-3cf6-4be7-8795-fc44926e5795
+                    request_id: 1a9c38b5-d2af-4585-9326-bdaebdfcbdb7
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1019,7 +1019,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '0025865f-092a-47c9-ab39-7d5a36e53de6'
+                    request_id: cdbd8a9f-4e72-47c4-baac-9b3a13555ba7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1066,7 +1066,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '183'
+                    id: '44'
                     object: collection
                     deleted: true
               schema:
@@ -1079,7 +1079,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: b6510404-984d-45eb-b3b7-1b32b3c89504
+                    request_id: 35bfc48b-0e74-474e-a3fd-a7793909287b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1093,7 +1093,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e7950f43-c275-4a8c-9833-d7906b1f02af
+                    request_id: 3d8fa38e-7917-4df9-8438-0c99cc3ee3b6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1127,10 +1127,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '98'
+                    id: '35'
                     workspace_id: this_is_an_id80_that_should_be_at_least_4
-                    created_at: 1709050233
-                    updated_at: 1709050233
+                    created_at: 1709225789
+                    updated_at: 1709225789
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1144,7 +1144,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: e8f4a672-30cc-46e3-8187-d564b31e42f8
+                    request_id: 273e6bff-4ed0-4492-9858-f9003c2df964
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1158,7 +1158,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1ea38be3-393a-4f0e-b233-b335f2f87d26
+                    request_id: 43ea75e2-ee8d-4e15-8965-6590bb8b13ba
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1196,7 +1196,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ec45ff2d-5ab8-435d-8253-a08f970ee63c
+                    request_id: '068016fb-1924-49d2-9796-7c3290cc256b'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1228,15 +1228,15 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '190'
+                    - id: '51'
                       workspace_id: this_is_an_id90_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-90/section-15
                       order: 15
-                      created_at: 1709050235
-                      updated_at: 1709050235
+                      created_at: 1709225791
+                      updated_at: 1709225791
                       type: section
-                      parent_id: 189
+                      parent_id: 50
                     total_count: 1
                     pages:
                       type: pages
@@ -1253,7 +1253,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7e8ea6c9-7535-4bd2-af62-7263cf4447c4
+                    request_id: f3bc9c18-8a12-4f4f-8fc4-757f4186f344
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1278,15 +1278,15 @@ paths:
               examples:
                 section created:
                   value:
-                    id: '195'
+                    id: '56'
                     workspace_id: this_is_an_id94_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-94/
                     order: 1
-                    created_at: 1709050236
-                    updated_at: 1709050236
+                    created_at: 1709225792
+                    updated_at: 1709225792
                     type: section
-                    parent_id: '193'
+                    parent_id: '54'
               schema:
                 "$ref": "#/components/schemas/section"
         '401':
@@ -1297,7 +1297,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b567baea-0079-4506-9bb9-549070cb1fef
+                    request_id: d9b08ae4-5727-4d34-9cc7-71e83c1eff00
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1313,7 +1313,7 @@ paths:
                 summary: section created
                 value:
                   name: Thanks for everything
-                  parent_id: 193
+                  parent_id: 54
   "/help_center/sections/{id}":
     get:
       summary: Retrieve a section
@@ -1342,15 +1342,15 @@ paths:
               examples:
                 Section found:
                   value:
-                    id: '199'
+                    id: '60'
                     workspace_id: this_is_an_id98_that_should_be_at_least_4
                     name: English section title
                     url: http://help-center.test/myapp-98/section-19
                     order: 19
-                    created_at: 1709050237
-                    updated_at: 1709050237
+                    created_at: 1709225793
+                    updated_at: 1709225793
                     type: section
-                    parent_id: 198
+                    parent_id: 59
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1361,7 +1361,7 @@ paths:
                 Section not found:
                   value:
                     type: error.list
-                    request_id: d179d398-b2b0-4b3c-b002-dd294fcf3670
+                    request_id: 82096166-c675-45d3-a23c-a196d4e6cce6
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1375,7 +1375,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b19a95b8-7b03-4325-ae51-5c9b1448a9e7
+                    request_id: ce5891d6-af49-430f-af10-b28532f1e22d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1408,15 +1408,15 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '205'
+                    id: '66'
                     workspace_id: this_is_an_id104_that_should_be_at_least_
                     name: Update section name
                     url: http://help-center.test/myapp-104/section-22
                     order: 22
-                    created_at: 1709050238
-                    updated_at: 1709050238
+                    created_at: 1709225794
+                    updated_at: 1709225795
                     type: section
-                    parent_id: '204'
+                    parent_id: '65'
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1427,7 +1427,7 @@ paths:
                 Section Not Found:
                   value:
                     type: error.list
-                    request_id: 24de489b-4c28-40ce-b5b2-ff082dd5b0a9
+                    request_id: 1707bd75-53e6-42f1-92b4-f276d332ae92
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1441,7 +1441,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a047fa10-34f9-4469-b606-39e5f9d01a68
+                    request_id: 7968e987-076d-4396-9d1d-367f3dd13068
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1457,12 +1457,12 @@ paths:
                 summary: successful
                 value:
                   name: Update section name
-                  parent_id: 204
+                  parent_id: 65
               section_not_found:
                 summary: Section Not Found
                 value:
                   name: Update section name
-                  parent_id: 206
+                  parent_id: 67
     delete:
       summary: Delete a section
       parameters:
@@ -1489,7 +1489,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '211'
+                    id: '72'
                     object: section
                     deleted: true
               schema:
@@ -1502,7 +1502,7 @@ paths:
                 section Not Found:
                   value:
                     type: error.list
-                    request_id: c1598723-f3d7-4803-ae1c-00d84654d8e0
+                    request_id: ddccbc45-4f0d-4c4b-87bb-50dfa97fb476
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1516,7 +1516,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1818ab49-ebde-45e8-9ce6-f7d9ced459ce
+                    request_id: 198f75a0-04ef-4d52-a797-c39631b0d79e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1549,12 +1549,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 65de0981ba4d128431e8e1c0
+                    id: 65e0b7466abd01780bbd191c
                     app_id: this_is_an_id116_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1709050241
-                    updated_at: 1709050241
+                    created_at: 1709225798
+                    updated_at: 1709225798
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1591,7 +1591,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 45d62db2-049d-481b-9180-56a36e1a5995
+                    request_id: 65ccbfbd-6ec4-4b71-b714-493eb3033c70
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1689,12 +1689,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0983ba4d128431e8e1c8
+                      id: 65e0b7486abd01780bbd1924
                       app_id: this_is_an_id122_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709050243
-                      created_at: 1709050243
-                      updated_at: 1709050243
+                      remote_created_at: 1709225800
+                      created_at: 1709225800
+                      updated_at: 1709225800
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -1723,7 +1723,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: '097e8080-6c0b-41dd-8d57-5fc1f540e1d5'
+                    request_id: 39d7395c-b818-4b2b-84e7-cf065c313046
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1737,7 +1737,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c537004a-4b96-4289-883b-09d5defe9e74
+                    request_id: a37810c8-2eb3-4cc7-b63c-0c1cf4eb03fa
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1772,12 +1772,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0986ba4d128431e8e1d3
+                    id: 65e0b74a6abd01780bbd192f
                     app_id: this_is_an_id128_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1709050246
-                    created_at: 1709050246
-                    updated_at: 1709050246
+                    remote_created_at: 1709225802
+                    created_at: 1709225802
+                    updated_at: 1709225802
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1799,7 +1799,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: fcb79f88-58f2-4362-b840-d09b642b39eb
+                    request_id: b4de277e-6fb7-47dd-a76f-3646daec4013
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1813,7 +1813,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b00f9560-963d-4524-bde5-7c0f51bd2a4a
+                    request_id: 8c0c20ed-e2bc-4dd8-9acb-060f880ff7a7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1847,12 +1847,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0988ba4d128431e8e1dd
+                    id: 65e0b74c6abd01780bbd1939
                     app_id: this_is_an_id134_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1709050248
-                    created_at: 1709050249
-                    updated_at: 1709050249
+                    remote_created_at: 1709225804
+                    created_at: 1709225804
+                    updated_at: 1709225804
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1874,7 +1874,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 2fd19d5e-8aba-4994-9289-27039fb2abbe
+                    request_id: 735b8c46-0c0c-4d7e-b095-c365c20e0f19
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1888,7 +1888,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d2cad0df-6da9-4508-bcdb-0ea3982a7c1a
+                    request_id: 8c6dd975-b246-4fb4-8b09-dea9f9a582d8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1920,7 +1920,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 65de098bba4d128431e8e1e7
+                    id: 65e0b74e6abd01780bbd1943
                     object: company
                     deleted: true
               schema:
@@ -1933,7 +1933,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 1fd1ba4c-b89a-4002-82fe-c234563b3aaf
+                    request_id: c1f121ae-f243-4ea6-9501-d9cc707a4105
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1947,7 +1947,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3072b414-b200-412b-92a6-268202d501ab
+                    request_id: b6865339-eed0-48f8-b573-20394d0073d5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1999,7 +1999,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: e8665944-cd5e-491f-9641-aec8f398df88
+                    request_id: f5712f28-b56e-449b-93c0-ed93b2baf1bb
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2013,7 +2013,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b4b514e1-a39d-4090-ae22-001e0d5dd7d5
+                    request_id: 6097f8ed-1d67-41c1-ad96-c1c8c69497ad
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2058,7 +2058,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 5146498e-d624-42f9-b741-d07784718442
+                    request_id: 53c65e3a-4d35-4317-b5b9-2ccd7433ff6b
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2072,7 +2072,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 417cc613-acf8-4b38-82a9-10808c36a150
+                    request_id: b148b9b3-4a42-4ddc-9a22-a721d7f9fdc4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2129,12 +2129,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0991ba4d128431e8e203
+                      id: 65e0b7546abd01780bbd195f
                       app_id: this_is_an_id158_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709050257
-                      created_at: 1709050257
-                      updated_at: 1709050257
+                      remote_created_at: 1709225812
+                      created_at: 1709225812
+                      updated_at: 1709225812
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2163,7 +2163,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0d64a975-68ec-4516-9e16-ad5706b1368a
+                    request_id: 17db0283-7e4c-4d58-a636-1e72c26dced0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2215,12 +2215,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0992ba4d128431e8e209
+                      id: 65e0b7566abd01780bbd1965
                       app_id: this_is_an_id162_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709050258
-                      created_at: 1709050258
-                      updated_at: 1709050258
+                      remote_created_at: 1709225814
+                      created_at: 1709225814
+                      updated_at: 1709225814
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2234,7 +2234,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: f1b95683-9e09-4b74-a711-0bad6d1c8090
+                    scroll_param: 74fd2571-3d14-4568-b3b8-e579c13b87d9
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2245,7 +2245,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d01c06f7-71b0-4ea2-a523-300afa110dc5
+                    request_id: db497aa6-b288-4999-841e-aaaa9c481b3d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2280,12 +2280,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0994ba4d128431e8e212
+                    id: 65e0b7576abd01780bbd196e
                     app_id: this_is_an_id166_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1709050260
-                    created_at: 1709050260
-                    updated_at: 1709050260
+                    remote_created_at: 1709225815
+                    created_at: 1709225815
+                    updated_at: 1709225815
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2307,7 +2307,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 52c89559-d420-4b1f-9994-225c2420e80a
+                    request_id: c338a116-8c9d-4cb5-9fe5-f63ee54c305b
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2321,7 +2321,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 8690afe0-f03c-49a3-bc8a-7eac10a4e1c1
+                    request_id: 1bf1369b-4b68-4b22-9112-ef4548af8d07
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2335,7 +2335,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1a2baddf-e801-40f7-b458-873db58f553c
+                    request_id: 411d6f87-1c7d-4f25-8c6d-97bf1fc16846
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2358,7 +2358,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 65de0994ba4d128431e8e212
+                  id: 65e0b7576abd01780bbd196e
               bad_request:
                 summary: Bad Request
                 value:
@@ -2397,13 +2397,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 65de0999ba4d128431e8e233
+                      id: 65e0b75d6abd01780bbd198f
                       app_id: this_is_an_id182_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1709050265
-                      created_at: 1709050265
-                      updated_at: 1709050265
-                      last_request_at: 1708877465
+                      remote_created_at: 1709225821
+                      created_at: 1709225821
+                      updated_at: 1709225821
+                      last_request_at: 1709053021
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2432,7 +2432,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: ac25423a-67d6-4771-87aa-45d8f82d412a
+                    request_id: 8a6262c0-8058-49e7-a1a3-9a89afae5ec4
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2446,7 +2446,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a83d77cf-16b5-4a19-803e-73f3abb2ec12
+                    request_id: b8409fc8-5bea-4546-a126-2aa928aa763d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2489,12 +2489,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0997ba4d128431e8e222
+                    id: 65e0b75a6abd01780bbd197e
                     app_id: this_is_an_id174_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1709050263
-                    created_at: 1709050263
-                    updated_at: 1709050263
+                    remote_created_at: 1709225818
+                    created_at: 1709225818
+                    updated_at: 1709225819
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2516,14 +2516,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 29ca45fe-0c2a-44e7-9e4c-fbaae9b67053
+                    request_id: ec0e88c7-f6bc-4361-883e-7e02637af0c2
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: b323c186-4caf-497c-a7c6-34542f6bcea8
+                    request_id: 82dedc45-fbfc-4e71-aef1-6c22430d6265
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2537,7 +2537,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6cddec41-5868-4e83-9fcd-3ada1a64ef82
+                    request_id: 0174f7c3-5521-4ed7-a8e6-30bac1ecff6b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2573,42 +2573,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '29'
-                      created_at: 1708445468
+                      id: '3'
+                      created_at: 1708621024
                       contact:
                         type: contact
-                        id: 65de099cba4d128431e8e23e
+                        id: 65e0b7606abd01780bbd199a
                       author:
                         type: admin
-                        id: '991267380'
+                        id: '991266344'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '28'
-                      created_at: 1708359068
+                      id: '2'
+                      created_at: 1708534624
                       contact:
                         type: contact
-                        id: 65de099cba4d128431e8e23e
+                        id: 65e0b7606abd01780bbd199a
                       author:
                         type: admin
-                        id: '991267380'
+                        id: '991266344'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '27'
-                      created_at: 1708359068
+                      id: '1'
+                      created_at: 1708534624
                       contact:
                         type: contact
-                        id: 65de099cba4d128431e8e23e
+                        id: 65e0b7606abd01780bbd199a
                       author:
                         type: admin
-                        id: '991267380'
+                        id: '991266344'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
@@ -2631,7 +2631,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: cf65cb33-4301-44d8-996a-60f59d3682f1
+                    request_id: 90a107d3-a99e-4c5c-81a6-c18782fe7ff5
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2665,14 +2665,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '34'
-                    created_at: 1709050269
+                    id: '8'
+                    created_at: 1709225825
                     contact:
                       type: contact
-                      id: 65de099dba4d128431e8e240
+                      id: 65e0b7616abd01780bbd199c
                     author:
                       type: admin
-                      id: '991267382'
+                      id: '991266346'
                       name: Ciaran112 Lee
                       email: admin112@email.com
                       away_mode_enabled: false
@@ -2688,14 +2688,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 495c9786-7d19-438a-8f2a-43fad3127a8d
+                    request_id: e2731ecd-f798-4563-b981-d3d4a7ff2b8a
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 4592959f-f687-475c-b94a-66805d53b5a9
+                    request_id: bf22ae9c-be1e-4b57-b682-5aa69653028d
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2725,20 +2725,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 65de099dba4d128431e8e240
-                  admin_id: 991267382
+                  contact_id: 65e0b7616abd01780bbd199c
+                  admin_id: 991266346
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 65de099dba4d128431e8e241
+                  contact_id: 65e0b7616abd01780bbd199d
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991267384
+                  admin_id: 991266348
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -2771,10 +2771,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 65de099fba4d128431e8e243
+                      id: 65e0b7636abd01780bbd199f
                       name: segment
-                      created_at: 1709050271
-                      updated_at: 1709050271
+                      created_at: 1709225827
+                      updated_at: 1709225827
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -2786,7 +2786,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 9cb7e6da-9d55-40d8-838e-441be22ef87b
+                    request_id: b2d6fd5c-7b0a-4399-96a9-623acc3a08f6
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2800,7 +2800,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ce9c8958-bab6-448c-af87-31780e7b3391
+                    request_id: c381189e-9a16-4e26-925f-4db0a4a28a09
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2844,7 +2844,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '93'
+                      id: '1'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -2858,7 +2858,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '95'
+                      id: '3'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -2881,7 +2881,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 3055e0ff-833c-4fdf-a491-3761e045b89a
+                    request_id: 19ca8841-91ea-4710-867f-87c91097f833
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2895,7 +2895,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 62f4c00f-1b52-4db3-9525-394e29dd550b
+                    request_id: ca023745-6f72-4b18-a8fa-9c9d08b28e37
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2936,7 +2936,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '108'
+                    id: '16'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -2959,14 +2959,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: e9bf77fe-9ef4-4005-9a27-5a6f3487f92d
+                    request_id: 432e2588-3372-4e35-b7fb-b8b490774a30
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 99fdc588-b4ba-48dd-be53-2d620bb5c805
+                    request_id: 28e903eb-1dd3-4d46-bd4e-950509651039
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -2980,7 +2980,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8a39b269-23ea-4de3-a8ec-7de821b866c7
+                    request_id: b16cecee-0f86-458b-9575-765d0190442b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3008,12 +3008,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 108
+                  id: 16
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 112
+                  id: 20
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -3059,7 +3059,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '124'
+                    id: '32'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3082,14 +3082,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: f380effe-fd15-45f9-b3df-8cdff35d4795
+                    request_id: 2afe1e9d-6490-4416-a3e8-544b205f75f3
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: af719eeb-e6cd-4d57-9fff-c1e4ead15f88
+                    request_id: d99c5c1f-0f5a-4735-986f-e825b648fe79
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3103,7 +3103,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ea1d9129-9117-41f1-b24f-2c73cabfbd45
+                    request_id: 10940f8c-af70-4410-a95a-5e8575dd69fd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3141,7 +3141,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '88'
+                      id: '1'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -3153,7 +3153,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: d78e2db5-ca8f-4d1e-bf63-6936a6e2aaf1
+                    request_id: 78425383-66e4-4560-b628-b9cf8a72a990
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3167,7 +3167,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ee82a065-5140-4eb2-bd88-8cc0b2624583
+                    request_id: 043c561f-afa5-4f0f-8ff9-68c9cc2168a7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3202,7 +3202,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '89'
+                    id: '2'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3214,14 +3214,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 93e6d1d5-9588-4cbd-bc07-6d9ab985ca04
+                    request_id: 765250a0-6dac-4b17-ad75-7ed82f48b2f2
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 248d5294-ae45-4683-88e2-b6d9fc80c754
+                    request_id: 8453cc2a-b5f7-48ab-8b2e-1be85bf28cb1
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3235,7 +3235,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 90a06d81-0ed7-4292-b3fd-2a05dea7ec19
+                    request_id: 7a6882fe-976a-44ba-b83c-4b61b3f6188c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3258,11 +3258,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 89
+                  id: 2
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 90
+                  id: 3
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3304,7 +3304,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '92'
+                    id: '5'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3316,14 +3316,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: dfa703fb-5763-42de-97a9-fb0ce158e29b
+                    request_id: 30e14bea-7c39-41e7-b8c4-364b46789a35
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 0a1ddc46-d540-44a8-aba8-58a065cc3a8f
+                    request_id: f5ba069d-410b-415d-9d16-f95340f0828c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3337,7 +3337,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d4c93d97-1868-488a-a925-811584ea9365
+                    request_id: e6cbef9f-3f73-4bdf-8fe2-bda0d17162a2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3371,7 +3371,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de09acba4d128431e8e25a
+                    id: 65e0b7716abd01780bbd19b6
                     workspace_id: this_is_an_id248_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3386,9 +3386,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709050284
-                    updated_at: 1709050284
-                    signed_up_at: 1709050284
+                    created_at: 1709225841
+                    updated_at: 1709225841
+                    signed_up_at: 1709225841
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3422,31 +3422,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de09acba4d128431e8e25a/tags"
+                      url: "/contacts/65e0b7716abd01780bbd19b6/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de09acba4d128431e8e25a/notes"
+                      url: "/contacts/65e0b7716abd01780bbd19b6/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de09acba4d128431e8e25a/companies"
+                      url: "/contacts/65e0b7716abd01780bbd19b6/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de09acba4d128431e8e25a/subscriptions"
+                      url: "/contacts/65e0b7716abd01780bbd19b6/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de09acba4d128431e8e25a/subscriptions"
+                      url: "/contacts/65e0b7716abd01780bbd19b6/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3465,7 +3465,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a3455118-3acd-4ecb-95de-e20c24c5d1c9
+                    request_id: 64641f6c-0051-4332-b86d-6d223592933e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3510,7 +3510,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de09adba4d128431e8e25b
+                    id: 65e0b7726abd01780bbd19b7
                     workspace_id: this_is_an_id252_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3525,9 +3525,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709050285
-                    updated_at: 1709050285
-                    signed_up_at: 1709050285
+                    created_at: 1709225842
+                    updated_at: 1709225842
+                    signed_up_at: 1709225842
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3561,31 +3561,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de09adba4d128431e8e25b/tags"
+                      url: "/contacts/65e0b7726abd01780bbd19b7/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de09adba4d128431e8e25b/notes"
+                      url: "/contacts/65e0b7726abd01780bbd19b7/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de09adba4d128431e8e25b/companies"
+                      url: "/contacts/65e0b7726abd01780bbd19b7/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de09adba4d128431e8e25b/subscriptions"
+                      url: "/contacts/65e0b7726abd01780bbd19b7/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de09adba4d128431e8e25b/subscriptions"
+                      url: "/contacts/65e0b7726abd01780bbd19b7/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3604,7 +3604,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6925c85e-fdbd-4f80-8c7e-c7dc74803000
+                    request_id: f78ddc20-ce46-4d0b-a271-9493520706ab
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3635,7 +3635,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de09aeba4d128431e8e25c
+                    id: 65e0b7746abd01780bbd19b8
                     object: contact
                     deleted: true
               schema:
@@ -3648,7 +3648,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 51ef99b6-8efd-4895-8979-dcf715e42d11
+                    request_id: 5de07750-993e-42d3-8394-32754ec7d150
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3676,7 +3676,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de09b0ba4d128431e8e25e
+                    id: 65e0b7756abd01780bbd19ba
                     workspace_id: this_is_an_id260_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3691,9 +3691,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709050288
-                    updated_at: 1709050288
-                    signed_up_at: 1709050288
+                    created_at: 1709225845
+                    updated_at: 1709225845
+                    signed_up_at: 1709225845
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3727,31 +3727,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de09b0ba4d128431e8e25e/tags"
+                      url: "/contacts/65e0b7756abd01780bbd19ba/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de09b0ba4d128431e8e25e/notes"
+                      url: "/contacts/65e0b7756abd01780bbd19ba/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de09b0ba4d128431e8e25e/companies"
+                      url: "/contacts/65e0b7756abd01780bbd19ba/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de09b0ba4d128431e8e25e/subscriptions"
+                      url: "/contacts/65e0b7756abd01780bbd19ba/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de09b0ba4d128431e8e25e/subscriptions"
+                      url: "/contacts/65e0b7756abd01780bbd19ba/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3770,7 +3770,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: aacd2488-db35-4815-9633-e03b275441a0
+                    request_id: 0d336534-8ef0-4906-9d4e-74d5617083d9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3785,8 +3785,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 65de09b0ba4d128431e8e25d
-                  into: 65de09b0ba4d128431e8e25e
+                  from: 65e0b7756abd01780bbd19b9
+                  into: 65e0b7756abd01780bbd19ba
   "/contacts/search":
     post:
       summary: Search contacts
@@ -3915,7 +3915,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ab1a6ace-85fa-4e25-abaf-716f4fdf39cd
+                    request_id: 1a2a0fe4-6a40-4b45-8bd6-1d0e33ad87f6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3935,15 +3935,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: 65de09b1ba4d128431e8e261
+                      value: 65e0b7766abd01780bbd19bd
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: 65de09b1ba4d128431e8e261
+                        value: 65e0b7766abd01780bbd19bd
                       - field: id
                         operator: "="
-                        value: 65de09b1ba4d128431e8e261
+                        value: 65e0b7766abd01780bbd19bd
   "/contacts":
     get:
       summary: List all contacts
@@ -3982,7 +3982,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 79e2a732-73f5-48ea-84a2-2e148bddf4c3
+                    request_id: e4d0a5ea-9b50-440c-afdd-f84e7df51d1e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4008,7 +4008,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de09b4ba4d128431e8e263
+                    id: 65e0b7796abd01780bbd19bf
                     workspace_id: this_is_an_id272_that_should_be_at_least_
                     external_id:
                     role: user
@@ -4023,8 +4023,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709050292
-                    updated_at: 1709050292
+                    created_at: 1709225849
+                    updated_at: 1709225849
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -4059,31 +4059,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de09b4ba4d128431e8e263/tags"
+                      url: "/contacts/65e0b7796abd01780bbd19bf/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de09b4ba4d128431e8e263/notes"
+                      url: "/contacts/65e0b7796abd01780bbd19bf/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de09b4ba4d128431e8e263/companies"
+                      url: "/contacts/65e0b7796abd01780bbd19bf/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de09b4ba4d128431e8e263/subscriptions"
+                      url: "/contacts/65e0b7796abd01780bbd19bf/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de09b4ba4d128431e8e263/subscriptions"
+                      url: "/contacts/65e0b7796abd01780bbd19bf/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4102,7 +4102,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 467feb27-144b-4f98-99ba-766078fb1820
+                    request_id: 0d767be6-b448-4034-9177-ad7244120881
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4146,7 +4146,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de09b5ba4d128431e8e264
+                    id: 65e0b77a6abd01780bbd19c0
                     object: contact
                     archived: true
               schema:
@@ -4178,7 +4178,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de09b6ba4d128431e8e265
+                    id: 65e0b77b6abd01780bbd19c1
                     object: contact
                     archived: false
               schema:
@@ -4213,7 +4213,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '94'
+                    id: '7'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4225,7 +4225,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 319620b7-2ca6-4eed-a9f9-81e8ee8f8b4f
+                    request_id: b834a4c5-fa3f-4dff-b90c-9c951d39a843
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4239,7 +4239,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a12b449a-b04a-4bd7-8507-db84158441c6
+                    request_id: c4d0d462-5a85-41a1-b1df-658a9d5843dc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4268,13 +4268,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 94
-                  admin_id: 991267415
+                  id: 7
+                  admin_id: 991266379
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 95
-                  admin_id: 991267417
+                  id: 8
+                  admin_id: 991266381
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4312,7 +4312,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '97'
+                    id: '10'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4324,14 +4324,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 341d07ec-34b0-41f5-a057-7a6c2a9afd2a
+                    request_id: 04d95c87-3932-4712-a5f9-480c506a446a
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 5a9fe827-4a18-4edd-a96d-57f7b8fd1b7e
+                    request_id: 4007ec5c-764a-42df-9951-1ffe4d4b738e
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4345,7 +4345,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cb0eefc9-f58c-4a86-88fa-8ec98d1d8557
+                    request_id: f4065fe7-5ccb-4144-9923-c5438b8335f7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4368,15 +4368,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991267419
+                  admin_id: 991266383
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991267421
+                  admin_id: 991266385
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991267422
+                  admin_id: 991266386
   "/conversations":
     get:
       summary: List all conversations
@@ -4423,20 +4423,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '295'
-                      created_at: 1709050301
-                      updated_at: 1709050301
+                      id: '6'
+                      created_at: 1709225859
+                      updated_at: 1709225859
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918234'
+                        id: '403918066'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991267425'
+                          id: '991266389'
                           name: Ciaran152 Lee
                           email: admin152@email.com
                         attachments: []
@@ -4446,7 +4446,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de09bdba4d128431e8e269
+                          id: 65e0b7826abd01780bbd19c5
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -4474,7 +4474,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3a7d8baf-6048-4354-a256-bd47b380d4dc
+                    request_id: 5f5b64fc-2945-4dd8-b7bc-83ee7b6fd743
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4488,7 +4488,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 59304c13-ff1f-47c7-acec-4fca8b204200
+                    request_id: e5844c7c-36df-4292-a03c-22a4af0520bf
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4504,13 +4504,17 @@ paths:
       tags:
       - Conversations
       operationId: createConversation
-      description: "You can create a conversation that has been initiated by a contact
-        (ie. user or lead).\nThe conversation can be an in-app message only.\n\n>
-        \U0001F4D8 Sending for visitors\n>\n> You can also send a message from a visitor
-        by specifying their `user_id` or `id` value in the `from` field, along with
-        a `type` field value of `contact`.\n> This visitor will be automatically converted
-        to a contact with a lead role once the conversation is created.\n\nThis will
-        return the Message model that has been created.\n\n"
+      description: |+
+        You can create a conversation that has been initiated by a contact (ie. user or lead).
+        The conversation can be an in-app message only.
+
+        {% admonition type="info" name="Sending for visitors" %}
+        You can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.
+        This visitor will be automatically converted to a contact with a lead role once the conversation is created.
+        {% /admonition %}
+
+        This will return the Message model that has been created.
+
       responses:
         '200':
           description: conversation created
@@ -4520,11 +4524,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918244'
-                    created_at: 1709050327
+                    id: '403918076'
+                    created_at: 1709225883
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '320'
+                    conversation_id: '31'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -4535,7 +4539,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 5875c7d8-2e36-46ed-91f6-9d75c9f888a6
+                    request_id: b73c6b47-462b-498c-9dca-b0677e575810
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -4549,7 +4553,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cb0c06a2-c753-4088-bfc9-208b6a4c5215
+                    request_id: 9b6e4f32-5edd-490f-8864-07bea0f25895
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4563,7 +4567,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: abb6f29a-4e8c-4100-b9c0-4dc0e131ac7e
+                    request_id: 4fde8882-1fc3-4cfd-96e6-0060f1f81a28
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4580,7 +4584,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65de09d6ba4d128431e8e27e
+                    id: 65e0b79a6abd01780bbd19da
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -4614,15 +4618,21 @@ paths:
       tags:
       - Conversations
       operationId: retrieveConversation
-      description: "\nYou can fetch the details of a single conversation.\n\nThis
-        will return a single Conversation model with all its conversation parts.\n\n>
-        \U0001F6A7 Hard limit of 500 parts\n>\n> The maximum number of conversation
-        parts that can be returned via the API is 500. If you have more than that
-        we will return the 500 most recent conversation parts.\n\n> \U0001F4D8 Bot
-        name in conversation parts\n>\n> For conversation parts generated by a bot,
-        bot name will depend on the following:\n- Customers that never turned on AI
-        answers will have `operator` as the bot name\n- Customers that have turned
-        on AI answers at some point will have `fin` as the bot name\n"
+      description: |2
+
+        You can fetch the details of a single conversation.
+
+        This will return a single Conversation model with all its conversation parts.
+
+        {% admonition type="warning" name="Hard limit of 500 parts" %}
+        The maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.
+        {% /admonition %}
+
+        ### Bot Name in Conversation Parts
+
+        For conversation parts generated by a bot, bot name will depend on the following:
+        - Customers that never turned on AI answers will have `operator` as the bot name
+        - Customers that have turned on AI answers at some point will have `fin` as the bot name
       responses:
         '200':
           description: conversation found
@@ -4632,20 +4642,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '324'
-                    created_at: 1709050333
-                    updated_at: 1709050333
+                    id: '35'
+                    created_at: 1709225889
+                    updated_at: 1709225889
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918248'
+                      id: '403918080'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267439'
+                        id: '991266403'
                         name: Ciaran159 Lee
                         email: admin159@email.com
                       attachments: []
@@ -4655,7 +4665,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de09dcba4d128431e8e282
+                        id: 65e0b7a16abd01780bbd19de
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4687,7 +4697,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 4026e447-e8ea-40ac-81bc-553fac5cdcdc
+                    request_id: 4ac4a36b-ceb2-4489-8342-6b6391d95eb0
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4701,7 +4711,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f5f1f8e6-bee8-4e4a-880d-c22c3b5c4a7d
+                    request_id: 2899097a-f3fe-4736-aca3-b73ac4c87723
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4715,7 +4725,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 54716546-30d6-4c3b-8e5f-29a813aca04d
+                    request_id: e8112b3f-9b39-4b97-8609-5173251060a5
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4745,10 +4755,14 @@ paths:
       tags:
       - Conversations
       operationId: updateConversation
-      description: "\nYou can update an existing conversation.\n\n> \U0001F4D8\n>\n>
-        If you want to update a conversation with either a reply (or actions such
-        as assign, unassign, open, close or snooze) then take a look at their own
-        sections respectively as they currently require different endpoints and parameters.\n\n"
+      description: |2+
+
+        You can update an existing conversation.
+
+        {% admonition type="info" name="Replying and other actions" %}
+        If you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.
+        {% /admonition %}
+
       responses:
         '200':
           description: conversation found
@@ -4758,20 +4772,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '328'
-                    created_at: 1709050339
-                    updated_at: 1709050341
+                    id: '39'
+                    created_at: 1709225896
+                    updated_at: 1709225898
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918252'
+                      id: '403918084'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267447'
+                        id: '991266411'
                         name: Ciaran163 Lee
                         email: admin163@email.com
                       attachments: []
@@ -4781,7 +4795,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de09e3ba4d128431e8e286
+                        id: 65e0b7a86abd01780bbd19e2
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4805,15 +4819,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '75'
+                        id: '4'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709050340
-                        updated_at: 1709050340
-                        notified_at: 1709050340
+                        created_at: 1709225898
+                        updated_at: 1709225898
+                        notified_at: 1709225898
                         assigned_to:
                         author:
-                          id: '991267448'
+                          id: '991266412'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4821,15 +4835,15 @@ paths:
                         external_id:
                         redacted: false
                       - type: conversation_part
-                        id: '76'
+                        id: '5'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709050341
-                        updated_at: 1709050341
-                        notified_at: 1709050341
+                        created_at: 1709225898
+                        updated_at: 1709225898
+                        notified_at: 1709225898
                         assigned_to:
                         author:
-                          id: '991267448'
+                          id: '991266412'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4847,7 +4861,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 668040f8-dcbb-4f70-8586-7b50e2ef0028
+                    request_id: a6e6fa82-7455-4635-b758-387144296abe
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4861,7 +4875,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2cc9e5e8-c8ee-4243-b10d-60a1ae38c9c1
+                    request_id: '048a8420-74fa-4f4e-8914-71810c474d23'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4875,7 +4889,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 7da364f1-3fc9-407a-96f6-6526dbb132e8
+                    request_id: 6a5732f9-c214-4972-8056-27c27d3da18b
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5015,20 +5029,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '335'
-                      created_at: 1709050351
-                      updated_at: 1709050351
+                      id: '46'
+                      created_at: 1709225908
+                      updated_at: 1709225908
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918259'
+                        id: '403918091'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991267477'
+                          id: '991266441'
                           name: Ciaran186 Lee
                           email: admin186@email.com
                         attachments: []
@@ -5038,7 +5052,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de09efba4d128431e8e28d
+                          id: 65e0b7b46abd01780bbd19e9
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -5072,15 +5086,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '335'
+                      value: '46'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '335'
+                        value: '46'
                       - field: id
                         operator: "="
-                        value: '335'
+                        value: '46'
   "/conversations/{id}/reply":
     post:
       summary: Reply to a conversation
@@ -5092,19 +5106,11 @@ paths:
       - name: id
         in: path
         required: true
+        description: The Intercom provisioned identifier for the conversation or the
+          string "last" to reply to the last part of the conversation
+        example: 123 or "last"
         schema:
-          oneOf:
-          - title: Conversation ID
-            type: string
-            description: The id of the conversation to target.
-            example: '123'
-          - title: The most recent conversation
-            type: string
-            enum:
-            - last
-            description: You can also reply to the most recent conversation on a workspace
-              by specifying `last` as the string.
-            example: last
+          type: string
       tags:
       - Conversations
       operationId: replyConversation
@@ -5119,20 +5125,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '343'
-                    created_at: 1709050359
-                    updated_at: 1709050360
-                    waiting_since: 1709050360
+                    id: '54'
+                    created_at: 1709225914
+                    updated_at: 1709225915
+                    waiting_since: 1709225915
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918262'
+                      id: '403918094'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267479'
+                        id: '991266443'
                         name: Ciaran187 Lee
                         email: admin187@email.com
                       attachments: []
@@ -5142,9 +5148,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de09f7ba4d128431e8e294
+                        id: 65e0b7ba6abd01780bbd19f0
                     first_contact_reply:
-                      created_at: 1709050360
+                      created_at: 1709225915
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5167,15 +5173,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '78'
+                        id: '7'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709050360
-                        updated_at: 1709050360
-                        notified_at: 1709050360
+                        created_at: 1709225915
+                        updated_at: 1709225915
+                        notified_at: 1709225915
                         assigned_to:
                         author:
-                          id: 65de09f7ba4d128431e8e294
+                          id: 65e0b7ba6abd01780bbd19f0
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5186,20 +5192,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '344'
-                    created_at: 1709050362
-                    updated_at: 1709050363
+                    id: '55'
+                    created_at: 1709225917
+                    updated_at: 1709225918
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918263'
+                      id: '403918095'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267481'
+                        id: '991266445'
                         name: Ciaran188 Lee
                         email: admin188@email.com
                       attachments: []
@@ -5209,7 +5215,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de09f9ba4d128431e8e295
+                        id: 65e0b7bd6abd01780bbd19f1
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5231,7 +5237,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '79'
+                        id: '8'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5246,12 +5252,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1709050363
-                        updated_at: 1709050363
-                        notified_at: 1709050363
+                        created_at: 1709225918
+                        updated_at: 1709225918
+                        notified_at: 1709225918
                         assigned_to:
                         author:
-                          id: '991267481'
+                          id: '991266445'
                           type: admin
                           name: Ciaran188 Lee
                           email: admin188@email.com
@@ -5262,20 +5268,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '346'
-                    created_at: 1709050365
-                    updated_at: 1709050366
-                    waiting_since: 1709050366
+                    id: '57'
+                    created_at: 1709225921
+                    updated_at: 1709225922
+                    waiting_since: 1709225922
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918265'
+                      id: '403918097'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267485'
+                        id: '991266449'
                         name: Ciaran190 Lee
                         email: admin190@email.com
                       attachments: []
@@ -5285,9 +5291,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de09fdba4d128431e8e297
+                        id: 65e0b7c16abd01780bbd19f3
                     first_contact_reply:
-                      created_at: 1709050366
+                      created_at: 1709225922
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5310,15 +5316,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '80'
+                        id: '9'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709050366
-                        updated_at: 1709050366
-                        notified_at: 1709050366
+                        created_at: 1709225922
+                        updated_at: 1709225922
+                        notified_at: 1709225922
                         assigned_to:
                         author:
-                          id: 65de09fdba4d128431e8e297
+                          id: 65e0b7c16abd01780bbd19f3
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5336,7 +5342,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: b6742bcf-d300-4fe7-ae01-8498f9615890
+                    request_id: a4b3b086-7e06-4cea-ac82-192f3252aa27
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5350,7 +5356,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: eda425de-c9b9-4e09-82fa-988cd219c045
+                    request_id: 3f64c744-95b0-46ab-9aab-f3ecb0641dd8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5364,7 +5370,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: c35b2f6b-5c2d-4e70-87fa-a2b32dada985
+                    request_id: d939dd30-4c19-4e0c-8bef-4b9be0b6c988
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5381,14 +5387,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de09f7ba4d128431e8e294
+                  intercom_user_id: 65e0b7ba6abd01780bbd19f0
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991267481
+                  admin_id: 991266445
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -5398,14 +5404,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de09fdba4d128431e8e297
+                  intercom_user_id: 65e0b7c16abd01780bbd19f3
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de09ffba4d128431e8e298
+                  intercom_user_id: 65e0b7c36abd01780bbd19f4
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -5426,10 +5432,11 @@ paths:
       - Conversations
       operationId: manageConversation
       description: |
-        You can close a conversation.
-        You can snooze a conversation to reopen on a future date.
-        You can open a conversation which is `snoozed` or `closed`.
-        You can assign a conversation to an admin and/or team.
+        For managing conversations you can:
+        - Close a conversation
+        - Snooze a conversation to reopen on a future date
+        - Open a conversation which is `snoozed` or `closed`
+        - Assign a conversation to an admin and/or team.
       responses:
         '200':
           description: Assign a conversation
@@ -5439,20 +5446,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '350'
-                    created_at: 1709050372
-                    updated_at: 1709050373
+                    id: '61'
+                    created_at: 1709225928
+                    updated_at: 1709225929
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918269'
+                      id: '403918101'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267493'
+                        id: '991266457'
                         name: Ciaran194 Lee
                         email: admin194@email.com
                       attachments: []
@@ -5462,7 +5469,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0a04ba4d128431e8e29b
+                        id: 65e0b7c86abd01780bbd19f7
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5484,15 +5491,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '81'
+                        id: '10'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1709050373
-                        updated_at: 1709050373
-                        notified_at: 1709050373
+                        created_at: 1709225929
+                        updated_at: 1709225929
+                        notified_at: 1709225929
                         assigned_to:
                         author:
-                          id: '991267493'
+                          id: '991266457'
                           type: admin
                           name: Ciaran194 Lee
                           email: admin194@email.com
@@ -5503,20 +5510,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '351'
-                    created_at: 1709050375
-                    updated_at: 1709050376
+                    id: '62'
+                    created_at: 1709225930
+                    updated_at: 1709225932
                     waiting_since:
-                    snoozed_until: 1709053976
+                    snoozed_until: 1709229531
                     source:
                       type: conversation
-                      id: '403918270'
+                      id: '403918102'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267495'
+                        id: '991266459'
                         name: Ciaran195 Lee
                         email: admin195@email.com
                       attachments: []
@@ -5526,7 +5533,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0a07ba4d128431e8e29c
+                        id: 65e0b7ca6abd01780bbd19f8
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5548,15 +5555,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '82'
+                        id: '11'
                         part_type: snoozed
                         body:
-                        created_at: 1709050376
-                        updated_at: 1709050376
-                        notified_at: 1709050376
+                        created_at: 1709225932
+                        updated_at: 1709225932
+                        notified_at: 1709225932
                         assigned_to:
                         author:
-                          id: '991267495'
+                          id: '991266459'
                           type: admin
                           name: Ciaran195 Lee
                           email: admin195@email.com
@@ -5567,20 +5574,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '356'
-                    created_at: 1709050375
-                    updated_at: 1709050384
+                    id: '67'
+                    created_at: 1709225930
+                    updated_at: 1709225939
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918271'
+                      id: '403918103'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267497'
+                        id: '991266461'
                         name: Ciaran196 Lee
                         email: admin196@email.com
                       attachments: []
@@ -5590,7 +5597,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0a0cba4d128431e8e2a1
+                        id: 65e0b7cf6abd01780bbd19fd
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5612,15 +5619,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '84'
+                        id: '13'
                         part_type: open
                         body:
-                        created_at: 1709050384
-                        updated_at: 1709050384
-                        notified_at: 1709050384
+                        created_at: 1709225939
+                        updated_at: 1709225939
+                        notified_at: 1709225939
                         assigned_to:
                         author:
-                          id: '991267497'
+                          id: '991266461'
                           type: admin
                           name: Ciaran196 Lee
                           email: admin196@email.com
@@ -5631,20 +5638,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '360'
-                    created_at: 1709050385
-                    updated_at: 1709050386
+                    id: '71'
+                    created_at: 1709225941
+                    updated_at: 1709225942
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918274'
+                      id: '403918106'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267499'
+                        id: '991266463'
                         name: Ciaran197 Lee
                         email: admin197@email.com
                       attachments: []
@@ -5654,9 +5661,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0a11ba4d128431e8e2a4
+                        id: 65e0b7d46abd01780bbd1a00
                     first_contact_reply:
-                    admin_assignee_id: 991267499
+                    admin_assignee_id: 991266463
                     team_assignee_id:
                     open: true
                     state: open
@@ -5676,17 +5683,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '85'
+                        id: '14'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1709050386
-                        updated_at: 1709050386
-                        notified_at: 1709050386
+                        created_at: 1709225942
+                        updated_at: 1709225942
+                        notified_at: 1709225942
                         assigned_to:
                           type: admin
-                          id: '991267499'
+                          id: '991266463'
                         author:
-                          id: '991267499'
+                          id: '991266463'
                           type: admin
                           name: Ciaran197 Lee
                           email: admin197@email.com
@@ -5704,7 +5711,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 7f672045-822a-40d3-a3d6-b0dc3084efa7
+                    request_id: f3cd2515-fa7e-4a9e-bcbc-0cce62dbdfb1
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5718,7 +5725,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8f735c3d-62d6-4ec9-91b3-b19bed6a554f
+                    request_id: 31074189-f181-423f-8968-031bd386533d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5732,7 +5739,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: b45af626-29d9-471a-b483-b25fecfb58b8
+                    request_id: 4c21fa16-479c-485d-8e94-9afbfa0e2695
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5753,32 +5760,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991267493
+                  admin_id: 991266457
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991267495
-                  snoozed_until: 1709053976
+                  admin_id: 991266459
+                  snoozed_until: 1709229531
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991267497
+                  admin_id: 991266461
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991267499
-                  assignee_id: 991267499
+                  admin_id: 991266463
+                  assignee_id: 991266463
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991267501
+                  admin_id: 991266465
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -5809,20 +5816,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '364'
-                    created_at: 1709050392
-                    updated_at: 1709050393
+                    id: '75'
+                    created_at: 1709225948
+                    updated_at: 1709225948
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918278'
+                      id: '403918110'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267507'
+                        id: '991266471'
                         name: Ciaran201 Lee
                         email: admin201@email.com
                       attachments: []
@@ -5832,7 +5839,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0a18ba4d128431e8e2a8
+                        id: 65e0b7db6abd01780bbd1a04
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5854,17 +5861,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '86'
+                        id: '15'
                         part_type: default_assignment
                         body:
-                        created_at: 1709050393
-                        updated_at: 1709050393
-                        notified_at: 1709050393
+                        created_at: 1709225948
+                        updated_at: 1709225948
+                        notified_at: 1709225948
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991267508'
+                          id: '991266472'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id357_that_should_be_at_least_@intercom.io
@@ -5882,7 +5889,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 18441643-b3df-4782-9fb1-7c14307e3cd2
+                    request_id: 9c1f543d-44d1-4d23-9813-b18603885519
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5896,7 +5903,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5c7be46c-bc16-407e-9ab2-422c15601ded
+                    request_id: 9f07fd6b-1962-4a8b-a7c8-b830e470a6d6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5910,7 +5917,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: e1c390dc-fb62-4bff-9809-38f770bfbe90
+                    request_id: e45f9d60-dca1-41a9-ad45-a8129d82dec8
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5934,11 +5941,13 @@ paths:
       tags:
       - Conversations
       operationId: attachContactToConversation
-      description: "You can add participants who are contacts to a conversation, on
-        behalf of either another contact or an admin.\n\n> \U0001F6A7 Note about contacts
-        without an email\n>\n> If you add a contact via the email parameter and there
-        is no user/lead found on that workspace with he given email, then we will
-        create a new contact with `role` set to `lead`.\n\n"
+      description: |+
+        You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.
+
+        {% admonition type="attention" name="Contacts without an email" %}
+        If you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.
+        {% /admonition %}
+
       responses:
         '200':
           description: Attach a contact to a conversation
@@ -5949,7 +5958,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65de0a1eba4d128431e8e2ac
+                      id: 65e0b7e26abd01780bbd1a08
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -5960,7 +5969,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: d95f2bec-d917-45e9-a7b9-ebac934855af
+                    request_id: 46d6e70c-b62d-4459-8197-a777f219c37f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5974,7 +5983,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 22a0c185-437c-4ee1-a510-77ba892f4d24
+                    request_id: 124560f8-88b1-4488-9715-48710e5bdde2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5988,7 +5997,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: de8fb16d-8998-4fb5-9338-6aae47e2b323
+                    request_id: 8d9bbbeb-ec62-4d06-b479-8e6535439984
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6003,15 +6012,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991267515
+                  admin_id: 991266479
                   customer:
-                    intercom_user_id: 65de0a1eba4d128431e8e2ac
+                    intercom_user_id: 65e0b7e26abd01780bbd1a08
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991267517
+                  admin_id: 991266481
                   customer:
-                    intercom_user_id: 65de0a20ba4d128431e8e2ad
+                    intercom_user_id: 65e0b7e46abd01780bbd1a09
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -6037,11 +6046,13 @@ paths:
       tags:
       - Conversations
       operationId: detachContactFromConversation
-      description: "You can add participants who are contacts to a conversation, on
-        behalf of either another contact or an admin.\n\n> \U0001F6A7 Note about contacts
-        without an email\n>\n> If you add a contact via the email parameter and there
-        is no user/lead found on that workspace with he given email, then we will
-        create a new contact with `role` set to `lead`.\n\n"
+      description: |+
+        You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.
+
+        {% admonition type="attention" name="Contacts without an email" %}
+        If you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.
+        {% /admonition %}
+
       responses:
         '200':
           description: Detach a contact from a group conversation
@@ -6052,7 +6063,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65de0a2bba4d128431e8e2b7
+                      id: 65e0b7f16abd01780bbd1a13
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6063,14 +6074,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: e7c66673-ba6a-407f-aa7e-ed7de0551bf6
+                    request_id: 45f38dbf-f892-4a73-bc71-c92d65a7e99b
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 80fa8961-228f-4f5e-a94d-0a5ead1df0d4
+                    request_id: d8f86bed-e3e5-49a4-a414-8d6d7becb73b
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -6084,7 +6095,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: acb8b57a-ff7d-46d0-ad2a-87e2c007b514
+                    request_id: 07e95fe0-f8c1-417e-8579-60e4b2da8323
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -6098,7 +6109,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: df6eb5f7-1a88-4c0a-ba97-86710ec39e42
+                    request_id: bfff6e48-4d72-4c03-89d4-1b63cc537a5f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6112,7 +6123,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 68320243-7387-4f8a-98fc-91afa6adb1fb
+                    request_id: 855d3fb7-a8db-45b3-9e9b-2c1c46ce0953
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6127,27 +6138,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991267523
+                  admin_id: 991266487
                   customer:
-                    intercom_user_id: 65de0a25ba4d128431e8e2b0
+                    intercom_user_id: 65e0b7e96abd01780bbd1a0c
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991267525
+                  admin_id: 991266489
                   customer:
-                    intercom_user_id: 65de0a2cba4d128431e8e2b8
+                    intercom_user_id: 65e0b7f26abd01780bbd1a14
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991267527
+                  admin_id: 991266491
                   customer:
-                    intercom_user_id: 65de0a34ba4d128431e8e2bf
+                    intercom_user_id: 65e0b7fa6abd01780bbd1a1b
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991267529
+                  admin_id: 991266493
                   customer:
-                    intercom_user_id: 65de0a3cba4d128431e8e2c6
+                    intercom_user_id: 65e0b8026abd01780bbd1a22
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6159,12 +6170,13 @@ paths:
       tags:
       - Conversations
       operationId: redactConversation
-      description: "You can redact a conversation part or the source message of a
-        conversation (as seen in the source object).\n\n> \U0001F4D8 Which parts and
-        source messages can I redact?\n>\n> If you are redacting a conversation part,
-        it must have a `body`.\n> If you are redacting a source message, it must have
-        been created by a contact.\n> We will return a `conversation_part_not_redactable`
-        error if these criteria are not met.\n\n"
+      description: |+
+        You can redact a conversation part or the source message of a conversation (as seen in the source object).
+
+        {% admonition type="info" name="Redacting parts and messages" %}
+        If you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.
+        {% /admonition %}
+
       responses:
         '200':
           description: Redact a conversation part
@@ -6174,20 +6186,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '420'
-                    created_at: 1709050450
-                    updated_at: 1709050452
-                    waiting_since: 1709050451
+                    id: '131'
+                    created_at: 1709226011
+                    updated_at: 1709226013
+                    waiting_since: 1709226012
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918304'
+                      id: '403918136'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267535'
+                        id: '991266499'
                         name: Ciaran215 Lee
                         email: admin215@email.com
                       attachments: []
@@ -6197,9 +6209,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0a52ba4d128431e8e2db
+                        id: 65e0b81b6abd01780bbd1a37
                     first_contact_reply:
-                      created_at: 1709050451
+                      created_at: 1709226012
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6222,15 +6234,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '94'
+                        id: '23'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1709050451
-                        updated_at: 1709050452
-                        notified_at: 1709050451
+                        created_at: 1709226012
+                        updated_at: 1709226013
+                        notified_at: 1709226012
                         assigned_to:
                         author:
-                          id: 65de0a52ba4d128431e8e2db
+                          id: 65e0b81b6abd01780bbd1a37
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6248,7 +6260,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: dc785d4f-223a-4e18-85bb-fd122cb9fcb6
+                    request_id: 13c10542-aa3d-4fd3-9b5b-e01ca550eb60
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -6262,7 +6274,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9eb78203-45eb-44d0-a491-2ee5561b0998
+                    request_id: 77b4c369-0530-4586-849e-53b976e7bf43
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6278,8 +6290,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 420
-                  conversation_part_id: 94
+                  conversation_id: 131
+                  conversation_part_id: 23
               not_found:
                 summary: Not found
                 value:
@@ -6466,7 +6478,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 34
+                    - id: 2
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -6479,9 +6491,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991267560'
-                      created_at: 1709050464
-                      updated_at: 1709050464
+                      admin_id: '991266524'
+                      created_at: 1709226025
+                      updated_at: 1709226025
                       model: company
                     - type: data_attribute
                       name: id
@@ -6553,7 +6565,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2c590a87-f279-4fda-8dc1-e864a0e8a4dc
+                    request_id: 43c44629-ae2f-43ff-ac1e-57a232a9d606
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6578,7 +6590,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 37
+                    id: 5
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -6589,9 +6601,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991267562'
-                    created_at: 1709050465
-                    updated_at: 1709050465
+                    admin_id: '991266526'
+                    created_at: 1709226026
+                    updated_at: 1709226026
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6603,7 +6615,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: d8d6f5c6-3954-4de0-9e64-7a7aece28c79
+                    request_id: 4def5e8a-babb-49e1-92ac-88a04211d653
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6611,7 +6623,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: e854cf07-d0c5-46f3-b620-3cd2cf3209f3
+                    request_id: e3d42743-936e-487c-b5e0-98126ba22433
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -6619,7 +6631,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: 47c52e7b-5ca7-4b33-8948-d8ce69aa6472
+                    request_id: 4ea27434-2387-4a6d-940a-07670525196b
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6627,14 +6639,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: 6214a279-0d3b-41c8-8ba2-fb6d460f59ca
+                    request_id: 68adb27a-0b11-4585-9b88-d76b3a1c92d2
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: abaa0f14-662f-4ec8-af11-6031e800f4b9
+                    request_id: c50303ca-8c77-4bd6-96d8-56462fe0c78d
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -6649,7 +6661,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9f37e4e8-ddc4-411c-9648-f1100f722c46
+                    request_id: 38239f56-2a33-4e21-93a2-8542f5ac7fdb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6728,7 +6740,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 44
+                    id: 12
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -6743,9 +6755,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991267569'
-                    created_at: 1709050468
-                    updated_at: 1709050468
+                    admin_id: '991266533'
+                    created_at: 1709226029
+                    updated_at: 1709226030
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6757,7 +6769,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: c997a072-108e-462f-a2fa-cff4a983c33a
+                    request_id: 9641e3b3-4fbc-4df1-9f1a-cd7c27771271
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -6771,7 +6783,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: a0fba8a0-11d3-4f99-b03e-adaea51fa2aa
+                    request_id: 65374b59-a083-441b-8be8-a9c4b1543f19
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -6785,7 +6797,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: 7010036a-6cf4-49b9-834e-be4dd6187d8d
+                    request_id: e715f394-012a-4a09-8d0e-a27c9499d895
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -6800,7 +6812,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 94093ce5-d387-4332-ba7d-fde8f913012f
+                    request_id: fdda5347-a809-4c4f-ad76-daaf9fc4b17d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6905,7 +6917,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6efcba7a-248a-4613-9a10-290e0a27c521
+                    request_id: 7de27288-56dc-4b26-8f0b-c188c7072150
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6992,7 +7004,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 65de0a68ba4d128431e8e2e4
+                    intercom_user_id: 65e0b8326abd01780bbd1a40
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -7004,7 +7016,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fbadd549-8f09-4338-a95c-b8507b507846
+                    request_id: d1d700b4-e37c-41cc-9782-1fe696fd1d34
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7035,7 +7047,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3a019f4d-96bf-47be-aa49-248213a1fddc
+                    request_id: 67c98ed3-56ca-479a-a6ca-147bed37e8b7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7079,7 +7091,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: 8j2k0z25vnf3ibsy
+                    job_identifier: 94faed5gh8jd7k1n
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7094,8 +7106,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1709032474
-                  created_at_before: 1709050474
+                  created_at_after: 1709208036
+                  created_at_before: 1709226036
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -7129,7 +7141,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: xdohwu1p0ajl7qmf
+                    job_identifier: yp0bnq2jotg8gpyg
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7161,7 +7173,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: e7v36xri5baxubt3
+                    job_identifier: fmmuapt5pvgaryko
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -7222,30 +7234,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918309'
-                    created_at: 1709050477
+                    id: '403918141'
+                    created_at: 1709226039
                     body: heyy
                     message_type: inapp
-                    conversation_id: '425'
+                    conversation_id: '136'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918310'
-                    created_at: 1709050478
+                    id: '403918142'
+                    created_at: 1709226040
                     body: heyy
                     message_type: inapp
-                    conversation_id: '426'
+                    conversation_id: '137'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '15'
-                    created_at: 1709050479
+                    id: '5'
+                    created_at: 1709226041
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991267592'
+                      id: '991266556'
                       name: Ciaran265 Lee
                       email: admin265@email.com
                       away_mode_enabled: false
@@ -7260,14 +7272,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: ac04f741-0332-4699-8c33-36dd8ccceb5d
+                    request_id: 66d784f6-ed48-4e72-9e1e-f179178cff9e
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: fc703b0b-e926-4222-ab1e-8e89b6dcf608
+                    request_id: ea54cb2e-a826-40d6-ba87-78825f3c8dd0
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -7281,7 +7293,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: 5a96ef55-72d0-4050-8a97-f8960bb0025e
+                    request_id: 7a70a037-72d1-4af2-a8cf-683cac513ea2
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -7295,7 +7307,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ebbc4faa-f116-4237-a9e0-168ff56ec518
+                    request_id: 45516366-27b7-414f-a3cb-410c7a163328
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7309,7 +7321,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: e79ff8f9-99b1-4b2b-bdfb-51876ddb4aa5
+                    request_id: 967eecdd-e474-4637-a883-7cd96c6fe895
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -7326,7 +7338,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65de0a6dba4d128431e8e2e9
+                    id: 65e0b8376abd01780bbd1a45
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -7334,7 +7346,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 65de0a6eba4d128431e8e2ea
+                    id: 65e0b8386abd01780bbd1a46
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -7342,10 +7354,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267592'
+                    id: '991266556'
                   to:
                     type: user
-                    id: 65de0a6fba4d128431e8e2eb
+                    id: 65e0b8396abd01780bbd1a47
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -7353,10 +7365,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267594'
+                    id: '991266558'
                   to:
                     type: user
-                    id: 65de0a70ba4d128431e8e2ec
+                    id: 65e0b83a6abd01780bbd1a48
                   message_type: inapp
                   body:
                   subject: heyy
@@ -7365,7 +7377,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267595'
+                    id: '991266559'
                   to:
                     type: user
                     user_id: '70'
@@ -7376,10 +7388,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267596'
+                    id: '991266560'
                   to:
                     type: user
-                    id: 65de0a71ba4d128431e8e2ee
+                    id: 65e0b83b6abd01780bbd1a4a
                   message_type: email
                   body:
                   subject: heyy
@@ -7410,12 +7422,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '28'
+                    - id: '1'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991267601
+                      sender_id: 991266565
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7425,15 +7437,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709050482
-                      updated_at: 1709050482
+                      created_at: 1709226045
+                      updated_at: 1709226045
                       newsfeed_assignments: []
-                    - id: '29'
+                    - id: '2'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991267603
+                      sender_id: 991266567
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7443,8 +7455,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709050482
-                      updated_at: 1709050482
+                      created_at: 1709226045
+                      updated_at: 1709226045
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -7457,7 +7469,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f1bfe306-91d5-4f50-8039-0259f4ce190e
+                    request_id: 180240a0-e1e4-4096-9645-dd403295fdf7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7482,12 +7494,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '32'
+                    id: '5'
                     type: news-item
                     workspace_id: this_is_an_id483_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991267610
+                    sender_id: 991266574
                     state: live
                     labels:
                     - New
@@ -7498,10 +7510,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1709050484
-                    updated_at: 1709050484
+                    created_at: 1709226047
+                    updated_at: 1709226047
                     newsfeed_assignments:
-                    - newsfeed_id: 53
+                    - newsfeed_id: 3
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7513,7 +7525,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 50b4b635-c022-40d6-8712-65034a8c40cc
+                    request_id: ee0616d2-30df-4cb4-a5b4-2370f0fa78d1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7534,14 +7546,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991267610
+                  sender_id: 991266574
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 53
+                  - newsfeed_id: 3
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -7570,12 +7582,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '33'
+                    id: '6'
                     type: news-item
                     workspace_id: this_is_an_id487_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991267613
+                    sender_id: 991266577
                     state: live
                     labels: []
                     cover_image_url:
@@ -7585,11 +7597,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1709050485
-                    updated_at: 1709050485
+                    created_at: 1709226048
+                    updated_at: 1709226048
                     newsfeed_assignments:
-                    - newsfeed_id: 55
-                      published_at: 1709050485
+                    - newsfeed_id: 5
+                      published_at: 1709226048
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -7600,7 +7612,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 7a0299af-1141-43ea-94fd-e0e6bfccd79c
+                    request_id: d96fa3d2-45be-4694-91d4-6157439645c3
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7614,7 +7626,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 26664b19-e289-4b3c-847f-234e61a09d56
+                    request_id: 8ade289a-3359-4706-93d9-423017ae9ace
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7645,12 +7657,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '36'
+                    id: '9'
                     type: news-item
                     workspace_id: this_is_an_id493_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991267621
+                    sender_id: 991266585
                     state: live
                     labels: []
                     cover_image_url:
@@ -7658,8 +7670,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1709050487
-                    updated_at: 1709050487
+                    created_at: 1709226050
+                    updated_at: 1709226050
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7671,7 +7683,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: e0e97a68-4ad1-4ecb-89eb-c3a9ed3d2688
+                    request_id: 1d29f80a-e430-434f-8b6e-0a913746323b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7685,7 +7697,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2a9d9b40-ef33-43a5-b58a-014beaaf2f8b
+                    request_id: 07522f58-81fe-4acd-a5ec-6923b3cc30be
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7702,7 +7714,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991267621
+                  sender_id: 991266585
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7711,7 +7723,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991267624
+                  sender_id: 991266588
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7741,7 +7753,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '39'
+                    id: '12'
                     object: news-item
                     deleted: true
               schema:
@@ -7754,7 +7766,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 19df1992-c1fe-40bc-aca4-d426c705e5ce
+                    request_id: f747d884-9d15-4196-9497-a89e27e66df5
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7768,7 +7780,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e10ab413-d6ad-4434-bc6d-eadcd2c8cd1f
+                    request_id: b89683d7-d8a1-4ee0-849b-98f931b4123e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7821,7 +7833,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ba6280f2-285d-4219-a8c4-9a1fe9a810b1
+                    request_id: bf1ad2a3-7838-4d73-8cfc-42a7825a0eef
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7854,16 +7866,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '68'
+                    - id: '18'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709050492
-                      updated_at: 1709050492
-                    - id: '69'
+                      created_at: 1709226055
+                      updated_at: 1709226055
+                    - id: '19'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709050492
-                      updated_at: 1709050492
+                      created_at: 1709226055
+                      updated_at: 1709226055
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -7875,7 +7887,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '071683f8-8536-4ce1-9cfc-ad31bb7f0558'
+                    request_id: 3c808f9f-16fd-4c0d-8270-8220f80db0e9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7909,11 +7921,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '72'
+                    id: '22'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1709050493
-                    updated_at: 1709050493
+                    created_at: 1709226056
+                    updated_at: 1709226056
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -7924,7 +7936,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 70435f9f-2d14-4665-93ef-c53904aa6b32
+                    request_id: 63b8b07a-7c1c-45fb-8734-ee50d2c6db07
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7958,14 +7970,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '37'
-                    created_at: 1708359293
+                    id: '11'
+                    created_at: 1708534857
                     contact:
                       type: contact
-                      id: 65de0a7dba4d128431e8e2f1
+                      id: 65e0b8496abd01780bbd1a4d
                     author:
                       type: admin
-                      id: '991267640'
+                      id: '991266604'
                       name: Ciaran312 Lee
                       email: admin312@email.com
                       away_mode_enabled: false
@@ -7981,7 +7993,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: 555542d7-f743-420c-b7ef-01b1412071d5
+                    request_id: 53e51d3e-e15b-4fbb-ab3e-aaa2c7b1c558
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7995,7 +8007,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: eb8485f9-a8f8-4a30-a546-23710a3f6594
+                    request_id: 16443f9a-f3cd-41ac-b71c-ffd921e8fc0c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8031,16 +8043,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 65de0a7fba4d128431e8e2f4
+                      id: 65e0b84a6abd01780bbd1a50
                       name: John segment
-                      created_at: 1709050495
-                      updated_at: 1709050495
+                      created_at: 1709226058
+                      updated_at: 1709226058
                       person_type: user
                     - type: segment
-                      id: 65de0a7fba4d128431e8e2f5
+                      id: 65e0b84a6abd01780bbd1a51
                       name: Jane segment
-                      created_at: 1709050495
-                      updated_at: 1709050495
+                      created_at: 1709226058
+                      updated_at: 1709226058
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -8052,7 +8064,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 99ee9c74-03fd-466b-ad6b-b725fbfa50d0
+                    request_id: a7c7ffe4-1c3c-4ef5-9871-f9b08c1e67bd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8086,10 +8098,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 65de0a80ba4d128431e8e2f8
+                    id: 65e0b84b6abd01780bbd1a54
                     name: John segment
-                    created_at: 1709050496
-                    updated_at: 1709050496
+                    created_at: 1709226059
+                    updated_at: 1709226059
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -8101,7 +8113,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: d64567cf-1c15-4c87-ae0f-87e95b3a25bc
+                    request_id: 4e8d10c1-3ddd-44a6-a865-d83fd0c7a317
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8115,7 +8127,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a03737f1-587e-40ba-87b5-9cf6ecbdf38c
+                    request_id: 7903a259-d1c3-489d-bab0-65ac56a607f7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8145,7 +8157,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '137'
+                      id: '45'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -8168,7 +8180,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cc2bd09f-c482-48f3-9ee7-a3a51b8771fd
+                    request_id: d52c7000-71ef-4539-9dd2-7e00b5e97ff7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8198,7 +8210,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/ce1a9455-9fd7-40c2-bb2f-fe4a93ad7ed8
+                    url: http://via.intercom.io/msgr/572a54a1-f018-4695-9ce8-e242ea88ecb1
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -8231,7 +8243,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2be86d34-9fd4-45a1-8f25-43e2c2926511
+                    request_id: ae5d3cfc-b968-4a7b-9d5f-b8cc02ddad13
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8294,7 +8306,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '110'
+                      id: '23'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -8306,7 +8318,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2c0d07a6-2d50-45bb-a18a-52e2b89420e1
+                    request_id: add3c89f-7046-4e87-a368-5e31faf518ed
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8345,7 +8357,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '113'
+                    id: '26'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8357,7 +8369,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: adf820e2-9e70-45e2-9b1c-5a6f0363681e
+                    request_id: 9bc03e77-e5ca-452a-a1dc-dd67a4d5179b
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -8371,14 +8383,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: ac89d1be-072e-4a51-b2d2-4aab9ecbd159
+                    request_id: ff4da227-ee3b-406e-8240-0a34c089ce99
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: 34403e75-de54-45dd-aa5a-875447a70cbb
+                    request_id: da09e7c4-7831-4e28-b5ef-265a3eef99de
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -8392,7 +8404,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ea3bc152-3846-400f-b2ad-c5c5c7ef52d7
+                    request_id: 44a51ad4-09a0-4bd0-9d0d-06b3c0598e3f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8458,7 +8470,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '121'
+                    id: '34'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8470,7 +8482,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: fd531325-bcb7-4688-9238-140b9b83c903
+                    request_id: aee06eaf-a4da-4512-b8ff-01b7529cda02
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8484,7 +8496,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d88f23d6-8d7d-4680-978f-a0941f9835c3
+                    request_id: 71334029-5219-413d-8740-3802e1ca6bbc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8520,7 +8532,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 3b62b770-dde9-4de4-a95b-85f201b8c607
+                    request_id: d8bfd8b1-f269-4496-b8d5-dc18ddb1b3ff
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8534,7 +8546,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: 3234e31a-f460-4a64-b398-aac8cf9093d9
+                    request_id: 2c8be2bd-0f81-473e-aa0d-6d395e9ad0d8
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -8549,7 +8561,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: da3826c5-a0d5-4b8d-a339-3d6e901d6405
+                    request_id: 45088660-6a24-4236-9f4f-779c92833cb1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8587,7 +8599,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9f4ff40e-f354-4087-a2ee-21c203c2bce4
+                    request_id: 806768a3-a8ff-490f-9587-0e10817bef4d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8622,7 +8634,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991267678'
+                    id: '991266642'
                     name: team 1
                     admin_ids: []
               schema:
@@ -8635,7 +8647,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: b314b8d9-7046-4274-94a0-a2a20be1d37f
+                    request_id: b608cdb9-6e0b-4910-ad33-4f7453bccdb7
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -8649,7 +8661,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3c7f80b0-cb9e-466b-82e0-98b4d56a05ea
+                    request_id: 26f2e210-62b9-4e25-b3d8-0c39dce82193
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8681,26 +8693,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0a9bba4d128431e8e31c
+                    id: 65e0b8686abd01780bbd1a78
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Silver Stroller
+                    pseudonym: Grey Deer
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/silver-stroller.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/grey-deer.png
                     app_id: this_is_an_id609_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709050524
-                    remote_created_at: 1709050523
-                    signed_up_at: 1709050523
-                    updated_at: 1709050524
+                    created_at: 1709226088
+                    remote_created_at: 1709226088
+                    signed_up_at: 1709226088
+                    updated_at: 1709226088
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8733,7 +8745,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 2933ffe9-34ec-4861-9d1f-0830fd276083
+                    request_id: 803f45eb-26ec-4599-be0d-84eb1c67ca95
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8747,7 +8759,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bff6a6c5-1a31-4fde-802b-1a10895b15b2
+                    request_id: 5b297d94-166e-49a3-a89a-f74d34328d8f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8762,7 +8774,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 65de0a9bba4d128431e8e31c
+                  id: 65e0b8686abd01780bbd1a78
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -8795,7 +8807,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0a9dba4d128431e8e322
+                    id: 65e0b8696abd01780bbd1a7e
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -8811,10 +8823,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709050525
-                    remote_created_at: 1709050525
-                    signed_up_at: 1709050525
-                    updated_at: 1709050525
+                    created_at: 1709226089
+                    remote_created_at: 1709226089
+                    signed_up_at: 1709226089
+                    updated_at: 1709226089
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8847,7 +8859,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: c3998d4e-d8d9-405d-95dd-6aada6eaf264
+                    request_id: ec1f858b-ccd2-40db-915c-7c65a47157e8
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8861,7 +8873,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 93d9bae8-dcbf-4863-b16b-7d28579dd575
+                    request_id: c8a4e5aa-c572-4b69-97ba-9298361b9873
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8895,7 +8907,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0a9fba4d128431e8e328
+                    id: 65e0b86b6abd01780bbd1a84
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -8911,10 +8923,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709050527
-                    remote_created_at: 1709050527
-                    signed_up_at: 1709050527
-                    updated_at: 1709050527
+                    created_at: 1709226091
+                    remote_created_at: 1709226091
+                    signed_up_at: 1709226091
+                    updated_at: 1709226091
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8947,7 +8959,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: '09428d42-2574-46b3-b59c-0ad34ca2caab'
+                    request_id: 0bedf1e0-1b93-4da9-b353-d5849d751e62
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8961,7 +8973,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 184922e9-3339-40fc-8f8c-fa5e9fe52d36
+                    request_id: 7b7f3e10-99bc-46fb-9ca7-6ce7af0a5ae4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8994,7 +9006,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0aa1ba4d128431e8e32e
+                    id: 65e0b86d6abd01780bbd1a8a
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -9010,10 +9022,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709050529
-                    remote_created_at: 1709050529
-                    signed_up_at: 1709050529
-                    updated_at: 1709050529
+                    created_at: 1709226093
+                    remote_created_at: 1709226093
+                    signed_up_at: 1709226093
+                    updated_at: 1709226093
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -9046,7 +9058,7 @@ paths:
                 Visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 5f16c947-48fc-4452-bad7-15432afb686b
+                    request_id: f92c8d79-f2bd-4a7b-b28a-12fdf7178b49
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -9060,7 +9072,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 150029a0-34c2-4e15-9ea4-64e45d9767b3
+                    request_id: 2019606f-2403-4ded-ac71-8d26d7d6e5b4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9091,7 +9103,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0aa2ba4d128431e8e335
+                    id: 65e0b86f6abd01780bbd1a91
                     workspace_id: this_is_an_id633_that_should_be_at_least_
                     external_id:
                     role: user
@@ -9106,9 +9118,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709050530
-                    updated_at: 1709050531
-                    signed_up_at: 1709050530
+                    created_at: 1709226095
+                    updated_at: 1709226095
+                    signed_up_at: 1709226094
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -9142,31 +9154,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0aa2ba4d128431e8e335/tags"
+                      url: "/contacts/65e0b86f6abd01780bbd1a91/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0aa2ba4d128431e8e335/notes"
+                      url: "/contacts/65e0b86f6abd01780bbd1a91/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0aa2ba4d128431e8e335/companies"
+                      url: "/contacts/65e0b86f6abd01780bbd1a91/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0aa2ba4d128431e8e335/subscriptions"
+                      url: "/contacts/65e0b86f6abd01780bbd1a91/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0aa2ba4d128431e8e335/subscriptions"
+                      url: "/contacts/65e0b86f6abd01780bbd1a91/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -9185,7 +9197,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: afbe6231-1c8d-4f07-acdb-ad7298e0412a
+                    request_id: b9eb5918-e563-47c1-a2aa-90daaf2d1ad7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9453,12 +9465,32 @@ components:
           description: The id of the admin who is authoring the comment.
           example: '3156780'
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -10796,12 +10828,32 @@ components:
           type: string
           description: The email you have defined for the user.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -10829,12 +10881,32 @@ components:
           type: string
           description: The identifier for the contact as given by Intercom.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -10862,12 +10934,32 @@ components:
           type: string
           description: The external_id you have defined for the contact.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991267764'
+                    id: '991266728'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1709050635
+                      created_at: 1709226106
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991267765'
+                    id: '991266729'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: d24dd3ad-0759-4888-87b1-bc515c995f51
+                    request_id: c1d3117c-2d58-4c6b-8010-809360595b68
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 93138853-df9a-4b7f-a4f7-3bf81a0c0828
+                    request_id: 0f5dea50-e500-4e5e-ae51-9257ddb651de
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: 8df3f936-6f51-40ea-9b5c-1a455bc6bbe9
+                    - id: 5686ea27-56ef-4a40-bfb0-91785dec7a27
                       performed_by:
                         type: admin
-                        id: '991267769'
+                        id: '991266733'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1709050642
+                      created_at: 1709226112
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: 48e29dee-9a28-442d-b646-c6e0abc9513c
+                    - id: f444ae78-f556-429b-9174-550567230f13
                       performed_by:
                         type: admin
-                        id: '991267769'
+                        id: '991266733'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1709050642
+                      created_at: 1709226112
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6af2e105-c841-4829-8164-43d9472332ca
+                    request_id: d4677cbf-3c00-45fa-aea8-fdfd13fcf0ed
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991267771'
+                      id: '991266735'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e6500979-713c-48d0-aec0-0b77490a1871
+                    request_id: 84e336e8-e441-405d-b405-aef2d2690544
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991267773'
+                    id: '991266737'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: d0ce6fee-10aa-46f9-87bb-cd75a46005d7
+                    request_id: fa109ba4-5df2-44ad-bb2f-148da63529d6
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a4da9626-d600-4e65-94ac-ec98f4ffaaf3
+                    request_id: 7579884d-64de-4e64-9ac9-71442edd434f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -390,20 +390,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '54'
+                    - id: '23'
                       type: article
                       workspace_id: this_is_an_id22_that_should_be_at_least_4
-                      parent_id: 216
+                      parent_id: 77
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991267776
+                      author_id: 991266740
                       state: published
-                      created_at: 1709050646
-                      updated_at: 1709050646
-                      url: http://help-center.test/myapp-22/en/articles/54-this-is-the-article-title
+                      created_at: 1709226117
+                      updated_at: 1709226117
+                      url: http://help-center.test/myapp-22/en/articles/23-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -414,7 +414,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e9400496-0379-493e-b881-fe0fb749f5f6
+                    request_id: 1b8f8090-e073-45ab-8848-73ac7fa58205
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -439,10 +439,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '57'
+                    id: '26'
                     type: article
                     workspace_id: this_is_an_id26_that_should_be_at_least_4
-                    parent_id: 218
+                    parent_id: 79
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -456,11 +456,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991267781
+                    author_id: 991266745
                     state: published
-                    created_at: 1709050648
-                    updated_at: 1709050648
-                    url: http://help-center.test/myapp-26/en/articles/57-thanks-for-everything
+                    created_at: 1709226119
+                    updated_at: 1709226119
+                    url: http://help-center.test/myapp-26/en/articles/26-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -471,7 +471,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: ac45005e-1394-4ed1-a1ba-1098a4963af6
+                    request_id: 8b90c4e0-ff5e-4e46-99d9-b9510e604dba
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -486,7 +486,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d382f58d-c96d-4163-a55c-4b394c409952
+                    request_id: 8d165f9b-c39e-43ba-af6f-9be097c0d38f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -504,16 +504,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991267781
+                  author_id: 991266745
                   state: published
-                  parent_id: 218
+                  parent_id: 79
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991267781
+                      author_id: 991266745
                       state: published
               bad_request:
                 summary: Bad Request
@@ -550,10 +550,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '60'
+                    id: '29'
                     type: article
                     workspace_id: this_is_an_id32_that_should_be_at_least_4
-                    parent_id: 221
+                    parent_id: 82
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -567,11 +567,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991267786
+                    author_id: 991266750
                     state: published
-                    created_at: 1709050651
-                    updated_at: 1709050651
-                    url: http://help-center.test/myapp-32/en/articles/60-this-is-the-article-title
+                    created_at: 1709226121
+                    updated_at: 1709226121
+                    url: http://help-center.test/myapp-32/en/articles/29-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -582,7 +582,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: 5ec2ead9-3c69-4e67-9390-574f4670165f
+                    request_id: accd2af8-8026-450c-bae7-4bda3adc75f2
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -596,7 +596,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8085ebdc-17c9-4b5a-9b71-fa83bf8c6328
+                    request_id: '09f1292b-7619-4227-8a8d-57c0dc86afae'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -629,10 +629,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '63'
+                    id: '32'
                     type: article
                     workspace_id: this_is_an_id38_that_should_be_at_least_4
-                    parent_id: 224
+                    parent_id: 85
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -646,11 +646,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991267792
+                    author_id: 991266756
                     state: published
-                    created_at: 1709050653
-                    updated_at: 1709050653
-                    url: http://help-center.test/myapp-38/en/articles/63-christmas-is-here
+                    created_at: 1709226123
+                    updated_at: 1709226124
+                    url: http://help-center.test/myapp-38/en/articles/32-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -661,7 +661,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 29a1008e-1cc2-4853-8539-7ead6d66deb0
+                    request_id: 83e5f423-e60f-4d29-86ad-365ea97bb325
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -675,7 +675,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0d0aa63d-be38-421d-8746-0e072483f1cf
+                    request_id: 92270187-d774-4221-a6d9-5beeb411bb19
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -723,7 +723,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '66'
+                    id: '35'
                     object: article
                     deleted: true
               schema:
@@ -736,7 +736,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 4c07b260-1678-49f4-ba28-2d17066dc59f
+                    request_id: 0c0b325e-5b1c-4ba0-8b33-00d2fe749ca8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -750,7 +750,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e9c1b7c9-78f2-405e-806f-1d6419fdb926
+                    request_id: df01a12b-8d83-416b-9e11-6eacedacfe4f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -781,16 +781,16 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '232'
+                    - id: '93'
                       workspace_id: this_is_an_id52_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-52/collection-17
                       order: 17
-                      created_at: 1709050658
-                      updated_at: 1709050658
+                      created_at: 1709226128
+                      updated_at: 1709226128
                       description: english collection description
                       icon: bookmark
-                      help_center_id: 120
+                      help_center_id: 57
                       type: collection
                     total_count: 1
                     pages:
@@ -808,7 +808,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5702b2b4-3803-43d0-a726-28dab1d69dee
+                    request_id: 5ab43962-f05c-438f-aaa6-cf67e4bd2c7a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -833,16 +833,16 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '238'
+                    id: '99'
                     workspace_id: this_is_an_id56_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-56/
                     order: 1
-                    created_at: 1709050659
-                    updated_at: 1709050659
+                    created_at: 1709226130
+                    updated_at: 1709226130
                     description: ''
                     icon: book-bookmark
-                    help_center_id: 122
+                    help_center_id: 59
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -854,7 +854,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 64db59a1-07f2-48ca-b3cd-223dd3dc1944
+                    request_id: 7029f2b6-0c71-4a3a-8a8a-4fa92b5a8502
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -868,7 +868,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 78dd9f87-819d-4997-97b6-c6d023ea9d3e
+                    request_id: 59f23908-c4de-4a99-ac0a-23388a8f4729
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -916,16 +916,16 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '243'
+                    id: '104'
                     workspace_id: this_is_an_id62_that_should_be_at_least_4
                     name: English collection title
                     url: http://help-center.test/myapp-62/collection-22
                     order: 22
-                    created_at: 1709050660
-                    updated_at: 1709050660
+                    created_at: 1709226131
+                    updated_at: 1709226131
                     description: english collection description
                     icon: bookmark
-                    help_center_id: 125
+                    help_center_id: 62
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -937,7 +937,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: e610850b-1c9d-48d6-bcc9-6f30fa8396bd
+                    request_id: 195ccd61-5df9-4e76-bd12-d3a6779a5624
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -951,7 +951,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9cc2fcee-5ca2-4107-b126-d5d6b5cee928
+                    request_id: 17df26e9-1c3d-46df-882f-ad4809ea0405
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -984,16 +984,16 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '249'
+                    id: '110'
                     workspace_id: this_is_an_id68_that_should_be_at_least_4
                     name: Update collection name
                     url: http://help-center.test/myapp-68/collection-25
                     order: 25
-                    created_at: 1709050661
-                    updated_at: 1709050661
+                    created_at: 1709226133
+                    updated_at: 1709226133
                     description: english collection description
                     icon: folder
-                    help_center_id: 128
+                    help_center_id: 65
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -1005,7 +1005,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: ee13fe1f-88ea-4700-8847-b81c770a57e7
+                    request_id: f023e059-c09c-4ecb-87d0-a582de89a6b4
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1019,7 +1019,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4e425787-7bba-4bbd-9f09-e2d14248a8b2
+                    request_id: 9eec5fc2-b4e0-4a4d-88a6-a9a837cdd5b2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1066,7 +1066,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '255'
+                    id: '116'
                     object: collection
                     deleted: true
               schema:
@@ -1079,7 +1079,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: fa2f83ee-66d3-4dd3-896a-970a8600e881
+                    request_id: fec25809-592a-4665-9fea-26e4f761b704
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1093,7 +1093,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d588fc33-4c61-4903-9d4d-bb15b885d2e1
+                    request_id: df644784-9971-4586-9e36-22a1b956be13
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1127,10 +1127,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '134'
+                    id: '71'
                     workspace_id: this_is_an_id80_that_should_be_at_least_4
-                    created_at: 1709050664
-                    updated_at: 1709050664
+                    created_at: 1709226136
+                    updated_at: 1709226136
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1144,7 +1144,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: ff1fc4b8-2231-40fe-9f3c-86b2d3aeaf56
+                    request_id: 6fc11af8-0fc6-4e5d-80ad-648db7447a42
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1158,7 +1158,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 302f034c-3d2a-47e0-a446-7787c62e8298
+                    request_id: bc5742f0-94eb-477f-9dcb-b27f08169871
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1196,7 +1196,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e0419f38-23a0-43f8-ade2-c235c2a26a08
+                    request_id: 8a9a5e79-2fae-4881-bce9-7617492ff84c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1228,15 +1228,15 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '262'
+                    - id: '123'
                       workspace_id: this_is_an_id90_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-90/section-15
                       order: 15
-                      created_at: 1709050666
-                      updated_at: 1709050666
+                      created_at: 1709226138
+                      updated_at: 1709226138
                       type: section
-                      parent_id: 261
+                      parent_id: 122
                     total_count: 1
                     pages:
                       type: pages
@@ -1253,7 +1253,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f88c6c36-a49f-49b6-a1c9-8d0abeccc5fb
+                    request_id: 3249d150-d266-4bb5-91de-1393ab5fd2ac
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1278,15 +1278,15 @@ paths:
               examples:
                 section created:
                   value:
-                    id: '267'
+                    id: '128'
                     workspace_id: this_is_an_id94_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-94/
                     order: 1
-                    created_at: 1709050667
-                    updated_at: 1709050667
+                    created_at: 1709226139
+                    updated_at: 1709226139
                     type: section
-                    parent_id: '265'
+                    parent_id: '126'
               schema:
                 "$ref": "#/components/schemas/section"
         '401':
@@ -1297,7 +1297,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ef449a3e-7fc0-43e2-9d6b-326a3702f935
+                    request_id: 1448125f-b22f-45c1-b8d5-f7b030d9d657
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1313,7 +1313,7 @@ paths:
                 summary: section created
                 value:
                   name: Thanks for everything
-                  parent_id: 265
+                  parent_id: 126
   "/help_center/sections/{id}":
     get:
       summary: Retrieve a section
@@ -1342,15 +1342,15 @@ paths:
               examples:
                 Section found:
                   value:
-                    id: '271'
+                    id: '132'
                     workspace_id: this_is_an_id98_that_should_be_at_least_4
                     name: English section title
                     url: http://help-center.test/myapp-98/section-19
                     order: 19
-                    created_at: 1709050668
-                    updated_at: 1709050668
+                    created_at: 1709226140
+                    updated_at: 1709226140
                     type: section
-                    parent_id: 270
+                    parent_id: 131
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1361,7 +1361,7 @@ paths:
                 Section not found:
                   value:
                     type: error.list
-                    request_id: 1057e7f9-fdfa-42e8-9712-c41335f640e1
+                    request_id: 3a7e5589-95b0-49c9-a868-cd02806f71b9
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1375,7 +1375,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 934946f4-1bc4-45b3-931a-254fb6dbd9da
+                    request_id: b0826648-80c9-47ff-98ce-7d7464786218
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1408,15 +1408,15 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '277'
+                    id: '138'
                     workspace_id: this_is_an_id104_that_should_be_at_least_
                     name: Update section name
                     url: http://help-center.test/myapp-104/section-22
                     order: 22
-                    created_at: 1709050669
-                    updated_at: 1709050669
+                    created_at: 1709226141
+                    updated_at: 1709226141
                     type: section
-                    parent_id: '276'
+                    parent_id: '137'
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1427,7 +1427,7 @@ paths:
                 Section Not Found:
                   value:
                     type: error.list
-                    request_id: ed2aecf6-f5d9-4581-8e04-66158bbe0f96
+                    request_id: c27773a9-4ce7-4726-9615-9f0fc6088a8d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1441,7 +1441,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5ebb52d7-a311-49d6-9048-7edfbe1b9266
+                    request_id: 3610b578-b49f-49c4-af5e-bf429dc9044a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1457,12 +1457,12 @@ paths:
                 summary: successful
                 value:
                   name: Update section name
-                  parent_id: 276
+                  parent_id: 137
               section_not_found:
                 summary: Section Not Found
                 value:
                   name: Update section name
-                  parent_id: 278
+                  parent_id: 139
     delete:
       summary: Delete a section
       parameters:
@@ -1489,7 +1489,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '283'
+                    id: '144'
                     object: section
                     deleted: true
               schema:
@@ -1502,7 +1502,7 @@ paths:
                 section Not Found:
                   value:
                     type: error.list
-                    request_id: f36b0389-e273-42a9-a311-af0694c3b30e
+                    request_id: 62183ede-0fc0-4184-a202-a116cdb2b403
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1516,7 +1516,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b2a3271b-cbfa-440d-b551-cd02d9141999
+                    request_id: '009c6ee9-0d24-4f08-a7e8-225fdec7f446'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1549,12 +1549,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 65de0b30ba4d12866346359f
+                    id: 65e0b8a16abd017a41872c01
                     app_id: this_is_an_id116_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1709050672
-                    updated_at: 1709050672
+                    created_at: 1709226145
+                    updated_at: 1709226145
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1591,7 +1591,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5453c364-aff2-44c6-98e6-e03407f8b5bb
+                    request_id: ded39abc-f077-4c5c-8798-a3c4dd49769d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1689,12 +1689,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0b32ba4d1286634635a7
+                      id: 65e0b8a26abd017a41872c09
                       app_id: this_is_an_id122_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709050674
-                      created_at: 1709050674
-                      updated_at: 1709050674
+                      remote_created_at: 1709226146
+                      created_at: 1709226147
+                      updated_at: 1709226147
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -1723,7 +1723,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 66fa299c-8087-4e74-a42f-7f9a1d618760
+                    request_id: 44d08c01-c659-4622-b299-44e10f2424a0
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1737,7 +1737,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c2d2e1a1-c6c5-418f-88a9-b088b046a320
+                    request_id: ff971486-05a8-4fd9-a6c1-104fe196fac1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1772,12 +1772,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0b35ba4d1286634635b2
+                    id: 65e0b8a56abd017a41872c14
                     app_id: this_is_an_id128_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1709050677
-                    created_at: 1709050677
-                    updated_at: 1709050677
+                    remote_created_at: 1709226149
+                    created_at: 1709226149
+                    updated_at: 1709226149
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1799,7 +1799,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 3077d352-00c1-4063-ac5e-ced34498548c
+                    request_id: 8d0fcbed-e818-49fd-a307-dc5660756b18
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1813,7 +1813,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 14742b52-53ce-4a15-84be-bb624aae5eea
+                    request_id: bb0b9d85-8466-42ce-aa21-e2bab84d4611
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1847,12 +1847,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0b37ba4d1286634635bc
+                    id: 65e0b8a76abd017a41872c1e
                     app_id: this_is_an_id134_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1709050679
-                    created_at: 1709050679
-                    updated_at: 1709050679
+                    remote_created_at: 1709226151
+                    created_at: 1709226151
+                    updated_at: 1709226151
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1874,7 +1874,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 8ae2cb50-267c-489f-b677-3c9f9fc503cf
+                    request_id: e0638d68-97bf-4f08-b566-cd23061842e7
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1888,7 +1888,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d5154134-827a-4302-9df2-a48f7b3aab1e
+                    request_id: 29d773b6-7eef-44b6-a72b-f79a23887c68
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1920,7 +1920,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 65de0b39ba4d1286634635c6
+                    id: 65e0b8a96abd017a41872c28
                     object: company
                     deleted: true
               schema:
@@ -1933,7 +1933,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: a73678a8-7e95-4bc1-930a-2eade906a54a
+                    request_id: 78323694-4149-4430-a20b-1f4221e9e877
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1947,7 +1947,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fd4b315b-f43c-45c4-8ef9-8584be0d0a68
+                    request_id: 1dffe583-98a9-4e4b-a6cd-7cdae232060d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1999,7 +1999,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 1ea75759-bf56-4b46-9fd5-d5bc3376c8e8
+                    request_id: 52fac023-343e-447e-a18d-4c2203c4a5a7
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2013,7 +2013,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 42e80281-2dcf-46b3-9e72-9a262b2ea6d0
+                    request_id: 062cec56-c691-4ea8-bfbd-c6ca3a2cc1f2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2058,7 +2058,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 360fb9df-9360-4b23-a556-7a26b7467642
+                    request_id: 44c7d051-97b1-4d88-93ab-a6d565ff90b7
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2072,7 +2072,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 485d181c-fe8f-47f1-8bc7-b6ed5983787e
+                    request_id: 9bf2828e-f0e0-4bf0-b544-62cc20298c0b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2129,12 +2129,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0b3fba4d1286634635e2
+                      id: 65e0b8af6abd017a41872c44
                       app_id: this_is_an_id158_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709050687
-                      created_at: 1709050687
-                      updated_at: 1709050687
+                      remote_created_at: 1709226159
+                      created_at: 1709226159
+                      updated_at: 1709226159
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2163,7 +2163,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5b7301bd-2328-435d-b28a-128e3d1a31be
+                    request_id: e4c89cb6-6486-4130-b606-f116ddcfca0b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2215,12 +2215,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0b40ba4d1286634635e8
+                      id: 65e0b8b06abd017a41872c4a
                       app_id: this_is_an_id162_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709050688
-                      created_at: 1709050688
-                      updated_at: 1709050688
+                      remote_created_at: 1709226160
+                      created_at: 1709226160
+                      updated_at: 1709226160
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2234,7 +2234,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: c0452f9f-fe82-48d4-9473-98a5f39b4e80
+                    scroll_param: dc6df880-a654-40b6-9802-fdceafe05ecb
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2245,7 +2245,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 38206c79-5ed6-4384-92b5-38e64689584b
+                    request_id: 14571e78-486c-4c9f-afa4-d2acd685b9ad
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2280,12 +2280,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0b42ba4d1286634635f1
+                    id: 65e0b8b26abd017a41872c53
                     app_id: this_is_an_id166_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1709050690
-                    created_at: 1709050690
-                    updated_at: 1709050690
+                    remote_created_at: 1709226162
+                    created_at: 1709226162
+                    updated_at: 1709226162
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2307,7 +2307,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 7b2ef65d-2962-462e-97a7-b5ba1e4319b9
+                    request_id: 77d7f1c9-b3ad-4cc7-bfb2-dd033b509b54
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2321,7 +2321,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 51e5a388-a69f-4ce2-993b-cc3627a03829
+                    request_id: 962b58af-096f-4b7b-b22c-ae7199218f52
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2335,7 +2335,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7b0e2593-da15-48d6-a070-b7f53d7f6080
+                    request_id: b30bd0bf-545d-492a-a9f9-fd2784ce1db1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2358,7 +2358,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 65de0b42ba4d1286634635f1
+                  id: 65e0b8b26abd017a41872c53
               bad_request:
                 summary: Bad Request
                 value:
@@ -2397,13 +2397,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 65de0b48ba4d128663463612
+                      id: 65e0b8b86abd017a41872c74
                       app_id: this_is_an_id182_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1709050696
-                      created_at: 1709050696
-                      updated_at: 1709050696
-                      last_request_at: 1708877896
+                      remote_created_at: 1709226168
+                      created_at: 1709226168
+                      updated_at: 1709226168
+                      last_request_at: 1709053368
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2432,7 +2432,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 93b0db38-8928-493b-8baf-91d5078040b6
+                    request_id: 7a5d09b1-cf65-4d80-ade4-f7183c5be352
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2446,7 +2446,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 740300b5-9521-4d29-8925-e5195dbf1d27
+                    request_id: 28a8e759-f4ad-4bb2-8df6-c87637928b85
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2489,12 +2489,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0b45ba4d128663463601
+                    id: 65e0b8b56abd017a41872c63
                     app_id: this_is_an_id174_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1709050693
-                    created_at: 1709050693
-                    updated_at: 1709050693
+                    remote_created_at: 1709226165
+                    created_at: 1709226165
+                    updated_at: 1709226165
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2516,14 +2516,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 4ddc8440-846b-4367-b95c-c25f12e3b3be
+                    request_id: 7f1bd915-baed-47bb-895b-2a53a22c0459
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 8907bc13-7fd0-46a7-a00f-7d9c9f08e115
+                    request_id: f6b14bd1-c1a3-4bfa-886e-f70810bb3cce
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2537,7 +2537,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3e37311c-e018-4411-9c62-84574e24fd0c
+                    request_id: ea1871bb-cf51-47ab-968c-c624a4bd4ccc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2573,42 +2573,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '42'
-                      created_at: 1708445898
+                      id: '16'
+                      created_at: 1708621371
                       contact:
                         type: contact
-                        id: 65de0b4aba4d12866346361d
+                        id: 65e0b8bb6abd017a41872c7f
                       author:
                         type: admin
-                        id: '991267874'
+                        id: '991266838'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '41'
-                      created_at: 1708359498
+                      id: '15'
+                      created_at: 1708534971
                       contact:
                         type: contact
-                        id: 65de0b4aba4d12866346361d
+                        id: 65e0b8bb6abd017a41872c7f
                       author:
                         type: admin
-                        id: '991267874'
+                        id: '991266838'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '40'
-                      created_at: 1708359498
+                      id: '14'
+                      created_at: 1708534971
                       contact:
                         type: contact
-                        id: 65de0b4aba4d12866346361d
+                        id: 65e0b8bb6abd017a41872c7f
                       author:
                         type: admin
-                        id: '991267874'
+                        id: '991266838'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
@@ -2631,7 +2631,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 9c302332-e32b-4024-a829-21fcc0f768ed
+                    request_id: 3a9e03e5-6211-4ea4-9f49-4c448a776ad5
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2665,14 +2665,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '47'
-                    created_at: 1709050699
+                    id: '21'
+                    created_at: 1709226172
                     contact:
                       type: contact
-                      id: 65de0b4bba4d12866346361f
+                      id: 65e0b8bc6abd017a41872c81
                     author:
                       type: admin
-                      id: '991267876'
+                      id: '991266840'
                       name: Ciaran112 Lee
                       email: admin112@email.com
                       away_mode_enabled: false
@@ -2688,14 +2688,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 07bffc34-4245-4635-b47f-afcbdbe4bb8f
+                    request_id: dc8f3b96-dac0-4a4b-9f9a-cf09500cddd5
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: '0219453e-a4c3-4553-b753-b8cf2c5dc343'
+                    request_id: 1422f5e5-00a9-4519-86f8-9a97f8fda02b
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2725,20 +2725,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 65de0b4bba4d12866346361f
-                  admin_id: 991267876
+                  contact_id: 65e0b8bc6abd017a41872c81
+                  admin_id: 991266840
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 65de0b4cba4d128663463620
+                  contact_id: 65e0b8bc6abd017a41872c82
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991267878
+                  admin_id: 991266842
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -2771,10 +2771,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 65de0b4dba4d128663463622
+                      id: 65e0b8be6abd017a41872c84
                       name: segment
-                      created_at: 1709050701
-                      updated_at: 1709050701
+                      created_at: 1709226174
+                      updated_at: 1709226174
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -2786,7 +2786,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 983dfeb2-e655-43e7-93bb-6bbfbed1a25b
+                    request_id: 8241e13a-b35c-415e-8cd3-fe85bb285d06
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2800,7 +2800,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 82ba7378-e88b-42a9-a253-dc3711ec4117
+                    request_id: 61c68777-33f6-4793-a4a1-e8d570be260e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2844,7 +2844,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '139'
+                      id: '47'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -2858,7 +2858,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '141'
+                      id: '49'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -2881,7 +2881,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 374b4bc4-b747-4c12-b77f-f2176923dfc2
+                    request_id: 173b92e9-efe8-472b-af49-2e96905e04fa
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2895,7 +2895,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7e913d15-19c5-42ef-b918-f8b4f1dee7c7
+                    request_id: 04d8df52-c7f4-4596-9b6a-1d2ab84e8362
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2936,7 +2936,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '154'
+                    id: '62'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -2959,14 +2959,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 5136357b-cbea-4e9a-b89e-1313b79261a1
+                    request_id: a6a77aec-b6e3-4bc6-bd86-3150a361dd0a
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 7be30453-bb1e-4217-8403-73edc10de9cd
+                    request_id: daec5e97-1c1d-4847-b967-c6981469dc9a
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -2980,7 +2980,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5704a61f-a411-4c70-a7e7-6374a153013a
+                    request_id: a9110314-d486-441b-a3ac-756c25db5b53
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3008,12 +3008,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 154
+                  id: 62
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 158
+                  id: 66
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -3059,7 +3059,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '170'
+                    id: '78'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3082,14 +3082,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 8e1399bb-93d1-48c7-b77c-6512efc65535
+                    request_id: d3cd4511-a4e4-4a7f-a6d4-591219bf8f6e
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: cfdefa74-1ba3-4372-9fa4-ceeef0cd4253
+                    request_id: 4ce107fb-0a5a-4bb3-a3b7-b529113ae092
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3103,7 +3103,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a8c1e9a1-4d2b-4d43-9ca6-db38c548e0a9
+                    request_id: '085213f2-1260-4e52-8a32-817f69945a4c'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3141,7 +3141,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '129'
+                      id: '42'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -3153,7 +3153,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 10554483-85ca-496f-981e-1eca87d9e078
+                    request_id: 9f8aa4a7-7f78-4df9-90a1-4bfe5d9281f1
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3167,7 +3167,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8255fc4e-04af-4b54-9728-b88a5860c367
+                    request_id: 4ded729d-90c1-4b66-922d-a9d4a10a0506
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3202,7 +3202,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '130'
+                    id: '43'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3214,14 +3214,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: b5fe2d61-5fd8-4db7-b95e-a15fc096fc5e
+                    request_id: 9804cea9-11a4-4dda-be52-ad836030451b
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: e8969f9e-efb9-470a-90b2-ce24dd4c6c67
+                    request_id: 3a1ec603-067c-46cb-88be-cc96d088484f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3235,7 +3235,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3f7531a9-4067-4960-b9b4-d0c941dd7b08
+                    request_id: ffa57641-599d-4c36-8170-fd5e9d1a8cb0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3258,11 +3258,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 130
+                  id: 43
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 131
+                  id: 44
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3304,7 +3304,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '133'
+                    id: '46'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3316,14 +3316,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: '08f0cf83-df9b-463c-b4c4-87e87d43b758'
+                    request_id: b5c019e1-a11f-440e-a1e8-323fcee4e995
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 60a0cacd-3fb1-4d9d-9b8c-034fcc0c8497
+                    request_id: 209ca976-87f9-43cb-a339-bc80bcf48cd4
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3337,7 +3337,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0d01d379-e044-461f-8fc5-a6a9070fdb89
+                    request_id: 7c9e3b1d-5c52-4781-8154-63f49a08c6b5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3371,7 +3371,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0b5bba4d128663463639
+                    id: 65e0b8cb6abd017a41872c9b
                     workspace_id: this_is_an_id248_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3386,9 +3386,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709050715
-                    updated_at: 1709050715
-                    signed_up_at: 1709050715
+                    created_at: 1709226187
+                    updated_at: 1709226188
+                    signed_up_at: 1709226187
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3422,31 +3422,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5bba4d128663463639/tags"
+                      url: "/contacts/65e0b8cb6abd017a41872c9b/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5bba4d128663463639/notes"
+                      url: "/contacts/65e0b8cb6abd017a41872c9b/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5bba4d128663463639/companies"
+                      url: "/contacts/65e0b8cb6abd017a41872c9b/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5bba4d128663463639/subscriptions"
+                      url: "/contacts/65e0b8cb6abd017a41872c9b/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5bba4d128663463639/subscriptions"
+                      url: "/contacts/65e0b8cb6abd017a41872c9b/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3465,7 +3465,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 57979386-b0bd-4184-a449-b70cd8453717
+                    request_id: 25e1b4f9-616f-49b1-ae3d-a5b377d1a050
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3510,7 +3510,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0b5cba4d12866346363a
+                    id: 65e0b8cd6abd017a41872c9c
                     workspace_id: this_is_an_id252_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3525,9 +3525,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709050716
-                    updated_at: 1709050716
-                    signed_up_at: 1709050716
+                    created_at: 1709226189
+                    updated_at: 1709226189
+                    signed_up_at: 1709226189
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3561,31 +3561,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5cba4d12866346363a/tags"
+                      url: "/contacts/65e0b8cd6abd017a41872c9c/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5cba4d12866346363a/notes"
+                      url: "/contacts/65e0b8cd6abd017a41872c9c/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5cba4d12866346363a/companies"
+                      url: "/contacts/65e0b8cd6abd017a41872c9c/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5cba4d12866346363a/subscriptions"
+                      url: "/contacts/65e0b8cd6abd017a41872c9c/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5cba4d12866346363a/subscriptions"
+                      url: "/contacts/65e0b8cd6abd017a41872c9c/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3604,7 +3604,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bed12cfa-07e1-487a-a383-17b911929879
+                    request_id: 65ab87dc-222d-47c6-8de5-f0a0cd3b7db6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3635,7 +3635,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de0b5dba4d12866346363b
+                    id: 65e0b8ce6abd017a41872c9d
                     object: contact
                     deleted: true
               schema:
@@ -3648,7 +3648,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d389cecd-0ffd-42cd-8350-e5df1d0d9bc2
+                    request_id: e7ef040c-d4b4-4022-8874-f8320bef6c66
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3676,7 +3676,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0b5fba4d12866346363d
+                    id: 65e0b8d06abd017a41872c9f
                     workspace_id: this_is_an_id260_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3691,9 +3691,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709050719
-                    updated_at: 1709050719
-                    signed_up_at: 1709050718
+                    created_at: 1709226192
+                    updated_at: 1709226192
+                    signed_up_at: 1709226192
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3727,31 +3727,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5fba4d12866346363d/tags"
+                      url: "/contacts/65e0b8d06abd017a41872c9f/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5fba4d12866346363d/notes"
+                      url: "/contacts/65e0b8d06abd017a41872c9f/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5fba4d12866346363d/companies"
+                      url: "/contacts/65e0b8d06abd017a41872c9f/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5fba4d12866346363d/subscriptions"
+                      url: "/contacts/65e0b8d06abd017a41872c9f/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0b5fba4d12866346363d/subscriptions"
+                      url: "/contacts/65e0b8d06abd017a41872c9f/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3770,7 +3770,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4319b27a-ec68-416a-8898-23fb8ef7d244
+                    request_id: be98d8c4-908e-4ecc-bb96-5db612851ed6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3785,8 +3785,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 65de0b5eba4d12866346363c
-                  into: 65de0b5fba4d12866346363d
+                  from: 65e0b8d06abd017a41872c9e
+                  into: 65e0b8d06abd017a41872c9f
   "/contacts/search":
     post:
       summary: Search contacts
@@ -3915,7 +3915,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ddb0a210-b214-4b59-b482-420cf9a3f132
+                    request_id: b47daedb-d48e-49a6-a349-2501ad713503
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3935,15 +3935,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: 65de0b60ba4d128663463640
+                      value: 65e0b8d16abd017a41872ca2
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: 65de0b60ba4d128663463640
+                        value: 65e0b8d16abd017a41872ca2
                       - field: id
                         operator: "="
-                        value: 65de0b60ba4d128663463640
+                        value: 65e0b8d16abd017a41872ca2
   "/contacts":
     get:
       summary: List all contacts
@@ -3982,7 +3982,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d75c8035-72f1-4efb-8dd6-e99bc9e25c2c
+                    request_id: acf847a7-1842-4b7a-ac76-1d5c97d5f54d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4008,7 +4008,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0b62ba4d128663463642
+                    id: 65e0b8d46abd017a41872ca4
                     workspace_id: this_is_an_id272_that_should_be_at_least_
                     external_id:
                     role: user
@@ -4023,8 +4023,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709050722
-                    updated_at: 1709050722
+                    created_at: 1709226196
+                    updated_at: 1709226196
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -4059,31 +4059,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0b62ba4d128663463642/tags"
+                      url: "/contacts/65e0b8d46abd017a41872ca4/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0b62ba4d128663463642/notes"
+                      url: "/contacts/65e0b8d46abd017a41872ca4/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0b62ba4d128663463642/companies"
+                      url: "/contacts/65e0b8d46abd017a41872ca4/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0b62ba4d128663463642/subscriptions"
+                      url: "/contacts/65e0b8d46abd017a41872ca4/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0b62ba4d128663463642/subscriptions"
+                      url: "/contacts/65e0b8d46abd017a41872ca4/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4102,7 +4102,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 77624fa6-9a39-43b0-99f9-42b932d0c4a6
+                    request_id: 469177ba-74f8-41b3-a8e6-676628bacc0f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4146,7 +4146,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de0b63ba4d128663463643
+                    id: 65e0b8d56abd017a41872ca5
                     object: contact
                     archived: true
               schema:
@@ -4178,7 +4178,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de0b64ba4d128663463644
+                    id: 65e0b8d66abd017a41872ca6
                     object: contact
                     archived: false
               schema:
@@ -4213,7 +4213,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '135'
+                    id: '48'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4225,7 +4225,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 4b3442fb-0904-4cd5-895d-c31c90195b85
+                    request_id: 0fea79ad-83e2-4591-a5d0-cbdfcab9dcd3
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4239,7 +4239,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8ef3df60-7435-4e46-b202-802c339aca2e
+                    request_id: b4bfb28b-dae2-4d0b-b05b-5dffa3c7b0b7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4268,13 +4268,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 135
-                  admin_id: 991267909
+                  id: 48
+                  admin_id: 991266873
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 136
-                  admin_id: 991267911
+                  id: 49
+                  admin_id: 991266875
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4312,7 +4312,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '138'
+                    id: '51'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4324,14 +4324,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 9b55e75c-c580-432e-97d6-3d2f65f3d093
+                    request_id: 5d3ea137-1ed5-4d0e-b0fe-8bee92b62064
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 80800f07-8a38-4b76-b97f-e1e6ca14f753
+                    request_id: 2677d587-d63a-4d93-9da3-ef8a281e6559
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4345,7 +4345,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3b5a9706-9e0c-4f95-ae97-72c642986b97
+                    request_id: b89d338c-433f-4647-9778-7c7a0bfcad29
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4368,15 +4368,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991267913
+                  admin_id: 991266877
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991267915
+                  admin_id: 991266879
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991267916
+                  admin_id: 991266880
   "/conversations":
     get:
       summary: List all conversations
@@ -4423,20 +4423,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '432'
-                      created_at: 1709050733
-                      updated_at: 1709050733
+                      id: '143'
+                      created_at: 1709226206
+                      updated_at: 1709226206
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918315'
+                        id: '403918147'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991267919'
+                          id: '991266883'
                           name: Ciaran152 Lee
                           email: admin152@email.com
                         attachments: []
@@ -4446,7 +4446,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de0b6cba4d128663463648
+                          id: 65e0b8de6abd017a41872caa
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -4474,7 +4474,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8e3b2261-85b5-4fcf-b6d0-cdb1f1888447
+                    request_id: 2c216155-73ba-43e6-b3b3-f517499bdafb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4488,7 +4488,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 2f134e32-b3ab-4138-9672-dd01dbdae790
+                    request_id: 8fbbb6b3-a26f-4291-bc8d-c1560a995373
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4504,13 +4504,17 @@ paths:
       tags:
       - Conversations
       operationId: createConversation
-      description: "You can create a conversation that has been initiated by a contact
-        (ie. user or lead).\nThe conversation can be an in-app message only.\n\n>
-        \U0001F4D8 Sending for visitors\n>\n> You can also send a message from a visitor
-        by specifying their `user_id` or `id` value in the `from` field, along with
-        a `type` field value of `contact`.\n> This visitor will be automatically converted
-        to a contact with a lead role once the conversation is created.\n\nThis will
-        return the Message model that has been created.\n\n"
+      description: |+
+        You can create a conversation that has been initiated by a contact (ie. user or lead).
+        The conversation can be an in-app message only.
+
+        {% admonition type="info" name="Sending for visitors" %}
+        You can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.
+        This visitor will be automatically converted to a contact with a lead role once the conversation is created.
+        {% /admonition %}
+
+        This will return the Message model that has been created.
+
       responses:
         '200':
           description: conversation created
@@ -4520,11 +4524,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918325'
-                    created_at: 1709050757
+                    id: '403918157'
+                    created_at: 1709226231
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '457'
+                    conversation_id: '168'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -4535,7 +4539,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: bd3b2a93-a423-45e1-a489-eed9059b8796
+                    request_id: 7f6db282-ed54-4567-9294-2972487c5c3e
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -4549,7 +4553,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 89bc27d5-ab41-4ab7-ae50-d3e6a7079b7d
+                    request_id: e73b370f-8936-44d1-8b97-bde858c4f0be
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4563,7 +4567,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: f5aa108e-676d-41b7-99d4-82d4a303a85f
+                    request_id: c7551313-6972-47bc-9405-1d27c657c045
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4580,7 +4584,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65de0b84ba4d12866346365d
+                    id: 65e0b8f66abd017a41872cbf
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -4614,15 +4618,21 @@ paths:
       tags:
       - Conversations
       operationId: retrieveConversation
-      description: "\nYou can fetch the details of a single conversation.\n\nThis
-        will return a single Conversation model with all its conversation parts.\n\n>
-        \U0001F6A7 Hard limit of 500 parts\n>\n> The maximum number of conversation
-        parts that can be returned via the API is 500. If you have more than that
-        we will return the 500 most recent conversation parts.\n\n> \U0001F4D8 Bot
-        name in conversation parts\n>\n> For conversation parts generated by a bot,
-        bot name will depend on the following:\n- Customers that never turned on AI
-        answers will have `operator` as the bot name\n- Customers that have turned
-        on AI answers at some point will have `fin` as the bot name\n"
+      description: |2
+
+        You can fetch the details of a single conversation.
+
+        This will return a single Conversation model with all its conversation parts.
+
+        {% admonition type="warning" name="Hard limit of 500 parts" %}
+        The maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.
+        {% /admonition %}
+
+        ### Bot Name in Conversation Parts
+
+        For conversation parts generated by a bot, bot name will depend on the following:
+        - Customers that never turned on AI answers will have `operator` as the bot name
+        - Customers that have turned on AI answers at some point will have `fin` as the bot name
       responses:
         '200':
           description: conversation found
@@ -4632,20 +4642,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '461'
-                    created_at: 1709050763
-                    updated_at: 1709050763
+                    id: '172'
+                    created_at: 1709226237
+                    updated_at: 1709226237
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918329'
+                      id: '403918161'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267933'
+                        id: '991266897'
                         name: Ciaran159 Lee
                         email: admin159@email.com
                       attachments: []
@@ -4655,7 +4665,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0b8bba4d128663463661
+                        id: 65e0b8fd6abd017a41872cc3
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4687,7 +4697,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 7e9ed65b-3e48-402f-ad84-50a301a409bf
+                    request_id: 8fe833ff-6391-40d7-ad8b-6f02746872ed
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4701,7 +4711,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 485486e9-cbb5-451f-87f0-7a6d06a2086f
+                    request_id: da5033a3-915d-43cf-bfc6-d798ea9e33b8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4715,7 +4725,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: ffdae351-680b-4903-9e55-56f9f11db499
+                    request_id: 45dda5eb-de62-412a-b965-3b5b4f87113d
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4745,10 +4755,14 @@ paths:
       tags:
       - Conversations
       operationId: updateConversation
-      description: "\nYou can update an existing conversation.\n\n> \U0001F4D8\n>\n>
-        If you want to update a conversation with either a reply (or actions such
-        as assign, unassign, open, close or snooze) then take a look at their own
-        sections respectively as they currently require different endpoints and parameters.\n\n"
+      description: |2+
+
+        You can update an existing conversation.
+
+        {% admonition type="info" name="Replying and other actions" %}
+        If you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.
+        {% /admonition %}
+
       responses:
         '200':
           description: conversation found
@@ -4758,20 +4772,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '465'
-                    created_at: 1709050768
-                    updated_at: 1709050770
+                    id: '176'
+                    created_at: 1709226243
+                    updated_at: 1709226245
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918333'
+                      id: '403918165'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267941'
+                        id: '991266905'
                         name: Ciaran163 Lee
                         email: admin163@email.com
                       attachments: []
@@ -4781,7 +4795,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0b90ba4d128663463665
+                        id: 65e0b9036abd017a41872cc7
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4805,15 +4819,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '101'
+                        id: '30'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709050770
-                        updated_at: 1709050770
-                        notified_at: 1709050770
+                        created_at: 1709226245
+                        updated_at: 1709226245
+                        notified_at: 1709226245
                         assigned_to:
                         author:
-                          id: '991267942'
+                          id: '991266906'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4821,15 +4835,15 @@ paths:
                         external_id:
                         redacted: false
                       - type: conversation_part
-                        id: '102'
+                        id: '31'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709050770
-                        updated_at: 1709050770
-                        notified_at: 1709050770
+                        created_at: 1709226245
+                        updated_at: 1709226245
+                        notified_at: 1709226245
                         assigned_to:
                         author:
-                          id: '991267942'
+                          id: '991266906'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4847,7 +4861,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 7d509ed1-1c5c-44c1-a1f6-9bd89d11e3d5
+                    request_id: c852a0a6-6556-435c-8016-6f0424f3df20
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4861,7 +4875,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f8139038-368e-4b1e-919a-19b498ab5268
+                    request_id: 2b4ba49e-f0e4-4fa3-a1c2-b83f9f67b40a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4875,7 +4889,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 78e99db4-6890-4ac8-b77d-2ff575b5fff5
+                    request_id: 81fce3a7-9d06-47be-871c-2abb0e1710d1
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5015,20 +5029,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '472'
-                      created_at: 1709050779
-                      updated_at: 1709050779
+                      id: '183'
+                      created_at: 1709226254
+                      updated_at: 1709226254
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918340'
+                        id: '403918172'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991267971'
+                          id: '991266935'
                           name: Ciaran186 Lee
                           email: admin186@email.com
                         attachments: []
@@ -5038,7 +5052,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de0b9bba4d12866346366c
+                          id: 65e0b90e6abd017a41872cce
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -5072,15 +5086,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '472'
+                      value: '183'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '472'
+                        value: '183'
                       - field: id
                         operator: "="
-                        value: '472'
+                        value: '183'
   "/conversations/{id}/reply":
     post:
       summary: Reply to a conversation
@@ -5092,19 +5106,11 @@ paths:
       - name: id
         in: path
         required: true
+        description: The Intercom provisioned identifier for the conversation or the
+          string "last" to reply to the last part of the conversation
+        example: 123 or "last"
         schema:
-          oneOf:
-          - title: Conversation ID
-            type: string
-            description: The id of the conversation to target.
-            example: '123'
-          - title: The most recent conversation
-            type: string
-            enum:
-            - last
-            description: You can also reply to the most recent conversation on a workspace
-              by specifying `last` as the string.
-            example: last
+          type: string
       tags:
       - Conversations
       operationId: replyConversation
@@ -5119,20 +5125,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '480'
-                    created_at: 1709050787
-                    updated_at: 1709050788
-                    waiting_since: 1709050788
+                    id: '191'
+                    created_at: 1709226261
+                    updated_at: 1709226262
+                    waiting_since: 1709226262
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918343'
+                      id: '403918175'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267973'
+                        id: '991266937'
                         name: Ciaran187 Lee
                         email: admin187@email.com
                       attachments: []
@@ -5142,9 +5148,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0ba3ba4d128663463673
+                        id: 65e0b9156abd017a41872cd5
                     first_contact_reply:
-                      created_at: 1709050788
+                      created_at: 1709226262
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5167,15 +5173,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '104'
+                        id: '33'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709050788
-                        updated_at: 1709050788
-                        notified_at: 1709050788
+                        created_at: 1709226262
+                        updated_at: 1709226262
+                        notified_at: 1709226262
                         assigned_to:
                         author:
-                          id: 65de0ba3ba4d128663463673
+                          id: 65e0b9156abd017a41872cd5
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5186,20 +5192,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '481'
-                    created_at: 1709050789
-                    updated_at: 1709050790
+                    id: '192'
+                    created_at: 1709226264
+                    updated_at: 1709226265
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918344'
+                      id: '403918176'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267975'
+                        id: '991266939'
                         name: Ciaran188 Lee
                         email: admin188@email.com
                       attachments: []
@@ -5209,7 +5215,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0ba5ba4d128663463674
+                        id: 65e0b9186abd017a41872cd6
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5231,7 +5237,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '105'
+                        id: '34'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5246,12 +5252,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1709050790
-                        updated_at: 1709050790
-                        notified_at: 1709050790
+                        created_at: 1709226265
+                        updated_at: 1709226265
+                        notified_at: 1709226265
                         assigned_to:
                         author:
-                          id: '991267975'
+                          id: '991266939'
                           type: admin
                           name: Ciaran188 Lee
                           email: admin188@email.com
@@ -5262,20 +5268,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '483'
-                    created_at: 1709050792
-                    updated_at: 1709050793
-                    waiting_since: 1709050793
+                    id: '194'
+                    created_at: 1709226267
+                    updated_at: 1709226268
+                    waiting_since: 1709226268
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918346'
+                      id: '403918178'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267979'
+                        id: '991266943'
                         name: Ciaran190 Lee
                         email: admin190@email.com
                       attachments: []
@@ -5285,9 +5291,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0ba8ba4d128663463676
+                        id: 65e0b91b6abd017a41872cd8
                     first_contact_reply:
-                      created_at: 1709050793
+                      created_at: 1709226268
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5310,15 +5316,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '106'
+                        id: '35'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709050793
-                        updated_at: 1709050793
-                        notified_at: 1709050793
+                        created_at: 1709226268
+                        updated_at: 1709226268
+                        notified_at: 1709226268
                         assigned_to:
                         author:
-                          id: 65de0ba8ba4d128663463676
+                          id: 65e0b91b6abd017a41872cd8
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5336,7 +5342,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 1986acc0-7fa6-46bf-9e48-bba66f257f2e
+                    request_id: d61270b3-cba4-4737-81f3-5782ca80417b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5350,7 +5356,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: be0e3910-683e-4970-8f76-02d94117fa58
+                    request_id: 495b1fa0-1952-4c2a-8f06-6104577bba59
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5364,7 +5370,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: ced40bb1-91fe-47f2-a329-b1bcca6ea8fa
+                    request_id: 5c550a79-e53f-4342-bcc0-0791a2afb25f
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5381,14 +5387,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0ba3ba4d128663463673
+                  intercom_user_id: 65e0b9156abd017a41872cd5
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991267975
+                  admin_id: 991266939
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -5398,14 +5404,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0ba8ba4d128663463676
+                  intercom_user_id: 65e0b91b6abd017a41872cd8
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0baaba4d128663463677
+                  intercom_user_id: 65e0b91d6abd017a41872cd9
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -5426,10 +5432,11 @@ paths:
       - Conversations
       operationId: manageConversation
       description: |
-        You can close a conversation.
-        You can snooze a conversation to reopen on a future date.
-        You can open a conversation which is `snoozed` or `closed`.
-        You can assign a conversation to an admin and/or team.
+        For managing conversations you can:
+        - Close a conversation
+        - Snooze a conversation to reopen on a future date
+        - Open a conversation which is `snoozed` or `closed`
+        - Assign a conversation to an admin and/or team.
       responses:
         '200':
           description: Assign a conversation
@@ -5439,20 +5446,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '487'
-                    created_at: 1709050799
-                    updated_at: 1709050800
+                    id: '198'
+                    created_at: 1709226273
+                    updated_at: 1709226274
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918350'
+                      id: '403918182'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267987'
+                        id: '991266951'
                         name: Ciaran194 Lee
                         email: admin194@email.com
                       attachments: []
@@ -5462,7 +5469,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0bafba4d12866346367a
+                        id: 65e0b9216abd017a41872cdc
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5484,15 +5491,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '107'
+                        id: '36'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1709050800
-                        updated_at: 1709050800
-                        notified_at: 1709050800
+                        created_at: 1709226274
+                        updated_at: 1709226274
+                        notified_at: 1709226274
                         assigned_to:
                         author:
-                          id: '991267987'
+                          id: '991266951'
                           type: admin
                           name: Ciaran194 Lee
                           email: admin194@email.com
@@ -5503,20 +5510,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '488'
-                    created_at: 1709050801
-                    updated_at: 1709050802
+                    id: '199'
+                    created_at: 1709226275
+                    updated_at: 1709226276
                     waiting_since:
-                    snoozed_until: 1709054401
+                    snoozed_until: 1709229876
                     source:
                       type: conversation
-                      id: '403918351'
+                      id: '403918183'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267989'
+                        id: '991266953'
                         name: Ciaran195 Lee
                         email: admin195@email.com
                       attachments: []
@@ -5526,7 +5533,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0bb1ba4d12866346367b
+                        id: 65e0b9236abd017a41872cdd
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5548,15 +5555,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '108'
+                        id: '37'
                         part_type: snoozed
                         body:
-                        created_at: 1709050802
-                        updated_at: 1709050802
-                        notified_at: 1709050802
+                        created_at: 1709226276
+                        updated_at: 1709226276
+                        notified_at: 1709226276
                         assigned_to:
                         author:
-                          id: '991267989'
+                          id: '991266953'
                           type: admin
                           name: Ciaran195 Lee
                           email: admin195@email.com
@@ -5567,20 +5574,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '493'
-                    created_at: 1709050800
-                    updated_at: 1709050810
+                    id: '204'
+                    created_at: 1709226275
+                    updated_at: 1709226284
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918352'
+                      id: '403918184'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267991'
+                        id: '991266955'
                         name: Ciaran196 Lee
                         email: admin196@email.com
                       attachments: []
@@ -5590,7 +5597,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0bb5ba4d128663463680
+                        id: 65e0b9286abd017a41872ce2
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5612,15 +5619,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '110'
+                        id: '39'
                         part_type: open
                         body:
-                        created_at: 1709050810
-                        updated_at: 1709050810
-                        notified_at: 1709050810
+                        created_at: 1709226284
+                        updated_at: 1709226284
+                        notified_at: 1709226284
                         assigned_to:
                         author:
-                          id: '991267991'
+                          id: '991266955'
                           type: admin
                           name: Ciaran196 Lee
                           email: admin196@email.com
@@ -5631,20 +5638,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '497'
-                    created_at: 1709050811
-                    updated_at: 1709050812
+                    id: '208'
+                    created_at: 1709226285
+                    updated_at: 1709226285
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918355'
+                      id: '403918187'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267993'
+                        id: '991266957'
                         name: Ciaran197 Lee
                         email: admin197@email.com
                       attachments: []
@@ -5654,9 +5661,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0bbbba4d128663463683
+                        id: 65e0b92c6abd017a41872ce5
                     first_contact_reply:
-                    admin_assignee_id: 991267993
+                    admin_assignee_id: 991266957
                     team_assignee_id:
                     open: true
                     state: open
@@ -5676,17 +5683,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '111'
+                        id: '40'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1709050812
-                        updated_at: 1709050812
-                        notified_at: 1709050812
+                        created_at: 1709226285
+                        updated_at: 1709226285
+                        notified_at: 1709226285
                         assigned_to:
                           type: admin
-                          id: '991267993'
+                          id: '991266957'
                         author:
-                          id: '991267993'
+                          id: '991266957'
                           type: admin
                           name: Ciaran197 Lee
                           email: admin197@email.com
@@ -5704,7 +5711,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 3791b551-7309-49e3-a783-a8b60d7dcb8f
+                    request_id: a473e093-f474-4e06-96e2-a01f29dcd994
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5718,7 +5725,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 307a48df-1358-456c-9e81-73c2b2a1a907
+                    request_id: f6309020-62ca-47b0-b94b-ec0798102836
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5732,7 +5739,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 65710975-b666-46bd-bc86-f31314175c39
+                    request_id: 7c6f7c2a-5c08-4bbb-b8c0-b438be2d37de
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5753,32 +5760,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991267987
+                  admin_id: 991266951
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991267989
-                  snoozed_until: 1709054401
+                  admin_id: 991266953
+                  snoozed_until: 1709229876
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991267991
+                  admin_id: 991266955
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991267993
-                  assignee_id: 991267993
+                  admin_id: 991266957
+                  assignee_id: 991266957
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991267995
+                  admin_id: 991266959
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -5809,20 +5816,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '501'
-                    created_at: 1709050817
-                    updated_at: 1709050818
+                    id: '212'
+                    created_at: 1709226291
+                    updated_at: 1709226292
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918359'
+                      id: '403918191'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268001'
+                        id: '991266965'
                         name: Ciaran201 Lee
                         email: admin201@email.com
                       attachments: []
@@ -5832,7 +5839,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0bc1ba4d128663463687
+                        id: 65e0b9336abd017a41872ce9
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5854,17 +5861,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '112'
+                        id: '41'
                         part_type: default_assignment
                         body:
-                        created_at: 1709050818
-                        updated_at: 1709050818
-                        notified_at: 1709050818
+                        created_at: 1709226292
+                        updated_at: 1709226292
+                        notified_at: 1709226292
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991268002'
+                          id: '991266966'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id357_that_should_be_at_least_@intercom.io
@@ -5882,7 +5889,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: a8cdac57-6c8b-483d-986b-2042554d3a6f
+                    request_id: d5fdf34f-837a-478f-8d77-b27a2c597b3d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5896,7 +5903,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b81bb165-8359-41fc-bb75-bcc27c49b115
+                    request_id: e29f6fbf-5a65-4474-b641-18632f55b17b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5910,7 +5917,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: b37c6430-9617-4ce6-bf1d-30b226aa5e53
+                    request_id: e16a0c18-0893-4c60-8dc8-df5298fbac16
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5934,11 +5941,13 @@ paths:
       tags:
       - Conversations
       operationId: attachContactToConversation
-      description: "You can add participants who are contacts to a conversation, on
-        behalf of either another contact or an admin.\n\n> \U0001F6A7 Note about contacts
-        without an email\n>\n> If you add a contact via the email parameter and there
-        is no user/lead found on that workspace with he given email, then we will
-        create a new contact with `role` set to `lead`.\n\n"
+      description: |+
+        You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.
+
+        {% admonition type="attention" name="Contacts without an email" %}
+        If you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.
+        {% /admonition %}
+
       responses:
         '200':
           description: Attach a contact to a conversation
@@ -5949,7 +5958,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65de0bc7ba4d12866346368b
+                      id: 65e0b9386abd017a41872ced
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -5960,7 +5969,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 1d1da789-a5f8-4897-902b-cdc6c4959db3
+                    request_id: 64eb1f4c-0f8f-46db-b1b4-3f08235decb9
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5974,7 +5983,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 208e2257-6bf2-4e82-82ac-42534880823f
+                    request_id: b0c6a702-ea2c-4758-86bd-ab0a7773d043
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5988,7 +5997,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 68ad8573-7438-4fc2-b061-0570af1d8469
+                    request_id: fdefc589-3547-4302-ba2e-81b8369afd1a
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6003,15 +6012,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991268009
+                  admin_id: 991266973
                   customer:
-                    intercom_user_id: 65de0bc7ba4d12866346368b
+                    intercom_user_id: 65e0b9386abd017a41872ced
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991268011
+                  admin_id: 991266975
                   customer:
-                    intercom_user_id: 65de0bc9ba4d12866346368c
+                    intercom_user_id: 65e0b93a6abd017a41872cee
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -6037,11 +6046,13 @@ paths:
       tags:
       - Conversations
       operationId: detachContactFromConversation
-      description: "You can add participants who are contacts to a conversation, on
-        behalf of either another contact or an admin.\n\n> \U0001F6A7 Note about contacts
-        without an email\n>\n> If you add a contact via the email parameter and there
-        is no user/lead found on that workspace with he given email, then we will
-        create a new contact with `role` set to `lead`.\n\n"
+      description: |+
+        You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.
+
+        {% admonition type="attention" name="Contacts without an email" %}
+        If you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.
+        {% /admonition %}
+
       responses:
         '200':
           description: Detach a contact from a group conversation
@@ -6052,7 +6063,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65de0bd4ba4d128663463696
+                      id: 65e0b9446abd017a41872cf8
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6063,14 +6074,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: e47e1154-c694-4181-9ddc-bbe921f01a35
+                    request_id: 6b3e07c6-967d-4087-b75a-8ed176a4c577
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 281488be-aaf9-438f-abb6-06009d9d292b
+                    request_id: 9eba53af-c4d9-4e46-ab92-dbb289df033d
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -6084,7 +6095,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: d6d7dd78-e7c4-40c6-9191-f38ef1e3dcec
+                    request_id: 21ffe7d8-659b-49c1-9b87-dc3354862f61
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -6098,7 +6109,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a700d518-73e8-4f36-b120-acd698ee6474
+                    request_id: '08181616-b404-487e-8e64-38095fdc3a8e'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6112,7 +6123,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 15fa0698-1b4d-4ee6-90d4-af9e5fc8edba
+                    request_id: e9b424d5-fd1e-4d87-8d05-9a0b422a2e9a
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6127,27 +6138,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991268017
+                  admin_id: 991266981
                   customer:
-                    intercom_user_id: 65de0bcdba4d12866346368f
+                    intercom_user_id: 65e0b93e6abd017a41872cf1
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991268019
+                  admin_id: 991266983
                   customer:
-                    intercom_user_id: 65de0bd5ba4d128663463697
+                    intercom_user_id: 65e0b9456abd017a41872cf9
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991268021
+                  admin_id: 991266985
                   customer:
-                    intercom_user_id: 65de0bddba4d12866346369e
+                    intercom_user_id: 65e0b94c6abd017a41872d00
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991268023
+                  admin_id: 991266987
                   customer:
-                    intercom_user_id: 65de0be5ba4d1286634636a5
+                    intercom_user_id: 65e0b9546abd017a41872d07
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6159,12 +6170,13 @@ paths:
       tags:
       - Conversations
       operationId: redactConversation
-      description: "You can redact a conversation part or the source message of a
-        conversation (as seen in the source object).\n\n> \U0001F4D8 Which parts and
-        source messages can I redact?\n>\n> If you are redacting a conversation part,
-        it must have a `body`.\n> If you are redacting a source message, it must have
-        been created by a contact.\n> We will return a `conversation_part_not_redactable`
-        error if these criteria are not met.\n\n"
+      description: |+
+        You can redact a conversation part or the source message of a conversation (as seen in the source object).
+
+        {% admonition type="info" name="Redacting parts and messages" %}
+        If you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.
+        {% /admonition %}
+
       responses:
         '200':
           description: Redact a conversation part
@@ -6174,20 +6186,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '557'
-                    created_at: 1709050876
-                    updated_at: 1709050877
-                    waiting_since: 1709050877
+                    id: '268'
+                    created_at: 1709226346
+                    updated_at: 1709226347
+                    waiting_since: 1709226347
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918385'
+                      id: '403918217'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268029'
+                        id: '991266993'
                         name: Ciaran215 Lee
                         email: admin215@email.com
                       attachments: []
@@ -6197,9 +6209,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0bfcba4d1286634636ba
+                        id: 65e0b9696abd017a41872d1c
                     first_contact_reply:
-                      created_at: 1709050877
+                      created_at: 1709226347
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6222,15 +6234,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '120'
+                        id: '49'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1709050877
-                        updated_at: 1709050877
-                        notified_at: 1709050877
+                        created_at: 1709226347
+                        updated_at: 1709226347
+                        notified_at: 1709226347
                         assigned_to:
                         author:
-                          id: 65de0bfcba4d1286634636ba
+                          id: 65e0b9696abd017a41872d1c
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6248,7 +6260,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 0cba7a3f-3f95-4909-a20f-a6f25f02561b
+                    request_id: 0ad4d7ea-529d-4af6-8244-7ea864f86d46
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -6262,7 +6274,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 031f2d50-6cfd-41b8-ba47-cffb78366557
+                    request_id: '066299f2-3dcb-4f21-99ac-313fcc8a6cca'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6278,8 +6290,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 557
-                  conversation_part_id: 120
+                  conversation_id: 268
+                  conversation_part_id: 49
               not_found:
                 summary: Not found
                 value:
@@ -6466,7 +6478,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 50
+                    - id: 18
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -6479,9 +6491,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991268054'
-                      created_at: 1709050890
-                      updated_at: 1709050890
+                      admin_id: '991267018'
+                      created_at: 1709226358
+                      updated_at: 1709226358
                       model: company
                     - type: data_attribute
                       name: id
@@ -6553,7 +6565,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 65f22c6c-50b9-47e9-998c-b7842e886166
+                    request_id: 2ecd21e6-6521-4f98-8c9f-2208c36864c9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6578,7 +6590,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 53
+                    id: 21
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -6589,9 +6601,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991268056'
-                    created_at: 1709050891
-                    updated_at: 1709050891
+                    admin_id: '991267020'
+                    created_at: 1709226359
+                    updated_at: 1709226359
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6603,7 +6615,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: 87ecc0b2-25c3-40c5-8ec9-da14745d6fb4
+                    request_id: 99254deb-aaaa-4564-b484-c1548220c009
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6611,7 +6623,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: a91adc0a-04ff-4bdf-9891-003199edca88
+                    request_id: f73a3fd9-8e7e-46f0-9a21-1db4dbcdaf45
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -6619,7 +6631,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: 65327c00-4945-4894-97ff-2a715b3b3ccf
+                    request_id: c2e32466-1d9b-4ee4-b22c-1cc5944ad710
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6627,14 +6639,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: 37e8fad1-40f2-493f-a083-6e8c166b1c82
+                    request_id: 92162c89-7f6f-4f1f-a73d-08ed437d8ec5
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: 33b1b330-1471-45bf-8f38-86fa9da7c448
+                    request_id: 45c30926-6992-44dc-a9ac-aa8587996dd8
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -6649,7 +6661,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 00a79614-cd8b-47ec-942f-8494175e0355
+                    request_id: 456e5cd0-258a-4335-805b-c9600f12ac36
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6728,7 +6740,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 60
+                    id: 28
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -6743,9 +6755,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991268063'
-                    created_at: 1709050894
-                    updated_at: 1709050895
+                    admin_id: '991267027'
+                    created_at: 1709226363
+                    updated_at: 1709226363
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6757,7 +6769,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: 94d9132d-84ef-4f7a-b8fb-a278eff57c4e
+                    request_id: 4643ce69-c06e-450a-a793-0aaadc6b222b
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -6771,7 +6783,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: f1c552d8-e9ac-4594-bb06-256ef7bd55ea
+                    request_id: 576934f5-ca0e-49d5-8a06-496743cdf535
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -6785,7 +6797,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: 28ce6f59-41eb-422f-b79e-2f05e87ddd4a
+                    request_id: 41fe90fb-8142-4da8-be0a-4980aca82e63
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -6800,7 +6812,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 82342db4-7c02-4c47-9800-3be35b903743
+                    request_id: 83c65463-c613-44d1-9872-28a9ff7ebb13
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6905,7 +6917,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7f01db36-b00d-48ce-9169-8ce4af157c7b
+                    request_id: 1873230a-803e-408e-99ec-baab7dd367c9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6992,7 +7004,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 65de0c13ba4d1286634636c3
+                    intercom_user_id: 65e0b9806abd017a41872d25
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -7004,7 +7016,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 43a855e0-0202-4d01-810c-e541d4b2a7c6
+                    request_id: 40ac4c78-2bfd-4ed6-aaf9-b2e9e2a1cd56
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7035,7 +7047,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5787c949-1233-4fc6-aa84-da21776f2dba
+                    request_id: 80620550-c19c-4a2c-a7e3-f20f54637c1b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7079,7 +7091,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: aodg0lr3x4a8lewu
+                    job_identifier: qiln6lj584rv9rud
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7094,8 +7106,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1709032901
-                  created_at_before: 1709050901
+                  created_at_after: 1709208371
+                  created_at_before: 1709226371
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -7129,7 +7141,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: 8e8ffdvhikb7qyej
+                    job_identifier: 1cy7kj1by3rc2yez
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7161,7 +7173,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: xlnhqzhl2id2asi0
+                    job_identifier: yl4vzza51zca6qv3
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -7222,30 +7234,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918390'
-                    created_at: 1709050904
+                    id: '403918222'
+                    created_at: 1709226373
                     body: heyy
                     message_type: inapp
-                    conversation_id: '562'
+                    conversation_id: '273'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918391'
-                    created_at: 1709050905
+                    id: '403918223'
+                    created_at: 1709226374
                     body: heyy
                     message_type: inapp
-                    conversation_id: '563'
+                    conversation_id: '274'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '20'
-                    created_at: 1709050906
+                    id: '10'
+                    created_at: 1709226376
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991268086'
+                      id: '991267050'
                       name: Ciaran265 Lee
                       email: admin265@email.com
                       away_mode_enabled: false
@@ -7260,14 +7272,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: aa31a845-0cd3-409e-ba89-efc11fec6cf1
+                    request_id: 3a127c41-f539-436b-ab33-7c82ab894402
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: 2242c477-cc07-44a3-97cd-92deeaa92eb6
+                    request_id: 709cd1fa-8ba7-4da7-980c-b8169039e298
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -7281,7 +7293,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: cdee9d99-69e9-4d35-8ced-fe8db4315039
+                    request_id: '0238e3cc-3dfe-454f-975b-fb9dec86f87e'
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -7295,7 +7307,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d55fd3a9-c996-4525-946d-cf5176414698
+                    request_id: 2678bb0e-fac4-4694-9608-2727a4cbee47
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7309,7 +7321,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 7ee2ac53-72b3-41de-bfa9-e80db2789470
+                    request_id: 8aac0609-1ee3-4b2c-b446-8f8cb872391b
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -7326,7 +7338,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65de0c17ba4d1286634636c8
+                    id: 65e0b9856abd017a41872d2a
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -7334,7 +7346,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 65de0c18ba4d1286634636c9
+                    id: 65e0b9866abd017a41872d2b
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -7342,10 +7354,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268086'
+                    id: '991267050'
                   to:
                     type: user
-                    id: 65de0c19ba4d1286634636ca
+                    id: 65e0b9876abd017a41872d2c
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -7353,10 +7365,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268088'
+                    id: '991267052'
                   to:
                     type: user
-                    id: 65de0c1aba4d1286634636cb
+                    id: 65e0b9886abd017a41872d2d
                   message_type: inapp
                   body:
                   subject: heyy
@@ -7365,7 +7377,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268089'
+                    id: '991267053'
                   to:
                     type: user
                     user_id: '70'
@@ -7376,10 +7388,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268090'
+                    id: '991267054'
                   to:
                     type: user
-                    id: 65de0c1cba4d1286634636cd
+                    id: 65e0b9f76abd017a41872d2f
                   message_type: email
                   body:
                   subject: heyy
@@ -7410,12 +7422,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '42'
+                    - id: '16'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991268095
+                      sender_id: 991267061
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7425,15 +7437,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709050910
-                      updated_at: 1709050910
+                      created_at: 1709226489
+                      updated_at: 1709226489
                       newsfeed_assignments: []
-                    - id: '43'
+                    - id: '15'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991268097
+                      sender_id: 991267059
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7443,8 +7455,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709050910
-                      updated_at: 1709050910
+                      created_at: 1709226488
+                      updated_at: 1709226488
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -7457,7 +7469,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ce0e7599-727f-4671-b5f9-c1e990d092e7
+                    request_id: ea0e1fb6-93b3-4a62-a61c-2781211ecba2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7482,12 +7494,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '46'
+                    id: '19'
                     type: news-item
                     workspace_id: this_is_an_id483_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991268104
+                    sender_id: 991267068
                     state: live
                     labels:
                     - New
@@ -7498,10 +7510,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1709050911
-                    updated_at: 1709050911
+                    created_at: 1709226490
+                    updated_at: 1709226490
                     newsfeed_assignments:
-                    - newsfeed_id: 78
+                    - newsfeed_id: 28
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7513,7 +7525,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0f3b6a08-3001-426b-b642-5c9876a3ec9f
+                    request_id: 82e10dfa-2675-483e-b819-dee80a61ffe5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7534,14 +7546,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991268104
+                  sender_id: 991267068
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 78
+                  - newsfeed_id: 28
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -7570,12 +7582,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '47'
+                    id: '20'
                     type: news-item
                     workspace_id: this_is_an_id487_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991268107
+                    sender_id: 991267071
                     state: live
                     labels: []
                     cover_image_url:
@@ -7585,11 +7597,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1709050912
-                    updated_at: 1709050912
+                    created_at: 1709226491
+                    updated_at: 1709226491
                     newsfeed_assignments:
-                    - newsfeed_id: 80
-                      published_at: 1709050913
+                    - newsfeed_id: 30
+                      published_at: 1709226492
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -7600,7 +7612,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: fc3fc353-c17c-4f24-a3d6-ecd5f2f7b37d
+                    request_id: adff157f-be79-4900-a5d2-64da166d6641
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7614,7 +7626,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1d4deb6b-019d-447b-8b89-2dd49212f8ee
+                    request_id: 398cfc64-c254-43aa-bc6c-a9db118fbc51
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7645,12 +7657,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '50'
+                    id: '23'
                     type: news-item
                     workspace_id: this_is_an_id493_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991268115
+                    sender_id: 991267079
                     state: live
                     labels: []
                     cover_image_url:
@@ -7658,8 +7670,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1709050914
-                    updated_at: 1709050915
+                    created_at: 1709226493
+                    updated_at: 1709226493
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7671,7 +7683,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: b09a3351-933c-4b8e-b84a-a5e56ed9011f
+                    request_id: 3a721e08-ebc8-47ef-a897-47466aadf145
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7685,7 +7697,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 60b28d82-f3fe-4c5d-b204-6a3ed93b3321
+                    request_id: 3475759f-ff43-4b18-bf43-3ce745fa6a21
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7702,7 +7714,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991268115
+                  sender_id: 991267079
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7711,7 +7723,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991268118
+                  sender_id: 991267082
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7741,7 +7753,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '53'
+                    id: '26'
                     object: news-item
                     deleted: true
               schema:
@@ -7754,7 +7766,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 90677dbe-f954-4464-98a9-576a96bf972c
+                    request_id: 444fdc0c-2f90-497e-ba9e-2536bf87394f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7768,7 +7780,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 25a1b3a9-3c9d-462e-bc4e-e5ba076c98d2
+                    request_id: f8ac0486-3b2f-4da6-94c7-acc70708b3aa
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7821,7 +7833,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 72a0e45b-88cd-4a39-972d-1b9712de1554
+                    request_id: e90cf8fc-71da-4820-93b4-9f6e3b931680
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7854,16 +7866,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '93'
+                    - id: '43'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709050919
-                      updated_at: 1709050919
-                    - id: '94'
+                      created_at: 1709226498
+                      updated_at: 1709226498
+                    - id: '44'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709050919
-                      updated_at: 1709050919
+                      created_at: 1709226498
+                      updated_at: 1709226498
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -7875,7 +7887,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2e26507c-88f6-4ac2-8784-101cdbf63eba
+                    request_id: e9c6ab6d-fd26-433c-aea0-9f5c1fb4e245
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7909,11 +7921,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '97'
+                    id: '47'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1709050920
-                    updated_at: 1709050920
+                    created_at: 1709226499
+                    updated_at: 1709226499
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -7924,7 +7936,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 31c37590-c4f6-489a-9eb7-668f7e1ac580
+                    request_id: 55fcbb91-01de-46c8-8287-16c1869f49cc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7958,14 +7970,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '50'
-                    created_at: 1708359721
+                    id: '24'
+                    created_at: 1708535300
                     contact:
                       type: contact
-                      id: 65de0c29ba4d1286634636d0
+                      id: 65e0ba046abd017a41872d32
                     author:
                       type: admin
-                      id: '991268134'
+                      id: '991267098'
                       name: Ciaran312 Lee
                       email: admin312@email.com
                       away_mode_enabled: false
@@ -7981,7 +7993,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: f0f6eec6-9d4f-4c9b-8e14-d2131c3a90a2
+                    request_id: 4674b90d-cfa9-43e6-94be-77d87af60c36
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7995,7 +8007,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e4cbadef-d164-44af-95c3-cbc96033f78c
+                    request_id: 84d90b9d-a6af-4325-af79-47b766c202b8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8031,16 +8043,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 65de0c2aba4d1286634636d3
+                      id: 65e0ba056abd017a41872d35
                       name: John segment
-                      created_at: 1709050922
-                      updated_at: 1709050922
+                      created_at: 1709226501
+                      updated_at: 1709226501
                       person_type: user
                     - type: segment
-                      id: 65de0c2aba4d1286634636d4
+                      id: 65e0ba056abd017a41872d36
                       name: Jane segment
-                      created_at: 1709050922
-                      updated_at: 1709050922
+                      created_at: 1709226501
+                      updated_at: 1709226501
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -8052,7 +8064,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d99841be-d64e-4683-b19c-c35bd3545ec0
+                    request_id: eccea87a-018e-4f8b-9444-d99ee3069319
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8086,10 +8098,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 65de0c2cba4d1286634636d7
+                    id: 65e0ba066abd017a41872d39
                     name: John segment
-                    created_at: 1709050924
-                    updated_at: 1709050924
+                    created_at: 1709226502
+                    updated_at: 1709226502
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -8101,7 +8113,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: 0f26343e-01d5-4967-800e-65786e7aeaab
+                    request_id: b2fb5b4e-481f-4462-a735-ce303b1da528
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8115,7 +8127,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3b4a5f1b-c015-43e1-ba02-0dd9a95faa1b
+                    request_id: 675ad361-2d7a-4037-bf6a-422e2f81cc98
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8145,7 +8157,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '183'
+                      id: '91'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -8168,7 +8180,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1c6d475a-8dc3-4d3b-bc4b-7c3d5312ebdc
+                    request_id: 8babb440-4482-40b3-b13a-bd0ed4749b5d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8198,7 +8210,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/ccd89e27-caf8-40ad-a130-7821cfd2edbd
+                    url: http://via.intercom.io/msgr/6ebbd1ba-f6cb-4e65-9872-d504008c4ef0
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -8231,7 +8243,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d559d4b9-15bb-4282-8c37-2d0f5ef1aa8d
+                    request_id: e506572b-9ca3-472a-9f40-68c3e25d7390
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8294,7 +8306,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '151'
+                      id: '64'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -8306,7 +8318,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4dba2237-fe31-4d89-b974-0e88a2ad55aa
+                    request_id: 9366b9f2-c6c8-41d9-9503-e1636ee2c3bc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8345,7 +8357,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '154'
+                    id: '67'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8357,7 +8369,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: c2703ea4-60db-4439-b497-abb1d0632e7e
+                    request_id: 53070439-0773-4060-abf2-11a302109fc8
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -8371,14 +8383,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: 235f3782-c60d-401f-8efe-df3a4c3f5260
+                    request_id: df522d5b-c048-4094-8914-0e80876ac062
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: d68c9669-54d7-40f2-b10f-3e820464bb04
+                    request_id: 3912b584-297d-4ebd-89f4-635b8a142b8c
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -8392,7 +8404,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9c2c2090-5af8-4e60-8118-f7bdf3b58f43
+                    request_id: f663e1fd-98ab-48e1-b0da-e37e8aa1077b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8458,7 +8470,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '162'
+                    id: '75'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8470,7 +8482,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: abe0e64d-845c-486b-b2d7-d57797ae5391
+                    request_id: 5c5c2b27-6a14-4e51-8238-0723d4a2dc81
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8484,7 +8496,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ea4e6488-98ec-4931-bd95-d27d46312f34
+                    request_id: 14602be5-e43b-4e98-a9a3-7d2cffc74390
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8520,7 +8532,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: f8d4e475-56b1-408f-8a73-bbb35b439ecd
+                    request_id: d4ebbe62-57e1-4923-bcaa-ee131aa8d056
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8534,7 +8546,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: 20a9f954-78d0-401f-a042-8389093ebe66
+                    request_id: 61c10f64-0569-4300-8ade-8e28710cb909
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -8549,7 +8561,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5c537665-07c8-4c6e-973a-3eb76687670b
+                    request_id: b1255db5-fe23-418e-82d7-cff2863e879e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8587,7 +8599,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 15058e27-b731-4418-937b-8fdb711d0fb8
+                    request_id: c489fb57-1349-457f-bf14-76dc2e0f2b73
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8622,7 +8634,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991268172'
+                    id: '991267136'
                     name: team 1
                     admin_ids: []
               schema:
@@ -8635,7 +8647,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: 18c129cb-19be-4a54-a174-be1021517c46
+                    request_id: 530447b6-7692-4d3a-bfc2-7f2991665b42
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -8649,7 +8661,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a4f4fb57-9497-49b0-abd2-54107d4443ca
+                    request_id: '0883726f-32f3-49e9-b670-8801680b0e47'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8681,26 +8693,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0c49ba4d1286634636fb
+                    id: 65e0ba226abd017a41872d5d
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Charcoal Lamp
+                    pseudonym: Mint Diamond
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/charcoal-lamp.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/mint-diamond.png
                     app_id: this_is_an_id609_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709050953
-                    remote_created_at: 1709050953
-                    signed_up_at: 1709050953
-                    updated_at: 1709050954
+                    created_at: 1709226530
+                    remote_created_at: 1709226530
+                    signed_up_at: 1709226530
+                    updated_at: 1709226531
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8733,7 +8745,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 6112c528-a2c7-4ca2-9d7f-f9f6df6f79b3
+                    request_id: d243da06-144d-4a69-bf4b-55d56035c4da
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8747,7 +8759,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 27d98be0-0a4d-4e14-be62-5406721a56dc
+                    request_id: 94381b24-5571-405d-9e3f-abe50fe2f065
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8762,7 +8774,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 65de0c49ba4d1286634636fb
+                  id: 65e0ba226abd017a41872d5d
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -8795,7 +8807,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0c4bba4d128663463701
+                    id: 65e0ba246abd017a41872d63
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -8811,10 +8823,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709050955
-                    remote_created_at: 1709050955
-                    signed_up_at: 1709050955
-                    updated_at: 1709050955
+                    created_at: 1709226532
+                    remote_created_at: 1709226532
+                    signed_up_at: 1709226532
+                    updated_at: 1709226532
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8847,7 +8859,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: 732a1a5f-0de0-44f6-93e8-a9338bd560af
+                    request_id: ffd9f817-89bd-496c-828d-7c72ee14b20c
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8861,7 +8873,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 314c3929-22c2-4d14-8a2a-825890ce3d2f
+                    request_id: 791182b8-df1f-455e-8bb6-44c4c9185e73
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8895,7 +8907,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0c4dba4d128663463707
+                    id: 65e0ba266abd017a41872d69
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -8911,10 +8923,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709050957
-                    remote_created_at: 1709050957
-                    signed_up_at: 1709050957
-                    updated_at: 1709050957
+                    created_at: 1709226534
+                    remote_created_at: 1709226534
+                    signed_up_at: 1709226534
+                    updated_at: 1709226534
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8947,7 +8959,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: a3123290-1d2a-4844-9e6b-430a0c8bccb7
+                    request_id: ae844ba8-ceec-436f-a42c-416a439fe2bf
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8961,7 +8973,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 38f34b8f-49f4-4f93-8dba-95c054209a9f
+                    request_id: eb4de280-fac7-497d-ba3c-3d2d9fbef909
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8994,7 +9006,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0c4eba4d12866346370d
+                    id: 65e0ba286abd017a41872d6f
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -9010,10 +9022,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709050958
-                    remote_created_at: 1709050958
-                    signed_up_at: 1709050958
-                    updated_at: 1709050959
+                    created_at: 1709226536
+                    remote_created_at: 1709226536
+                    signed_up_at: 1709226536
+                    updated_at: 1709226536
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -9046,7 +9058,7 @@ paths:
                 Visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 3b9ea476-5f4d-4be1-a773-1f1a51d48a54
+                    request_id: 50630bcc-4882-43d7-8c8f-2551a86f2aa2
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -9060,7 +9072,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4c4f23ae-9505-4405-b447-8ecdd9efa11f
+                    request_id: 7230c653-5e84-44af-b824-c5345430cc02
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9091,7 +9103,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0c50ba4d128663463714
+                    id: 65e0ba296abd017a41872d76
                     workspace_id: this_is_an_id633_that_should_be_at_least_
                     external_id:
                     role: user
@@ -9106,9 +9118,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709050960
-                    updated_at: 1709050961
-                    signed_up_at: 1709050960
+                    created_at: 1709226537
+                    updated_at: 1709226538
+                    signed_up_at: 1709226537
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -9142,31 +9154,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0c50ba4d128663463714/tags"
+                      url: "/contacts/65e0ba296abd017a41872d76/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0c50ba4d128663463714/notes"
+                      url: "/contacts/65e0ba296abd017a41872d76/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0c50ba4d128663463714/companies"
+                      url: "/contacts/65e0ba296abd017a41872d76/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0c50ba4d128663463714/subscriptions"
+                      url: "/contacts/65e0ba296abd017a41872d76/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0c50ba4d128663463714/subscriptions"
+                      url: "/contacts/65e0ba296abd017a41872d76/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -9185,7 +9197,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6117f43d-6057-49b4-8656-63b7b5184341
+                    request_id: be6ad792-c726-4573-9180-a7b95eedc9f8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9477,12 +9489,32 @@ components:
           description: The id of the admin who is authoring the comment.
           example: '3156780'
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -10820,12 +10852,32 @@ components:
           type: string
           description: The email you have defined for the user.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -10853,12 +10905,32 @@ components:
           type: string
           description: The identifier for the contact as given by Intercom.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -10886,12 +10958,32 @@ components:
           type: string
           description: The external_id you have defined for the contact.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991266728'
+                    id: '991269090'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1709226106
+                      created_at: 1709288768
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991266729'
+                    id: '991269091'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: c1d3117c-2d58-4c6b-8010-809360595b68
+                    request_id: 0dfa247f-e43a-4010-af0e-71a3b3c18941
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0f5dea50-e500-4e5e-ae51-9257ddb651de
+                    request_id: 9789170e-35a2-4957-b781-81a392526bd2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: 5686ea27-56ef-4a40-bfb0-91785dec7a27
+                    - id: a4924818-5bf5-4c56-a597-56fd95637da7
                       performed_by:
                         type: admin
-                        id: '991266733'
+                        id: '991269095'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1709226112
+                      created_at: 1709288775
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: f444ae78-f556-429b-9174-550567230f13
+                    - id: d4495958-2545-4ea5-a2d0-a45475c26fe8
                       performed_by:
                         type: admin
-                        id: '991266733'
+                        id: '991269095'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1709226112
+                      created_at: 1709288775
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d4677cbf-3c00-45fa-aea8-fdfd13fcf0ed
+                    request_id: 737bcbca-6862-4275-96d4-c147528fe844
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991266735'
+                      id: '991269097'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 84e336e8-e441-405d-b405-aef2d2690544
+                    request_id: 5b82bf11-129f-4dd6-907e-3e64add9cb5a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991266737'
+                    id: '991269099'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: fa109ba4-5df2-44ad-bb2f-148da63529d6
+                    request_id: 1c3a5356-0943-4f0c-9a7f-3323105267e6
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7579884d-64de-4e64-9ac9-71442edd434f
+                    request_id: dee3c9d9-c5e8-49a5-9c1d-ec94d43de3c9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -390,20 +390,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '23'
+                    - id: '127'
                       type: article
                       workspace_id: this_is_an_id22_that_should_be_at_least_4
-                      parent_id: 77
+                      parent_id: 444
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991266740
+                      author_id: 991269102
                       state: published
-                      created_at: 1709226117
-                      updated_at: 1709226117
-                      url: http://help-center.test/myapp-22/en/articles/23-this-is-the-article-title
+                      created_at: 1709288780
+                      updated_at: 1709288780
+                      url: http://help-center.test/myapp-22/en/articles/127-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -414,7 +414,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1b8f8090-e073-45ab-8848-73ac7fa58205
+                    request_id: ab994e46-b125-40d4-b4ae-9f6e9ead75bf
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -439,10 +439,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '26'
+                    id: '130'
                     type: article
                     workspace_id: this_is_an_id26_that_should_be_at_least_4
-                    parent_id: 79
+                    parent_id: 446
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -456,11 +456,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991266745
+                    author_id: 991269107
                     state: published
-                    created_at: 1709226119
-                    updated_at: 1709226119
-                    url: http://help-center.test/myapp-26/en/articles/26-thanks-for-everything
+                    created_at: 1709288782
+                    updated_at: 1709288782
+                    url: http://help-center.test/myapp-26/en/articles/130-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -471,7 +471,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 8b90c4e0-ff5e-4e46-99d9-b9510e604dba
+                    request_id: 81d7f376-42b5-45ce-b29a-2f2616f66a34
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -486,7 +486,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8d165f9b-c39e-43ba-af6f-9be097c0d38f
+                    request_id: 9d2cfacc-989e-4a94-a34b-35cafa02519d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -504,16 +504,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991266745
+                  author_id: 991269107
                   state: published
-                  parent_id: 79
+                  parent_id: 446
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991266745
+                      author_id: 991269107
                       state: published
               bad_request:
                 summary: Bad Request
@@ -550,10 +550,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '29'
+                    id: '133'
                     type: article
                     workspace_id: this_is_an_id32_that_should_be_at_least_4
-                    parent_id: 82
+                    parent_id: 449
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -567,11 +567,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991266750
+                    author_id: 991269112
                     state: published
-                    created_at: 1709226121
-                    updated_at: 1709226121
-                    url: http://help-center.test/myapp-32/en/articles/29-this-is-the-article-title
+                    created_at: 1709288785
+                    updated_at: 1709288785
+                    url: http://help-center.test/myapp-32/en/articles/133-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -582,7 +582,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: accd2af8-8026-450c-bae7-4bda3adc75f2
+                    request_id: f7d3c4ed-3f4d-4103-b146-ac57eae0c94c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -596,7 +596,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '09f1292b-7619-4227-8a8d-57c0dc86afae'
+                    request_id: 1df5d098-d68b-43a4-a78f-c4262b6f563f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -629,10 +629,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '32'
+                    id: '136'
                     type: article
                     workspace_id: this_is_an_id38_that_should_be_at_least_4
-                    parent_id: 85
+                    parent_id: 452
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -646,11 +646,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991266756
+                    author_id: 991269118
                     state: published
-                    created_at: 1709226123
-                    updated_at: 1709226124
-                    url: http://help-center.test/myapp-38/en/articles/32-christmas-is-here
+                    created_at: 1709288787
+                    updated_at: 1709288788
+                    url: http://help-center.test/myapp-38/en/articles/136-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -661,7 +661,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 83e5f423-e60f-4d29-86ad-365ea97bb325
+                    request_id: 1090127d-c4b1-4d29-9546-5f200b9c86ca
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -675,7 +675,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 92270187-d774-4221-a6d9-5beeb411bb19
+                    request_id: f5417e15-8617-4a67-bb7b-ed1f34dc89b9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -723,7 +723,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '35'
+                    id: '139'
                     object: article
                     deleted: true
               schema:
@@ -736,7 +736,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 0c0b325e-5b1c-4ba0-8b33-00d2fe749ca8
+                    request_id: aa959cab-0605-49ea-912d-42e4828a0b5d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -750,7 +750,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: df01a12b-8d83-416b-9e11-6eacedacfe4f
+                    request_id: 5fa73e59-838c-4570-a982-0179e5114c49
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -781,16 +781,16 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '93'
+                    - id: '460'
                       workspace_id: this_is_an_id52_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-52/collection-17
                       order: 17
-                      created_at: 1709226128
-                      updated_at: 1709226128
+                      created_at: 1709288794
+                      updated_at: 1709288794
                       description: english collection description
                       icon: bookmark
-                      help_center_id: 57
+                      help_center_id: 228
                       type: collection
                     total_count: 1
                     pages:
@@ -808,7 +808,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5ab43962-f05c-438f-aaa6-cf67e4bd2c7a
+                    request_id: 95fe82d7-d0a2-4d4c-8a57-dab6aaaad8a0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -833,16 +833,16 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '99'
+                    id: '466'
                     workspace_id: this_is_an_id56_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-56/
                     order: 1
-                    created_at: 1709226130
-                    updated_at: 1709226130
+                    created_at: 1709288795
+                    updated_at: 1709288795
                     description: ''
                     icon: book-bookmark
-                    help_center_id: 59
+                    help_center_id: 230
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -854,7 +854,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 7029f2b6-0c71-4a3a-8a8a-4fa92b5a8502
+                    request_id: c8e716b9-ca65-4a28-8c9f-898be5a87e4e
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -868,7 +868,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 59f23908-c4de-4a99-ac0a-23388a8f4729
+                    request_id: 89af20a7-dcb6-49db-8cf9-aafcf42dff93
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -916,16 +916,16 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '104'
+                    id: '471'
                     workspace_id: this_is_an_id62_that_should_be_at_least_4
                     name: English collection title
                     url: http://help-center.test/myapp-62/collection-22
                     order: 22
-                    created_at: 1709226131
-                    updated_at: 1709226131
+                    created_at: 1709288796
+                    updated_at: 1709288796
                     description: english collection description
                     icon: bookmark
-                    help_center_id: 62
+                    help_center_id: 233
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -937,7 +937,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 195ccd61-5df9-4e76-bd12-d3a6779a5624
+                    request_id: ce805539-1c7e-4813-9364-c59dece4ce16
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -951,7 +951,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 17df26e9-1c3d-46df-882f-ad4809ea0405
+                    request_id: b695002e-eda6-4dc9-854e-5ce9c43be999
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -984,16 +984,16 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '110'
+                    id: '477'
                     workspace_id: this_is_an_id68_that_should_be_at_least_4
                     name: Update collection name
                     url: http://help-center.test/myapp-68/collection-25
                     order: 25
-                    created_at: 1709226133
-                    updated_at: 1709226133
+                    created_at: 1709288797
+                    updated_at: 1709288798
                     description: english collection description
                     icon: folder
-                    help_center_id: 65
+                    help_center_id: 236
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -1005,7 +1005,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: f023e059-c09c-4ecb-87d0-a582de89a6b4
+                    request_id: 63194363-6a55-496d-9e9d-e9a9603aa1c8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1019,7 +1019,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9eec5fc2-b4e0-4a4d-88a6-a9a837cdd5b2
+                    request_id: f03bf8a4-c182-4467-bd1d-1a22a278bb93
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1066,7 +1066,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '116'
+                    id: '483'
                     object: collection
                     deleted: true
               schema:
@@ -1079,7 +1079,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: fec25809-592a-4665-9fea-26e4f761b704
+                    request_id: db2640b1-9f67-471c-bee1-04d7e5755f4b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1093,7 +1093,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: df644784-9971-4586-9e36-22a1b956be13
+                    request_id: 7f615fee-b1f9-422a-9614-911b74bc74cd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1127,10 +1127,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '71'
+                    id: '242'
                     workspace_id: this_is_an_id80_that_should_be_at_least_4
-                    created_at: 1709226136
-                    updated_at: 1709226136
+                    created_at: 1709288801
+                    updated_at: 1709288801
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1144,7 +1144,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 6fc11af8-0fc6-4e5d-80ad-648db7447a42
+                    request_id: 6167a2ab-8d98-4f3c-8525-4584285e6064
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1158,7 +1158,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bc5742f0-94eb-477f-9dcb-b27f08169871
+                    request_id: 94fda6ae-034d-4be6-8320-c184ffa15efb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1196,7 +1196,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8a9a5e79-2fae-4881-bce9-7617492ff84c
+                    request_id: 79da0c81-a676-447e-af19-522d22734241
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1228,15 +1228,15 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '123'
+                    - id: '490'
                       workspace_id: this_is_an_id90_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-90/section-15
                       order: 15
-                      created_at: 1709226138
-                      updated_at: 1709226138
+                      created_at: 1709288803
+                      updated_at: 1709288803
                       type: section
-                      parent_id: 122
+                      parent_id: 489
                     total_count: 1
                     pages:
                       type: pages
@@ -1253,7 +1253,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3249d150-d266-4bb5-91de-1393ab5fd2ac
+                    request_id: 4e47ec90-0ac7-4d4e-acdf-45b38dd5d5d0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1278,15 +1278,15 @@ paths:
               examples:
                 section created:
                   value:
-                    id: '128'
+                    id: '495'
                     workspace_id: this_is_an_id94_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-94/
                     order: 1
-                    created_at: 1709226139
-                    updated_at: 1709226139
+                    created_at: 1709288804
+                    updated_at: 1709288804
                     type: section
-                    parent_id: '126'
+                    parent_id: '493'
               schema:
                 "$ref": "#/components/schemas/section"
         '401':
@@ -1297,7 +1297,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1448125f-b22f-45c1-b8d5-f7b030d9d657
+                    request_id: 817d809e-f22d-42be-be55-729533d5e403
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1313,7 +1313,7 @@ paths:
                 summary: section created
                 value:
                   name: Thanks for everything
-                  parent_id: 126
+                  parent_id: 493
   "/help_center/sections/{id}":
     get:
       summary: Retrieve a section
@@ -1342,15 +1342,15 @@ paths:
               examples:
                 Section found:
                   value:
-                    id: '132'
+                    id: '499'
                     workspace_id: this_is_an_id98_that_should_be_at_least_4
                     name: English section title
                     url: http://help-center.test/myapp-98/section-19
                     order: 19
-                    created_at: 1709226140
-                    updated_at: 1709226140
+                    created_at: 1709288805
+                    updated_at: 1709288805
                     type: section
-                    parent_id: 131
+                    parent_id: 498
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1361,7 +1361,7 @@ paths:
                 Section not found:
                   value:
                     type: error.list
-                    request_id: 3a7e5589-95b0-49c9-a868-cd02806f71b9
+                    request_id: 879d3202-d9af-49bf-a7f4-99120adb0483
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1375,7 +1375,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b0826648-80c9-47ff-98ce-7d7464786218
+                    request_id: 317419ce-e8da-4169-8de7-2d7a2bd79016
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1408,15 +1408,15 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '138'
+                    id: '505'
                     workspace_id: this_is_an_id104_that_should_be_at_least_
                     name: Update section name
                     url: http://help-center.test/myapp-104/section-22
                     order: 22
-                    created_at: 1709226141
-                    updated_at: 1709226141
+                    created_at: 1709288806
+                    updated_at: 1709288807
                     type: section
-                    parent_id: '137'
+                    parent_id: '504'
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1427,7 +1427,7 @@ paths:
                 Section Not Found:
                   value:
                     type: error.list
-                    request_id: c27773a9-4ce7-4726-9615-9f0fc6088a8d
+                    request_id: b39e7346-4e06-4f1e-928f-6ed7217785f5
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1441,7 +1441,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3610b578-b49f-49c4-af5e-bf429dc9044a
+                    request_id: 4a001c21-2036-405e-a274-c4162eed4bc6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1457,12 +1457,12 @@ paths:
                 summary: successful
                 value:
                   name: Update section name
-                  parent_id: 137
+                  parent_id: 504
               section_not_found:
                 summary: Section Not Found
                 value:
                   name: Update section name
-                  parent_id: 139
+                  parent_id: 506
     delete:
       summary: Delete a section
       parameters:
@@ -1489,7 +1489,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '144'
+                    id: '511'
                     object: section
                     deleted: true
               schema:
@@ -1502,7 +1502,7 @@ paths:
                 section Not Found:
                   value:
                     type: error.list
-                    request_id: 62183ede-0fc0-4184-a202-a116cdb2b403
+                    request_id: 4f8da433-ccd4-474c-a335-3c2fcfac154d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1516,7 +1516,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '009c6ee9-0d24-4f08-a7e8-225fdec7f446'
+                    request_id: f125e68c-83ae-4e2a-a739-625a34555f2a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1549,12 +1549,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 65e0b8a16abd017a41872c01
+                    id: 65e1ad6aba4d12362a43559e
                     app_id: this_is_an_id116_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1709226145
-                    updated_at: 1709226145
+                    created_at: 1709288810
+                    updated_at: 1709288810
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1591,7 +1591,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ded39abc-f077-4c5c-8798-a3c4dd49769d
+                    request_id: 56077cc6-329b-4f4d-b155-3394867f263f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1689,12 +1689,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0b8a26abd017a41872c09
+                      id: 65e1ad6bba4d12362a4355a6
                       app_id: this_is_an_id122_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709226146
-                      created_at: 1709226147
-                      updated_at: 1709226147
+                      remote_created_at: 1709288811
+                      created_at: 1709288811
+                      updated_at: 1709288811
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -1723,7 +1723,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 44d08c01-c659-4622-b299-44e10f2424a0
+                    request_id: 8e7ccb89-2490-4dd5-9bed-37a325e93738
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1737,7 +1737,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ff971486-05a8-4fd9-a6c1-104fe196fac1
+                    request_id: 941eca73-043e-4347-bd46-6d092a3dd40c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1772,12 +1772,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0b8a56abd017a41872c14
+                    id: 65e1ad6fba4d12362a4355b1
                     app_id: this_is_an_id128_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1709226149
-                    created_at: 1709226149
-                    updated_at: 1709226149
+                    remote_created_at: 1709288815
+                    created_at: 1709288815
+                    updated_at: 1709288815
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1799,7 +1799,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 8d0fcbed-e818-49fd-a307-dc5660756b18
+                    request_id: b694ae10-2fcf-4525-96d0-69e8bf0a8f4f
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1813,7 +1813,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bb0b9d85-8466-42ce-aa21-e2bab84d4611
+                    request_id: 84662c87-bb70-44cd-88e0-988705d32a6c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1847,12 +1847,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0b8a76abd017a41872c1e
+                    id: 65e1ad71ba4d12362a4355bb
                     app_id: this_is_an_id134_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1709226151
-                    created_at: 1709226151
-                    updated_at: 1709226151
+                    remote_created_at: 1709288817
+                    created_at: 1709288817
+                    updated_at: 1709288817
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1874,7 +1874,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: e0638d68-97bf-4f08-b566-cd23061842e7
+                    request_id: cc67ed4b-4934-4f42-a79e-c59f6bebffc5
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1888,7 +1888,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 29d773b6-7eef-44b6-a72b-f79a23887c68
+                    request_id: 963cc8a0-756a-43b6-8eb7-9f1ad27d829f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1920,7 +1920,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 65e0b8a96abd017a41872c28
+                    id: 65e1ad73ba4d12362a4355c5
                     object: company
                     deleted: true
               schema:
@@ -1933,7 +1933,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 78323694-4149-4430-a20b-1f4221e9e877
+                    request_id: 846d7e2e-4e53-4730-873d-5f1875545632
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1947,7 +1947,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1dffe583-98a9-4e4b-a6cd-7cdae232060d
+                    request_id: 278f2b1d-a300-4378-9079-77aeed6c2cb1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1999,7 +1999,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 52fac023-343e-447e-a18d-4c2203c4a5a7
+                    request_id: 130678f5-13b3-4b7c-be68-760b6ec27303
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2013,7 +2013,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 062cec56-c691-4ea8-bfbd-c6ca3a2cc1f2
+                    request_id: a8469dea-2b2c-46e0-b74c-b3c345876336
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2058,7 +2058,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 44c7d051-97b1-4d88-93ab-a6d565ff90b7
+                    request_id: 25276285-db1f-4782-9e63-7611f58b2486
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2072,7 +2072,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9bf2828e-f0e0-4bf0-b544-62cc20298c0b
+                    request_id: ad8e5c3f-c2cd-4772-b037-05e61a17a901
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2129,12 +2129,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0b8af6abd017a41872c44
+                      id: 65e1ad7aba4d12362a4355e1
                       app_id: this_is_an_id158_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709226159
-                      created_at: 1709226159
-                      updated_at: 1709226159
+                      remote_created_at: 1709288826
+                      created_at: 1709288826
+                      updated_at: 1709288826
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2163,7 +2163,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e4c89cb6-6486-4130-b606-f116ddcfca0b
+                    request_id: a89f806e-0165-4414-a18c-49bd68b17d53
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2215,12 +2215,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0b8b06abd017a41872c4a
+                      id: 65e1ad7bba4d12362a4355e7
                       app_id: this_is_an_id162_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709226160
-                      created_at: 1709226160
-                      updated_at: 1709226160
+                      remote_created_at: 1709288827
+                      created_at: 1709288827
+                      updated_at: 1709288827
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2234,7 +2234,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: dc6df880-a654-40b6-9802-fdceafe05ecb
+                    scroll_param: ad4c5245-c07b-4f9f-96d5-6d4ffb6c21ed
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2245,7 +2245,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 14571e78-486c-4c9f-afa4-d2acd685b9ad
+                    request_id: aa8ca319-effb-4e25-9006-947c1768217a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2280,12 +2280,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0b8b26abd017a41872c53
+                    id: 65e1ad7dba4d12362a4355f0
                     app_id: this_is_an_id166_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1709226162
-                    created_at: 1709226162
-                    updated_at: 1709226162
+                    remote_created_at: 1709288829
+                    created_at: 1709288829
+                    updated_at: 1709288829
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2307,7 +2307,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 77d7f1c9-b3ad-4cc7-bfb2-dd033b509b54
+                    request_id: ec8c3dbd-02c9-4144-b5fd-7b16eb00291d
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2321,7 +2321,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 962b58af-096f-4b7b-b22c-ae7199218f52
+                    request_id: dc4bcc3f-35f7-412e-828b-cd680813af28
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2335,7 +2335,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b30bd0bf-545d-492a-a9f9-fd2784ce1db1
+                    request_id: 03fcb8e4-7239-4d13-ac13-b599a508ab6d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2358,7 +2358,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 65e0b8b26abd017a41872c53
+                  id: 65e1ad7dba4d12362a4355f0
               bad_request:
                 summary: Bad Request
                 value:
@@ -2397,13 +2397,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 65e0b8b86abd017a41872c74
+                      id: 65e1ad83ba4d12362a435611
                       app_id: this_is_an_id182_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1709226168
-                      created_at: 1709226168
-                      updated_at: 1709226168
-                      last_request_at: 1709053368
+                      remote_created_at: 1709288835
+                      created_at: 1709288835
+                      updated_at: 1709288835
+                      last_request_at: 1709116035
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2432,7 +2432,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 7a5d09b1-cf65-4d80-ade4-f7183c5be352
+                    request_id: 9f5206be-cad1-4ee8-a58b-9bade7a8fd95
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2446,7 +2446,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 28a8e759-f4ad-4bb2-8df6-c87637928b85
+                    request_id: 4d6338a7-a88e-4201-acc7-ab9820753d7e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2489,12 +2489,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0b8b56abd017a41872c63
+                    id: 65e1ad80ba4d12362a435600
                     app_id: this_is_an_id174_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1709226165
-                    created_at: 1709226165
-                    updated_at: 1709226165
+                    remote_created_at: 1709288832
+                    created_at: 1709288832
+                    updated_at: 1709288832
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2516,14 +2516,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 7f1bd915-baed-47bb-895b-2a53a22c0459
+                    request_id: 9865a0fe-44a8-43f8-93d2-4e98d9b62075
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: f6b14bd1-c1a3-4bfa-886e-f70810bb3cce
+                    request_id: dd1bdccb-adde-4628-9474-5d37a849c256
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2537,7 +2537,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ea1871bb-cf51-47ab-968c-c624a4bd4ccc
+                    request_id: 1d5c16a6-8b19-4c0a-a295-029e1ed20e73
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2573,42 +2573,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '16'
-                      created_at: 1708621371
+                      id: '78'
+                      created_at: 1708684037
                       contact:
                         type: contact
-                        id: 65e0b8bb6abd017a41872c7f
+                        id: 65e1ad85ba4d12362a43561c
                       author:
                         type: admin
-                        id: '991266838'
+                        id: '991269200'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '15'
-                      created_at: 1708534971
+                      id: '77'
+                      created_at: 1708597637
                       contact:
                         type: contact
-                        id: 65e0b8bb6abd017a41872c7f
+                        id: 65e1ad85ba4d12362a43561c
                       author:
                         type: admin
-                        id: '991266838'
+                        id: '991269200'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '14'
-                      created_at: 1708534971
+                      id: '76'
+                      created_at: 1708597637
                       contact:
                         type: contact
-                        id: 65e0b8bb6abd017a41872c7f
+                        id: 65e1ad85ba4d12362a43561c
                       author:
                         type: admin
-                        id: '991266838'
+                        id: '991269200'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
@@ -2631,7 +2631,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 3a9e03e5-6211-4ea4-9f49-4c448a776ad5
+                    request_id: ebb5fffb-5765-4175-aedb-065890a85736
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2665,14 +2665,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '21'
-                    created_at: 1709226172
+                    id: '83'
+                    created_at: 1709288838
                     contact:
                       type: contact
-                      id: 65e0b8bc6abd017a41872c81
+                      id: 65e1ad86ba4d12362a43561e
                     author:
                       type: admin
-                      id: '991266840'
+                      id: '991269202'
                       name: Ciaran112 Lee
                       email: admin112@email.com
                       away_mode_enabled: false
@@ -2688,14 +2688,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: dc8f3b96-dac0-4a4b-9f9a-cf09500cddd5
+                    request_id: 58617f54-f906-4594-ab8e-97df9b14f8ce
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 1422f5e5-00a9-4519-86f8-9a97f8fda02b
+                    request_id: cfbeb4eb-ade1-4ac3-9153-bd2b0b3c2fb7
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2725,20 +2725,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 65e0b8bc6abd017a41872c81
-                  admin_id: 991266840
+                  contact_id: 65e1ad86ba4d12362a43561e
+                  admin_id: 991269202
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 65e0b8bc6abd017a41872c82
+                  contact_id: 65e1ad87ba4d12362a43561f
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991266842
+                  admin_id: 991269204
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -2771,10 +2771,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 65e0b8be6abd017a41872c84
+                      id: 65e1ad88ba4d12362a435621
                       name: segment
-                      created_at: 1709226174
-                      updated_at: 1709226174
+                      created_at: 1709288840
+                      updated_at: 1709288840
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -2786,7 +2786,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 8241e13a-b35c-415e-8cd3-fe85bb285d06
+                    request_id: 8524799c-7fdf-4403-b9fb-f503a506a86b
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2800,7 +2800,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 61c68777-33f6-4793-a4a1-e8d570be260e
+                    request_id: c54749ae-5f50-46c3-9f00-8e6ca2a3f1b8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2844,7 +2844,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '47'
+                      id: '275'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -2858,7 +2858,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '49'
+                      id: '277'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -2881,7 +2881,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 173b92e9-efe8-472b-af49-2e96905e04fa
+                    request_id: 4b5c2c0b-7306-4203-99b2-5e156a50630d
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2895,7 +2895,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 04d8df52-c7f4-4596-9b6a-1d2ab84e8362
+                    request_id: f9252c52-7ada-4a68-b88c-bda51226d780
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2936,7 +2936,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '62'
+                    id: '290'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -2959,14 +2959,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: a6a77aec-b6e3-4bc6-bd86-3150a361dd0a
+                    request_id: '08328cb0-6a04-487f-b7a2-5b8201396dba'
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: daec5e97-1c1d-4847-b967-c6981469dc9a
+                    request_id: de9e485f-923e-4870-8491-a116dbc9753d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -2980,7 +2980,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a9110314-d486-441b-a3ac-756c25db5b53
+                    request_id: ed31e7e4-172e-4b48-944a-3118431584de
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3008,12 +3008,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 62
+                  id: 290
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 66
+                  id: 294
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -3059,7 +3059,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '78'
+                    id: '306'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3082,14 +3082,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: d3cd4511-a4e4-4a7f-a6d4-591219bf8f6e
+                    request_id: f0e2b834-a343-4440-9f6f-6f41c45e1551
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 4ce107fb-0a5a-4bb3-a3b7-b529113ae092
+                    request_id: d3481b3d-ff07-401f-8d97-5078c43dcb7e
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3103,7 +3103,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '085213f2-1260-4e52-8a32-817f69945a4c'
+                    request_id: 7c28379e-9f80-4be6-b171-d92fe726ccd7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3141,7 +3141,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '42'
+                      id: '230'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -3153,7 +3153,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 9f8aa4a7-7f78-4df9-90a1-4bfe5d9281f1
+                    request_id: 1619cd2e-d5d6-4360-ab5f-790c7158127a
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3167,7 +3167,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4ded729d-90c1-4b66-922d-a9d4a10a0506
+                    request_id: 2bedd490-2a07-4026-aaa3-cc134ee68e7f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3202,7 +3202,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '43'
+                    id: '231'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3214,14 +3214,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 9804cea9-11a4-4dda-be52-ad836030451b
+                    request_id: 70154f2b-ab88-427d-b8f9-d75c6b69fa2e
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 3a1ec603-067c-46cb-88be-cc96d088484f
+                    request_id: a91387b7-b030-4edd-b245-3f1c094b0345
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3235,7 +3235,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ffa57641-599d-4c36-8170-fd5e9d1a8cb0
+                    request_id: 2d10215f-5950-45f5-91e4-97979fd7ff47
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3258,11 +3258,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 43
+                  id: 231
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 44
+                  id: 232
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3304,7 +3304,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '46'
+                    id: '234'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3316,14 +3316,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: b5c019e1-a11f-440e-a1e8-323fcee4e995
+                    request_id: 41d3d685-d3ba-4bef-b750-b9d502bebafb
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 209ca976-87f9-43cb-a339-bc80bcf48cd4
+                    request_id: 39acdcd2-8330-4a21-9d67-8216ef66cac1
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3337,7 +3337,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7c9e3b1d-5c52-4781-8154-63f49a08c6b5
+                    request_id: c55496c2-555f-47bc-bb40-722d9a782884
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3371,7 +3371,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0b8cb6abd017a41872c9b
+                    id: 65e1ad98ba4d12362a435638
                     workspace_id: this_is_an_id248_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3386,9 +3386,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226187
-                    updated_at: 1709226188
-                    signed_up_at: 1709226187
+                    created_at: 1709288856
+                    updated_at: 1709288856
+                    signed_up_at: 1709288856
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3422,31 +3422,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8cb6abd017a41872c9b/tags"
+                      url: "/contacts/65e1ad98ba4d12362a435638/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8cb6abd017a41872c9b/notes"
+                      url: "/contacts/65e1ad98ba4d12362a435638/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8cb6abd017a41872c9b/companies"
+                      url: "/contacts/65e1ad98ba4d12362a435638/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8cb6abd017a41872c9b/subscriptions"
+                      url: "/contacts/65e1ad98ba4d12362a435638/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8cb6abd017a41872c9b/subscriptions"
+                      url: "/contacts/65e1ad98ba4d12362a435638/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3465,7 +3465,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 25e1b4f9-616f-49b1-ae3d-a5b377d1a050
+                    request_id: 7f508d14-2566-4e82-9f98-8c518439d9d2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3510,7 +3510,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0b8cd6abd017a41872c9c
+                    id: 65e1ad99ba4d12362a435639
                     workspace_id: this_is_an_id252_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3525,9 +3525,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226189
-                    updated_at: 1709226189
-                    signed_up_at: 1709226189
+                    created_at: 1709288857
+                    updated_at: 1709288857
+                    signed_up_at: 1709288857
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3561,31 +3561,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8cd6abd017a41872c9c/tags"
+                      url: "/contacts/65e1ad99ba4d12362a435639/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8cd6abd017a41872c9c/notes"
+                      url: "/contacts/65e1ad99ba4d12362a435639/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8cd6abd017a41872c9c/companies"
+                      url: "/contacts/65e1ad99ba4d12362a435639/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8cd6abd017a41872c9c/subscriptions"
+                      url: "/contacts/65e1ad99ba4d12362a435639/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8cd6abd017a41872c9c/subscriptions"
+                      url: "/contacts/65e1ad99ba4d12362a435639/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3604,7 +3604,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 65ab87dc-222d-47c6-8de5-f0a0cd3b7db6
+                    request_id: 33c525a6-1a71-45d7-bcc2-7851b726c7fe
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3635,7 +3635,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0b8ce6abd017a41872c9d
+                    id: 65e1ad9aba4d12362a43563a
                     object: contact
                     deleted: true
               schema:
@@ -3648,7 +3648,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e7ef040c-d4b4-4022-8874-f8320bef6c66
+                    request_id: c0750623-1580-45b8-85a1-e734c0418461
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3676,7 +3676,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0b8d06abd017a41872c9f
+                    id: 65e1ad9cba4d12362a43563c
                     workspace_id: this_is_an_id260_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3691,9 +3691,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226192
-                    updated_at: 1709226192
-                    signed_up_at: 1709226192
+                    created_at: 1709288860
+                    updated_at: 1709288860
+                    signed_up_at: 1709288860
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3727,31 +3727,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8d06abd017a41872c9f/tags"
+                      url: "/contacts/65e1ad9cba4d12362a43563c/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8d06abd017a41872c9f/notes"
+                      url: "/contacts/65e1ad9cba4d12362a43563c/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8d06abd017a41872c9f/companies"
+                      url: "/contacts/65e1ad9cba4d12362a43563c/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8d06abd017a41872c9f/subscriptions"
+                      url: "/contacts/65e1ad9cba4d12362a43563c/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8d06abd017a41872c9f/subscriptions"
+                      url: "/contacts/65e1ad9cba4d12362a43563c/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3770,7 +3770,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: be98d8c4-908e-4ecc-bb96-5db612851ed6
+                    request_id: 443a53f7-8025-4cea-b279-5f051eadd24c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3785,8 +3785,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 65e0b8d06abd017a41872c9e
-                  into: 65e0b8d06abd017a41872c9f
+                  from: 65e1ad9cba4d12362a43563b
+                  into: 65e1ad9cba4d12362a43563c
   "/contacts/search":
     post:
       summary: Search contacts
@@ -3915,7 +3915,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b47daedb-d48e-49a6-a349-2501ad713503
+                    request_id: bb979922-6c16-466e-b0e4-1f174f5486f5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3935,15 +3935,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: 65e0b8d16abd017a41872ca2
+                      value: 65e1ad9eba4d12362a43563f
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: 65e0b8d16abd017a41872ca2
+                        value: 65e1ad9eba4d12362a43563f
                       - field: id
                         operator: "="
-                        value: 65e0b8d16abd017a41872ca2
+                        value: 65e1ad9eba4d12362a43563f
   "/contacts":
     get:
       summary: List all contacts
@@ -3982,7 +3982,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: acf847a7-1842-4b7a-ac76-1d5c97d5f54d
+                    request_id: 41ae47a6-8294-44a1-ab50-64e9d7f31f33
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4008,7 +4008,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0b8d46abd017a41872ca4
+                    id: 65e1ada0ba4d12362a435641
                     workspace_id: this_is_an_id272_that_should_be_at_least_
                     external_id:
                     role: user
@@ -4023,8 +4023,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226196
-                    updated_at: 1709226196
+                    created_at: 1709288865
+                    updated_at: 1709288865
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -4059,31 +4059,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8d46abd017a41872ca4/tags"
+                      url: "/contacts/65e1ada0ba4d12362a435641/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8d46abd017a41872ca4/notes"
+                      url: "/contacts/65e1ada0ba4d12362a435641/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8d46abd017a41872ca4/companies"
+                      url: "/contacts/65e1ada0ba4d12362a435641/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8d46abd017a41872ca4/subscriptions"
+                      url: "/contacts/65e1ada0ba4d12362a435641/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0b8d46abd017a41872ca4/subscriptions"
+                      url: "/contacts/65e1ada0ba4d12362a435641/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4102,7 +4102,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 469177ba-74f8-41b3-a8e6-676628bacc0f
+                    request_id: 50034b42-35e8-438b-8e82-8d2ddce95b82
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4146,7 +4146,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0b8d56abd017a41872ca5
+                    id: 65e1ada1ba4d12362a435642
                     object: contact
                     archived: true
               schema:
@@ -4178,7 +4178,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0b8d66abd017a41872ca6
+                    id: 65e1ada2ba4d12362a435643
                     object: contact
                     archived: false
               schema:
@@ -4213,7 +4213,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '48'
+                    id: '236'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4225,7 +4225,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 0fea79ad-83e2-4591-a5d0-cbdfcab9dcd3
+                    request_id: b806a184-063a-4e35-862d-accf44ac62ce
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4239,7 +4239,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b4bfb28b-dae2-4d0b-b05b-5dffa3c7b0b7
+                    request_id: 62bdeee4-19c3-4a64-824c-258e465fcaf8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4268,13 +4268,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 48
-                  admin_id: 991266873
+                  id: 236
+                  admin_id: 991269235
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 49
-                  admin_id: 991266875
+                  id: 237
+                  admin_id: 991269237
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4312,7 +4312,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '51'
+                    id: '239'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4324,14 +4324,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 5d3ea137-1ed5-4d0e-b0fe-8bee92b62064
+                    request_id: c2a05557-af1e-45f6-968e-8e0d0158c6a7
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 2677d587-d63a-4d93-9da3-ef8a281e6559
+                    request_id: 83c0cd5e-1ce3-418a-aeb4-adc82ffc4d42
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4345,7 +4345,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b89d338c-433f-4647-9778-7c7a0bfcad29
+                    request_id: 6cb5c448-03e5-4055-ae22-2363c30b7c61
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4368,15 +4368,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991266877
+                  admin_id: 991269239
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991266879
+                  admin_id: 991269241
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991266880
+                  admin_id: 991269242
   "/conversations":
     get:
       summary: List all conversations
@@ -4423,20 +4423,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '143'
-                      created_at: 1709226206
-                      updated_at: 1709226206
+                      id: '741'
+                      created_at: 1709288877
+                      updated_at: 1709288877
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918147'
+                        id: '403918494'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991266883'
+                          id: '991269245'
                           name: Ciaran152 Lee
                           email: admin152@email.com
                         attachments: []
@@ -4446,7 +4446,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0b8de6abd017a41872caa
+                          id: 65e1adadba4d12362a435647
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -4474,7 +4474,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2c216155-73ba-43e6-b3b3-f517499bdafb
+                    request_id: cf8d65ea-fd44-4a8a-8c23-f3483b10d68b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4488,7 +4488,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 8fbbb6b3-a26f-4291-bc8d-c1560a995373
+                    request_id: a3b188e5-d9e4-4a8c-997f-a4505dd955d2
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4524,11 +4524,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918157'
-                    created_at: 1709226231
+                    id: '403918504'
+                    created_at: 1709288916
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '168'
+                    conversation_id: '766'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -4539,7 +4539,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 7f6db282-ed54-4567-9294-2972487c5c3e
+                    request_id: 79fd5938-9dc3-4696-a9d0-e55ac5fbb6a7
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -4553,7 +4553,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e73b370f-8936-44d1-8b97-bde858c4f0be
+                    request_id: d61091a8-3f81-4c90-9a67-2c61d9e80670
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4567,7 +4567,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: c7551313-6972-47bc-9405-1d27c657c045
+                    request_id: 7370ffe8-b42a-411f-a2aa-622f766998a2
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4584,7 +4584,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65e0b8f66abd017a41872cbf
+                    id: 65e1add2ba4d12362a43565c
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -4642,20 +4642,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '172'
-                    created_at: 1709226237
-                    updated_at: 1709226237
+                    id: '770'
+                    created_at: 1709288924
+                    updated_at: 1709288924
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918161'
+                      id: '403918508'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266897'
+                        id: '991269259'
                         name: Ciaran159 Lee
                         email: admin159@email.com
                       attachments: []
@@ -4665,7 +4665,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b8fd6abd017a41872cc3
+                        id: 65e1addcba4d12362a435660
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4697,7 +4697,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 8fe833ff-6391-40d7-ad8b-6f02746872ed
+                    request_id: 28df1f00-bf56-4e93-a880-9b45ad0c0daa
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4711,7 +4711,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: da5033a3-915d-43cf-bfc6-d798ea9e33b8
+                    request_id: 9015c6bc-7af2-4df7-afa5-38be8b8f83a5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4725,7 +4725,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 45dda5eb-de62-412a-b965-3b5b4f87113d
+                    request_id: 5a0ace2b-964d-4710-a515-05fcdee485a0
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4772,20 +4772,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '176'
-                    created_at: 1709226243
-                    updated_at: 1709226245
+                    id: '774'
+                    created_at: 1709288933
+                    updated_at: 1709288936
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918165'
+                      id: '403918512'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266905'
+                        id: '991269267'
                         name: Ciaran163 Lee
                         email: admin163@email.com
                       attachments: []
@@ -4795,7 +4795,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b9036abd017a41872cc7
+                        id: 65e1ade5ba4d12362a435664
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4819,15 +4819,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '30'
+                        id: '191'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709226245
-                        updated_at: 1709226245
-                        notified_at: 1709226245
+                        created_at: 1709288936
+                        updated_at: 1709288936
+                        notified_at: 1709288936
                         assigned_to:
                         author:
-                          id: '991266906'
+                          id: '991269268'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4835,15 +4835,15 @@ paths:
                         external_id:
                         redacted: false
                       - type: conversation_part
-                        id: '31'
+                        id: '192'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709226245
-                        updated_at: 1709226245
-                        notified_at: 1709226245
+                        created_at: 1709288936
+                        updated_at: 1709288936
+                        notified_at: 1709288936
                         assigned_to:
                         author:
-                          id: '991266906'
+                          id: '991269268'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4861,7 +4861,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: c852a0a6-6556-435c-8016-6f0424f3df20
+                    request_id: 0c2675c3-2fec-4a91-8456-fa1bc2340dbd
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4875,7 +4875,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2b4ba49e-f0e4-4fa3-a1c2-b83f9f67b40a
+                    request_id: 06e0a165-5e0d-4d96-8d6d-8a524e86f584
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4889,7 +4889,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 81fce3a7-9d06-47be-871c-2abb0e1710d1
+                    request_id: 54e10a8e-92b0-4be4-8e8f-fbc18e228dc5
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4944,57 +4944,57 @@ paths:
 
         Most keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `"foorbar"`).
 
-        | Field                                     | Type                                                                                     |
-        | :---------------------------------------- | :--------------------------------------------------------------------------------------- |
-        | id                                        | String                                                                                   |
-        | created_at                                | Date (UNIX timestamp)                                                                    |
-        | updated_at                                | Date (UNIX timestamp)                                                                    |
-        | source.type                               | String<br>Accepted fields are `conversation`, `push`, `facebook`, `twitter` and `email`. |
-        | source.id                                 | String                                                                                   |
-        | source.delivered_as                       | String                                                                                   |
-        | source.subject                            | String                                                                                   |
-        | source.body                               | String                                                                                   |
-        | source.author.id                          | String                                                                                   |
-        | source.author.type                        | String                                                                                   |
-        | source.author.name                        | String                                                                                   |
-        | source.author.email                       | String                                                                                   |
-        | source.url                                | String                                                                                   |
-        | contact_ids                               | String                                                                                   |
-        | teammate_ids                              | String                                                                                   |
-        | admin_assignee_id                         | String                                                                                   |
-        | team_assignee_id                          | String                                                                                   |
-        | channel_initiated                         | String                                                                                   |
-        | open                                      | Boolean                                                                                  |
-        | read                                      | Boolean                                                                                  |
-        | state                                     | String                                                                                   |
-        | waiting_since                             | Date (UNIX timestamp)                                                                    |
-        | snoozed_until                             | Date (UNIX timestamp)                                                                    |
-        | tag_ids                                   | String                                                                                   |
-        | priority                                  | String                                                                                   |
-        | statistics.time_to_assignment             | Integer                                                                                  |
-        | statistics.time_to_admin_reply            | Integer                                                                                  |
-        | statistics.time_to_first_close            | Integer                                                                                  |
-        | statistics.time_to_last_close             | Integer                                                                                  |
-        | statistics.median_time_to_reply           | Integer                                                                                  |
-        | statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                    |
-        | statistics.first_assignment_at            | Date (UNIX timestamp)                                                                    |
-        | statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                    |
-        | statistics.first_close_at                 | Date (UNIX timestamp)                                                                    |
-        | statistics.last_assignment_at             | Date (UNIX timestamp)                                                                    |
-        | statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                    |
-        | statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                    |
-        | statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                    |
-        | statistics.last_close_at                  | Date (UNIX timestamp)                                                                    |
-        | statistics.last_closed_by_id              | String                                                                                   |
-        | statistics.count_reopens                  | Integer                                                                                  |
-        | statistics.count_assignments              | Integer                                                                                  |
-        | statistics.count_conversation_parts       | Integer                                                                                  |
-        | conversation_rating.requested_at          | Date (UNIX timestamp)                                                                    |
-        | conversation_rating.replied_at            | Date (UNIX timestamp)                                                                    |
-        | conversation_rating.score                 | Integer                                                                                  |
-        | conversation_rating.remark                | String                                                                                   |
-        | conversation_rating.contact_id            | String                                                                                   |
-        | conversation_rating.admin_d               | String                                                                                   |
+        | Field                                     | Type                                                                                                                                                   |
+        | :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
+        | id                                        | String                                                                                                                                                 |
+        | created_at                                | Date (UNIX timestamp)                                                                                                                                  |
+        | updated_at                                | Date (UNIX timestamp)                                                                                                                                  |
+        | source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |
+        | source.id                                 | String                                                                                                                                                 |
+        | source.delivered_as                       | String                                                                                                                                                 |
+        | source.subject                            | String                                                                                                                                                 |
+        | source.body                               | String                                                                                                                                                 |
+        | source.author.id                          | String                                                                                                                                                 |
+        | source.author.type                        | String                                                                                                                                                 |
+        | source.author.name                        | String                                                                                                                                                 |
+        | source.author.email                       | String                                                                                                                                                 |
+        | source.url                                | String                                                                                                                                                 |
+        | contact_ids                               | String                                                                                                                                                 |
+        | teammate_ids                              | String                                                                                                                                                 |
+        | admin_assignee_id                         | String                                                                                                                                                 |
+        | team_assignee_id                          | String                                                                                                                                                 |
+        | channel_initiated                         | String                                                                                                                                                 |
+        | open                                      | Boolean                                                                                                                                                |
+        | read                                      | Boolean                                                                                                                                                |
+        | state                                     | String                                                                                                                                                 |
+        | waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |
+        | snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |
+        | tag_ids                                   | String                                                                                                                                                 |
+        | priority                                  | String                                                                                                                                                 |
+        | statistics.time_to_assignment             | Integer                                                                                                                                                |
+        | statistics.time_to_admin_reply            | Integer                                                                                                                                                |
+        | statistics.time_to_first_close            | Integer                                                                                                                                                |
+        | statistics.time_to_last_close             | Integer                                                                                                                                                |
+        | statistics.median_time_to_reply           | Integer                                                                                                                                                |
+        | statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_closed_by_id              | String                                                                                                                                                 |
+        | statistics.count_reopens                  | Integer                                                                                                                                                |
+        | statistics.count_assignments              | Integer                                                                                                                                                |
+        | statistics.count_conversation_parts       | Integer                                                                                                                                                |
+        | conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |
+        | conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | conversation_rating.score                 | Integer                                                                                                                                                |
+        | conversation_rating.remark                | String                                                                                                                                                 |
+        | conversation_rating.contact_id            | String                                                                                                                                                 |
+        | conversation_rating.admin_d               | String                                                                                                                                                 |
 
         ### Accepted Operators
 
@@ -5029,20 +5029,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '183'
-                      created_at: 1709226254
-                      updated_at: 1709226254
+                      id: '781'
+                      created_at: 1709288952
+                      updated_at: 1709288952
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918172'
+                        id: '403918519'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991266935'
+                          id: '991269297'
                           name: Ciaran186 Lee
                           email: admin186@email.com
                         attachments: []
@@ -5052,7 +5052,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0b90e6abd017a41872cce
+                          id: 65e1adf8ba4d12362a43566b
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -5086,15 +5086,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '183'
+                      value: '781'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '183'
+                        value: '781'
                       - field: id
                         operator: "="
-                        value: '183'
+                        value: '781'
   "/conversations/{id}/reply":
     post:
       summary: Reply to a conversation
@@ -5125,20 +5125,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '191'
-                    created_at: 1709226261
-                    updated_at: 1709226262
-                    waiting_since: 1709226262
+                    id: '789'
+                    created_at: 1709288965
+                    updated_at: 1709288966
+                    waiting_since: 1709288966
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918175'
+                      id: '403918522'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266937'
+                        id: '991269299'
                         name: Ciaran187 Lee
                         email: admin187@email.com
                       attachments: []
@@ -5148,9 +5148,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b9156abd017a41872cd5
+                        id: 65e1ae05ba4d12362a435672
                     first_contact_reply:
-                      created_at: 1709226262
+                      created_at: 1709288966
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5173,15 +5173,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '33'
+                        id: '194'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709226262
-                        updated_at: 1709226262
-                        notified_at: 1709226262
+                        created_at: 1709288966
+                        updated_at: 1709288966
+                        notified_at: 1709288966
                         assigned_to:
                         author:
-                          id: 65e0b9156abd017a41872cd5
+                          id: 65e1ae05ba4d12362a435672
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5192,20 +5192,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '192'
-                    created_at: 1709226264
-                    updated_at: 1709226265
+                    id: '790'
+                    created_at: 1709288968
+                    updated_at: 1709288969
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918176'
+                      id: '403918523'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266939'
+                        id: '991269301'
                         name: Ciaran188 Lee
                         email: admin188@email.com
                       attachments: []
@@ -5215,7 +5215,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b9186abd017a41872cd6
+                        id: 65e1ae07ba4d12362a435673
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5237,7 +5237,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '34'
+                        id: '195'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5252,12 +5252,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1709226265
-                        updated_at: 1709226265
-                        notified_at: 1709226265
+                        created_at: 1709288969
+                        updated_at: 1709288969
+                        notified_at: 1709288969
                         assigned_to:
                         author:
-                          id: '991266939'
+                          id: '991269301'
                           type: admin
                           name: Ciaran188 Lee
                           email: admin188@email.com
@@ -5268,20 +5268,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '194'
-                    created_at: 1709226267
-                    updated_at: 1709226268
-                    waiting_since: 1709226268
+                    id: '792'
+                    created_at: 1709288973
+                    updated_at: 1709288974
+                    waiting_since: 1709288974
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918178'
+                      id: '403918525'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266943'
+                        id: '991269305'
                         name: Ciaran190 Lee
                         email: admin190@email.com
                       attachments: []
@@ -5291,9 +5291,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b91b6abd017a41872cd8
+                        id: 65e1ae0cba4d12362a435675
                     first_contact_reply:
-                      created_at: 1709226268
+                      created_at: 1709288974
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5316,15 +5316,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '35'
+                        id: '196'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709226268
-                        updated_at: 1709226268
-                        notified_at: 1709226268
+                        created_at: 1709288974
+                        updated_at: 1709288974
+                        notified_at: 1709288974
                         assigned_to:
                         author:
-                          id: 65e0b91b6abd017a41872cd8
+                          id: 65e1ae0cba4d12362a435675
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5342,7 +5342,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: d61270b3-cba4-4737-81f3-5782ca80417b
+                    request_id: 98d4d4ac-e160-4318-b8fb-14cd90942a84
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5356,7 +5356,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 495b1fa0-1952-4c2a-8f06-6104577bba59
+                    request_id: c3d55012-86e2-4351-80dd-baa00310cf91
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5370,7 +5370,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 5c550a79-e53f-4342-bcc0-0791a2afb25f
+                    request_id: ba9c7e40-1cd5-41dd-a060-9318aaaf7b9a
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5387,14 +5387,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0b9156abd017a41872cd5
+                  intercom_user_id: 65e1ae05ba4d12362a435672
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991266939
+                  admin_id: 991269301
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -5404,14 +5404,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0b91b6abd017a41872cd8
+                  intercom_user_id: 65e1ae0cba4d12362a435675
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0b91d6abd017a41872cd9
+                  intercom_user_id: 65e1ae0fba4d12362a435676
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -5446,20 +5446,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '198'
-                    created_at: 1709226273
-                    updated_at: 1709226274
+                    id: '796'
+                    created_at: 1709288982
+                    updated_at: 1709288984
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918182'
+                      id: '403918529'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266951'
+                        id: '991269313'
                         name: Ciaran194 Lee
                         email: admin194@email.com
                       attachments: []
@@ -5469,7 +5469,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b9216abd017a41872cdc
+                        id: 65e1ae16ba4d12362a435679
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5491,15 +5491,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '36'
+                        id: '197'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1709226274
-                        updated_at: 1709226274
-                        notified_at: 1709226274
+                        created_at: 1709288984
+                        updated_at: 1709288984
+                        notified_at: 1709288984
                         assigned_to:
                         author:
-                          id: '991266951'
+                          id: '991269313'
                           type: admin
                           name: Ciaran194 Lee
                           email: admin194@email.com
@@ -5510,20 +5510,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '199'
-                    created_at: 1709226275
-                    updated_at: 1709226276
+                    id: '797'
+                    created_at: 1709288985
+                    updated_at: 1709288986
                     waiting_since:
-                    snoozed_until: 1709229876
+                    snoozed_until: 1709292586
                     source:
                       type: conversation
-                      id: '403918183'
+                      id: '403918530'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266953'
+                        id: '991269315'
                         name: Ciaran195 Lee
                         email: admin195@email.com
                       attachments: []
@@ -5533,7 +5533,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b9236abd017a41872cdd
+                        id: 65e1ae19ba4d12362a43567a
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5555,15 +5555,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '37'
+                        id: '198'
                         part_type: snoozed
                         body:
-                        created_at: 1709226276
-                        updated_at: 1709226276
-                        notified_at: 1709226276
+                        created_at: 1709288986
+                        updated_at: 1709288986
+                        notified_at: 1709288986
                         assigned_to:
                         author:
-                          id: '991266953'
+                          id: '991269315'
                           type: admin
                           name: Ciaran195 Lee
                           email: admin195@email.com
@@ -5574,20 +5574,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '204'
-                    created_at: 1709226275
-                    updated_at: 1709226284
+                    id: '802'
+                    created_at: 1709288985
+                    updated_at: 1709288998
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918184'
+                      id: '403918531'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266955'
+                        id: '991269317'
                         name: Ciaran196 Lee
                         email: admin196@email.com
                       attachments: []
@@ -5597,7 +5597,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b9286abd017a41872ce2
+                        id: 65e1ae20ba4d12362a43567f
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5619,15 +5619,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '39'
+                        id: '200'
                         part_type: open
                         body:
-                        created_at: 1709226284
-                        updated_at: 1709226284
-                        notified_at: 1709226284
+                        created_at: 1709288998
+                        updated_at: 1709288998
+                        notified_at: 1709288998
                         assigned_to:
                         author:
-                          id: '991266955'
+                          id: '991269317'
                           type: admin
                           name: Ciaran196 Lee
                           email: admin196@email.com
@@ -5638,20 +5638,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '208'
-                    created_at: 1709226285
-                    updated_at: 1709226285
+                    id: '806'
+                    created_at: 1709288999
+                    updated_at: 1709289001
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918187'
+                      id: '403918534'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266957'
+                        id: '991269319'
                         name: Ciaran197 Lee
                         email: admin197@email.com
                       attachments: []
@@ -5661,9 +5661,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b92c6abd017a41872ce5
+                        id: 65e1ae27ba4d12362a435682
                     first_contact_reply:
-                    admin_assignee_id: 991266957
+                    admin_assignee_id: 991269319
                     team_assignee_id:
                     open: true
                     state: open
@@ -5683,17 +5683,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '40'
+                        id: '201'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1709226285
-                        updated_at: 1709226285
-                        notified_at: 1709226285
+                        created_at: 1709289001
+                        updated_at: 1709289001
+                        notified_at: 1709289001
                         assigned_to:
                           type: admin
-                          id: '991266957'
+                          id: '991269319'
                         author:
-                          id: '991266957'
+                          id: '991269319'
                           type: admin
                           name: Ciaran197 Lee
                           email: admin197@email.com
@@ -5711,7 +5711,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: a473e093-f474-4e06-96e2-a01f29dcd994
+                    request_id: c9fd1970-6255-4f2a-b61a-dd6b9c9c563f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5725,7 +5725,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f6309020-62ca-47b0-b94b-ec0798102836
+                    request_id: 8f2b9bb7-cbd9-4e61-a212-111b1ba0a1a2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5739,7 +5739,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 7c6f7c2a-5c08-4bbb-b8c0-b438be2d37de
+                    request_id: b039fd7f-6f18-49b0-afab-f057c76eea39
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5760,32 +5760,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991266951
+                  admin_id: 991269313
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991266953
-                  snoozed_until: 1709229876
+                  admin_id: 991269315
+                  snoozed_until: 1709292586
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991266955
+                  admin_id: 991269317
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991266957
-                  assignee_id: 991266957
+                  admin_id: 991269319
+                  assignee_id: 991269319
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991266959
+                  admin_id: 991269321
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -5816,20 +5816,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '212'
-                    created_at: 1709226291
-                    updated_at: 1709226292
+                    id: '810'
+                    created_at: 1709289009
+                    updated_at: 1709289010
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918191'
+                      id: '403918538'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266965'
+                        id: '991269327'
                         name: Ciaran201 Lee
                         email: admin201@email.com
                       attachments: []
@@ -5839,7 +5839,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b9336abd017a41872ce9
+                        id: 65e1ae30ba4d12362a435686
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5861,17 +5861,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '41'
+                        id: '202'
                         part_type: default_assignment
                         body:
-                        created_at: 1709226292
-                        updated_at: 1709226292
-                        notified_at: 1709226292
+                        created_at: 1709289010
+                        updated_at: 1709289010
+                        notified_at: 1709289010
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991266966'
+                          id: '991269328'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id357_that_should_be_at_least_@intercom.io
@@ -5889,7 +5889,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: d5fdf34f-837a-478f-8d77-b27a2c597b3d
+                    request_id: 1a0e5965-9cf4-4000-9ba8-9b192c47c284
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5903,7 +5903,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e29f6fbf-5a65-4474-b641-18632f55b17b
+                    request_id: 2c608714-b9ae-4001-a77a-387b60a74d26
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5917,7 +5917,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: e16a0c18-0893-4c60-8dc8-df5298fbac16
+                    request_id: 7cbd3cb9-9610-41b3-8705-1deb266e5629
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5958,7 +5958,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65e0b9386abd017a41872ced
+                      id: 65e1ae39ba4d12362a43568a
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -5969,7 +5969,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 64eb1f4c-0f8f-46db-b1b4-3f08235decb9
+                    request_id: d75f395f-1af5-416b-be54-225359f8a004
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5983,7 +5983,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b0c6a702-ea2c-4758-86bd-ab0a7773d043
+                    request_id: 252de459-9205-48e6-a28d-bd6d8ff3b7bc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5997,7 +5997,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: fdefc589-3547-4302-ba2e-81b8369afd1a
+                    request_id: 0a7eebb8-7269-42a8-b705-1c4b24f521ee
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6012,15 +6012,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991266973
+                  admin_id: 991269335
                   customer:
-                    intercom_user_id: 65e0b9386abd017a41872ced
+                    intercom_user_id: 65e1ae39ba4d12362a43568a
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991266975
+                  admin_id: 991269337
                   customer:
-                    intercom_user_id: 65e0b93a6abd017a41872cee
+                    intercom_user_id: 65e1ae3cba4d12362a43568b
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -6063,7 +6063,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65e0b9446abd017a41872cf8
+                      id: 65e1ae4dba4d12362a435695
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6074,14 +6074,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 6b3e07c6-967d-4087-b75a-8ed176a4c577
+                    request_id: 7e8ac9f8-1a28-4dd4-bf42-fcbf634cbba5
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 9eba53af-c4d9-4e46-ab92-dbb289df033d
+                    request_id: 9cdf7e32-ef54-4110-8567-0b904ee536c2
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -6095,7 +6095,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: 21ffe7d8-659b-49c1-9b87-dc3354862f61
+                    request_id: 1ef03aed-8d21-43fb-80ee-56e5edc2170f
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -6109,7 +6109,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '08181616-b404-487e-8e64-38095fdc3a8e'
+                    request_id: 5c672a66-b315-40e7-b713-571d07ff1eef
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6123,7 +6123,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: e9b424d5-fd1e-4d87-8d05-9a0b422a2e9a
+                    request_id: 69c9c8c1-f4d7-4c5b-9ebc-08a99ed728be
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6138,27 +6138,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991266981
+                  admin_id: 991269343
                   customer:
-                    intercom_user_id: 65e0b93e6abd017a41872cf1
+                    intercom_user_id: 65e1ae42ba4d12362a43568e
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991266983
+                  admin_id: 991269345
                   customer:
-                    intercom_user_id: 65e0b9456abd017a41872cf9
+                    intercom_user_id: 65e1ae4eba4d12362a435696
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991266985
+                  admin_id: 991269347
                   customer:
-                    intercom_user_id: 65e0b94c6abd017a41872d00
+                    intercom_user_id: 65e1ae5bba4d12362a43569d
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991266987
+                  admin_id: 991269349
                   customer:
-                    intercom_user_id: 65e0b9546abd017a41872d07
+                    intercom_user_id: 65e1ae68ba4d12362a4356a4
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6186,20 +6186,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '268'
-                    created_at: 1709226346
-                    updated_at: 1709226347
-                    waiting_since: 1709226347
+                    id: '866'
+                    created_at: 1709289100
+                    updated_at: 1709289104
+                    waiting_since: 1709289102
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918217'
+                      id: '403918564'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991266993'
+                        id: '991269355'
                         name: Ciaran215 Lee
                         email: admin215@email.com
                       attachments: []
@@ -6209,9 +6209,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0b9696abd017a41872d1c
+                        id: 65e1ae8cba4d12362a4356b9
                     first_contact_reply:
-                      created_at: 1709226347
+                      created_at: 1709289102
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6234,15 +6234,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '49'
+                        id: '210'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1709226347
-                        updated_at: 1709226347
-                        notified_at: 1709226347
+                        created_at: 1709289102
+                        updated_at: 1709289103
+                        notified_at: 1709289102
                         assigned_to:
                         author:
-                          id: 65e0b9696abd017a41872d1c
+                          id: 65e1ae8cba4d12362a4356b9
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6260,7 +6260,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 0ad4d7ea-529d-4af6-8244-7ea864f86d46
+                    request_id: 652d3132-1483-4507-8447-0e1aefab391f
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -6274,7 +6274,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '066299f2-3dcb-4f21-99ac-313fcc8a6cca'
+                    request_id: 1f41108b-d283-4d23-a8f6-5c3e6a541255
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6290,8 +6290,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 268
-                  conversation_part_id: 49
+                  conversation_id: 866
+                  conversation_part_id: 210
               not_found:
                 summary: Not found
                 value:
@@ -6478,7 +6478,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 18
+                    - id: 83
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -6491,9 +6491,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991267018'
-                      created_at: 1709226358
-                      updated_at: 1709226358
+                      admin_id: '991269380'
+                      created_at: 1709289122
+                      updated_at: 1709289122
                       model: company
                     - type: data_attribute
                       name: id
@@ -6565,7 +6565,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2ecd21e6-6521-4f98-8c9f-2208c36864c9
+                    request_id: 14e36792-a88d-4dfe-8ff1-d5f9f4dc75b1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6590,7 +6590,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 21
+                    id: 86
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -6601,9 +6601,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991267020'
-                    created_at: 1709226359
-                    updated_at: 1709226359
+                    admin_id: '991269382'
+                    created_at: 1709289123
+                    updated_at: 1709289123
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6615,7 +6615,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: 99254deb-aaaa-4564-b484-c1548220c009
+                    request_id: 597a9345-68d7-42e1-ab2c-34028c50e317
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6623,7 +6623,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: f73a3fd9-8e7e-46f0-9a21-1db4dbcdaf45
+                    request_id: f4a47ba7-2ca4-48af-9e18-98531d90e2ae
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -6631,7 +6631,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: c2e32466-1d9b-4ee4-b22c-1cc5944ad710
+                    request_id: b585841e-dfd8-4e4e-93e0-512382d25b3a
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6639,14 +6639,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: 92162c89-7f6f-4f1f-a73d-08ed437d8ec5
+                    request_id: f8e08c62-58a4-4d70-bca4-15b1439772c3
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: 45c30926-6992-44dc-a9ac-aa8587996dd8
+                    request_id: a8b70be8-ebcd-4804-923b-b82269fc34fa
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -6661,7 +6661,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 456e5cd0-258a-4335-805b-c9600f12ac36
+                    request_id: 89f38cc9-4df1-4336-b7fb-680c67950060
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6740,7 +6740,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 28
+                    id: 93
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -6755,9 +6755,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991267027'
-                    created_at: 1709226363
-                    updated_at: 1709226363
+                    admin_id: '991269389'
+                    created_at: 1709289127
+                    updated_at: 1709289127
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6769,7 +6769,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: 4643ce69-c06e-450a-a793-0aaadc6b222b
+                    request_id: 215a9eb7-20b0-4f5d-826c-ea7d2308f3e2
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -6783,7 +6783,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: 576934f5-ca0e-49d5-8a06-496743cdf535
+                    request_id: e49e2414-969f-4d64-b04e-22e84316f45c
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -6797,7 +6797,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: 41fe90fb-8142-4da8-be0a-4980aca82e63
+                    request_id: 38ca2653-8e25-4a07-939c-ba1a6f13d84f
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -6812,7 +6812,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 83c65463-c613-44d1-9872-28a9ff7ebb13
+                    request_id: 22cbe677-2c4a-4861-ba7d-615890af1f26
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6917,7 +6917,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1873230a-803e-408e-99ec-baab7dd367c9
+                    request_id: 3bd74f06-e324-457f-b3ca-f3694e42631f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7004,7 +7004,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 65e0b9806abd017a41872d25
+                    intercom_user_id: 65e1aeabba4d12362a4356c2
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -7016,7 +7016,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 40ac4c78-2bfd-4ed6-aaf9-b2e9e2a1cd56
+                    request_id: 7a22c245-504b-46a7-8571-c1c1b509c0d0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7047,7 +7047,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 80620550-c19c-4a2c-a7e3-f20f54637c1b
+                    request_id: 933884e7-38b4-44c3-a906-2bbd240712fe
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7091,7 +7091,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: qiln6lj584rv9rud
+                    job_identifier: tj9bfdp48itf8cmn
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7106,8 +7106,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1709208371
-                  created_at_before: 1709226371
+                  created_at_after: 1709271134
+                  created_at_before: 1709289134
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -7141,7 +7141,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: 1cy7kj1by3rc2yez
+                    job_identifier: 8m37ep9xfdbbxsll
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7173,7 +7173,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: yl4vzza51zca6qv3
+                    job_identifier: rkan4d70n5gbxt4x
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -7234,30 +7234,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918222'
-                    created_at: 1709226373
+                    id: '403918569'
+                    created_at: 1709289136
                     body: heyy
                     message_type: inapp
-                    conversation_id: '273'
+                    conversation_id: '871'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918223'
-                    created_at: 1709226374
+                    id: '403918570'
+                    created_at: 1709289137
                     body: heyy
                     message_type: inapp
-                    conversation_id: '274'
+                    conversation_id: '872'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '10'
-                    created_at: 1709226376
+                    id: '30'
+                    created_at: 1709289139
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991267050'
+                      id: '991269412'
                       name: Ciaran265 Lee
                       email: admin265@email.com
                       away_mode_enabled: false
@@ -7272,14 +7272,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: 3a127c41-f539-436b-ab33-7c82ab894402
+                    request_id: b03ed819-7a90-48ef-afb6-6d2d2b9803bf
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: 709cd1fa-8ba7-4da7-980c-b8169039e298
+                    request_id: 0bd5a2e8-aff1-4fff-bd04-91e62988197f
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -7293,7 +7293,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: '0238e3cc-3dfe-454f-975b-fb9dec86f87e'
+                    request_id: 0e8c0c60-6bb4-48cc-a0f1-56a017d945b5
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -7307,7 +7307,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2678bb0e-fac4-4694-9608-2727a4cbee47
+                    request_id: 5bcb6168-ac4a-4f7e-b74f-5044d1516c80
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7321,7 +7321,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 8aac0609-1ee3-4b2c-b446-8f8cb872391b
+                    request_id: 9f58da4c-697e-4ddf-aa13-7b7c10253e64
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -7338,7 +7338,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65e0b9856abd017a41872d2a
+                    id: 65e1aeb0ba4d12362a4356c7
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -7346,7 +7346,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 65e0b9866abd017a41872d2b
+                    id: 65e1aeb1ba4d12362a4356c8
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -7354,10 +7354,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267050'
+                    id: '991269412'
                   to:
                     type: user
-                    id: 65e0b9876abd017a41872d2c
+                    id: 65e1aeb2ba4d12362a4356c9
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -7365,10 +7365,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267052'
+                    id: '991269414'
                   to:
                     type: user
-                    id: 65e0b9886abd017a41872d2d
+                    id: 65e1aeb3ba4d12362a4356ca
                   message_type: inapp
                   body:
                   subject: heyy
@@ -7377,7 +7377,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267053'
+                    id: '991269415'
                   to:
                     type: user
                     user_id: '70'
@@ -7388,10 +7388,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267054'
+                    id: '991269416'
                   to:
                     type: user
-                    id: 65e0b9f76abd017a41872d2f
+                    id: 65e1aeb4ba4d12362a4356cc
                   message_type: email
                   body:
                   subject: heyy
@@ -7422,12 +7422,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '16'
+                    - id: '72'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991267061
+                      sender_id: 991269423
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7437,15 +7437,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709226489
-                      updated_at: 1709226489
+                      created_at: 1709289143
+                      updated_at: 1709289143
                       newsfeed_assignments: []
-                    - id: '15'
+                    - id: '71'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991267059
+                      sender_id: 991269421
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7455,8 +7455,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709226488
-                      updated_at: 1709226488
+                      created_at: 1709289142
+                      updated_at: 1709289142
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -7469,7 +7469,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ea0e1fb6-93b3-4a62-a61c-2781211ecba2
+                    request_id: 22b1327f-390a-452f-aad5-8fe1d3f5c40f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7494,12 +7494,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '19'
+                    id: '75'
                     type: news-item
                     workspace_id: this_is_an_id483_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991267068
+                    sender_id: 991269430
                     state: live
                     labels:
                     - New
@@ -7510,10 +7510,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1709226490
-                    updated_at: 1709226490
+                    created_at: 1709289145
+                    updated_at: 1709289145
                     newsfeed_assignments:
-                    - newsfeed_id: 28
+                    - newsfeed_id: 128
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7525,7 +7525,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 82e10dfa-2675-483e-b819-dee80a61ffe5
+                    request_id: b0d443ef-9669-4334-a641-45c0429c9968
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7546,14 +7546,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991267068
+                  sender_id: 991269430
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 28
+                  - newsfeed_id: 128
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -7582,12 +7582,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '20'
+                    id: '76'
                     type: news-item
                     workspace_id: this_is_an_id487_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991267071
+                    sender_id: 991269433
                     state: live
                     labels: []
                     cover_image_url:
@@ -7597,11 +7597,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1709226491
-                    updated_at: 1709226491
+                    created_at: 1709289146
+                    updated_at: 1709289146
                     newsfeed_assignments:
-                    - newsfeed_id: 30
-                      published_at: 1709226492
+                    - newsfeed_id: 130
+                      published_at: 1709289146
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -7612,7 +7612,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: adff157f-be79-4900-a5d2-64da166d6641
+                    request_id: e99b4059-daa3-4f6f-850a-24b57621afbb
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7626,7 +7626,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 398cfc64-c254-43aa-bc6c-a9db118fbc51
+                    request_id: a251bac0-a937-432f-a970-91a6e1fccf7e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7657,12 +7657,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '23'
+                    id: '79'
                     type: news-item
                     workspace_id: this_is_an_id493_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991267079
+                    sender_id: 991269441
                     state: live
                     labels: []
                     cover_image_url:
@@ -7670,8 +7670,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1709226493
-                    updated_at: 1709226493
+                    created_at: 1709289148
+                    updated_at: 1709289148
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7683,7 +7683,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 3a721e08-ebc8-47ef-a897-47466aadf145
+                    request_id: 0ca85948-d68f-48a0-b4aa-a86aafc26fbb
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7697,7 +7697,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3475759f-ff43-4b18-bf43-3ce745fa6a21
+                    request_id: 680f245b-5b12-4f66-ad20-e4240e61db2e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7714,7 +7714,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991267079
+                  sender_id: 991269441
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7723,7 +7723,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991267082
+                  sender_id: 991269444
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7753,7 +7753,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '26'
+                    id: '82'
                     object: news-item
                     deleted: true
               schema:
@@ -7766,7 +7766,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 444fdc0c-2f90-497e-ba9e-2536bf87394f
+                    request_id: bfed0bd6-021a-40bb-b352-aaf051bb24d8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7780,7 +7780,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f8ac0486-3b2f-4da6-94c7-acc70708b3aa
+                    request_id: b06c615e-58ec-43ab-ae5e-24bc0e4ad8f2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7833,7 +7833,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e90cf8fc-71da-4820-93b4-9f6e3b931680
+                    request_id: 0500e6c2-6f7d-49f4-8174-fdf4be71da73
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7866,16 +7866,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '43'
+                    - id: '143'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709226498
-                      updated_at: 1709226498
-                    - id: '44'
+                      created_at: 1709289153
+                      updated_at: 1709289153
+                    - id: '144'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709226498
-                      updated_at: 1709226498
+                      created_at: 1709289153
+                      updated_at: 1709289153
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -7887,7 +7887,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e9c6ab6d-fd26-433c-aea0-9f5c1fb4e245
+                    request_id: 48b1658c-c93b-4407-8f69-093d65ea9e0a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7921,11 +7921,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '47'
+                    id: '147'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1709226499
-                    updated_at: 1709226499
+                    created_at: 1709289155
+                    updated_at: 1709289155
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -7936,7 +7936,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 55fcbb91-01de-46c8-8287-16c1869f49cc
+                    request_id: b72a1824-b039-4b22-8e5a-0aaa4ee9f977
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7970,14 +7970,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '24'
-                    created_at: 1708535300
+                    id: '86'
+                    created_at: 1708597955
                     contact:
                       type: contact
-                      id: 65e0ba046abd017a41872d32
+                      id: 65e1aec3ba4d12362a4356cf
                     author:
                       type: admin
-                      id: '991267098'
+                      id: '991269460'
                       name: Ciaran312 Lee
                       email: admin312@email.com
                       away_mode_enabled: false
@@ -7993,7 +7993,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: 4674b90d-cfa9-43e6-94be-77d87af60c36
+                    request_id: ceadc41c-28d4-4e74-a72f-59e748b02cd8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8007,7 +8007,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 84d90b9d-a6af-4325-af79-47b766c202b8
+                    request_id: c439adfe-5dae-45cf-8e2c-3103a4c335e6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8043,16 +8043,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 65e0ba056abd017a41872d35
+                      id: 65e1aec5ba4d12362a4356d2
                       name: John segment
-                      created_at: 1709226501
-                      updated_at: 1709226501
+                      created_at: 1709289157
+                      updated_at: 1709289157
                       person_type: user
                     - type: segment
-                      id: 65e0ba056abd017a41872d36
+                      id: 65e1aec5ba4d12362a4356d3
                       name: Jane segment
-                      created_at: 1709226501
-                      updated_at: 1709226501
+                      created_at: 1709289157
+                      updated_at: 1709289157
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -8064,7 +8064,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: eccea87a-018e-4f8b-9444-d99ee3069319
+                    request_id: a0bfcd80-a5af-4bc0-b36c-aa7538005ad2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8098,10 +8098,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 65e0ba066abd017a41872d39
+                    id: 65e1aec6ba4d12362a4356d6
                     name: John segment
-                    created_at: 1709226502
-                    updated_at: 1709226502
+                    created_at: 1709289158
+                    updated_at: 1709289158
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -8113,7 +8113,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: b2fb5b4e-481f-4462-a735-ce303b1da528
+                    request_id: 71f3146d-231b-4a4c-b754-de0976b85ab4
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8127,7 +8127,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 675ad361-2d7a-4037-bf6a-422e2f81cc98
+                    request_id: 0ba2e0a6-a2cc-433f-89b9-e7ce225f4e40
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8157,7 +8157,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '91'
+                      id: '319'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -8180,7 +8180,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8babb440-4482-40b3-b13a-bd0ed4749b5d
+                    request_id: e4562244-04a9-42f1-b33e-f4b989ef17fc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8210,7 +8210,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/6ebbd1ba-f6cb-4e65-9872-d504008c4ef0
+                    url: http://via.intercom.io/msgr/73d9a722-21be-4117-a4ed-cb9e630871b2
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -8243,7 +8243,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e506572b-9ca3-472a-9f40-68c3e25d7390
+                    request_id: a5486b5f-5836-4177-bcba-5eec335ffcee
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8306,7 +8306,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '64'
+                      id: '252'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -8318,7 +8318,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9366b9f2-c6c8-41d9-9503-e1636ee2c3bc
+                    request_id: f50ea524-cdfc-4ad7-aa4f-888f230016c0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8357,7 +8357,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '67'
+                    id: '255'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8369,7 +8369,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: 53070439-0773-4060-abf2-11a302109fc8
+                    request_id: 0f66350a-4424-4abf-9026-a071ca864796
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -8383,14 +8383,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: df522d5b-c048-4094-8914-0e80876ac062
+                    request_id: acbffefb-36dc-421e-a94d-310f61653643
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: 3912b584-297d-4ebd-89f4-635b8a142b8c
+                    request_id: e978ab35-2697-4673-9f8f-c62d75ebdff1
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -8404,7 +8404,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f663e1fd-98ab-48e1-b0da-e37e8aa1077b
+                    request_id: 9c2cf059-c4b0-4cda-b49e-7a0f0248d3fc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8470,7 +8470,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '75'
+                    id: '263'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8482,7 +8482,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 5c5c2b27-6a14-4e51-8238-0723d4a2dc81
+                    request_id: 3e94500c-cedd-4284-b4c4-7eefa93daa21
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8496,7 +8496,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 14602be5-e43b-4e98-a9a3-7d2cffc74390
+                    request_id: 04a47e2e-1166-48bb-8ff5-30d1e6b47a3a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8532,7 +8532,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: d4ebbe62-57e1-4923-bcaa-ee131aa8d056
+                    request_id: b8603174-0540-41c3-83e4-0b58fe5d5802
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8546,7 +8546,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: 61c10f64-0569-4300-8ade-8e28710cb909
+                    request_id: b239da9a-49da-478f-b87a-44062abf526e
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -8561,7 +8561,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b1255db5-fe23-418e-82d7-cff2863e879e
+                    request_id: eff5148e-de0e-4b2e-9b63-a7f0d0730748
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8599,7 +8599,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c489fb57-1349-457f-bf14-76dc2e0f2b73
+                    request_id: d24cfd64-81ba-434d-9469-c4cc8704e34e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8634,7 +8634,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991267136'
+                    id: '991269498'
                     name: team 1
                     admin_ids: []
               schema:
@@ -8647,7 +8647,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: 530447b6-7692-4d3a-bfc2-7f2991665b42
+                    request_id: b04148cd-bace-48c7-af46-55200d5a3d04
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -8661,7 +8661,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '0883726f-32f3-49e9-b670-8801680b0e47'
+                    request_id: 150b26fc-df1d-412b-be66-e2c8676a9ad9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8693,26 +8693,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0ba226abd017a41872d5d
+                    id: 65e1aee3ba4d12362a4356fa
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Mint Diamond
+                    pseudonym: Rose Unicorn
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/mint-diamond.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/rose-unicorn.png
                     app_id: this_is_an_id609_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226530
-                    remote_created_at: 1709226530
-                    signed_up_at: 1709226530
-                    updated_at: 1709226531
+                    created_at: 1709289187
+                    remote_created_at: 1709289187
+                    signed_up_at: 1709289187
+                    updated_at: 1709289187
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8745,7 +8745,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: d243da06-144d-4a69-bf4b-55d56035c4da
+                    request_id: e9e9a662-a179-4233-a6b7-e695e20980c7
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8759,7 +8759,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 94381b24-5571-405d-9e3f-abe50fe2f065
+                    request_id: 3f738bb4-304b-4f39-a4dc-2236eaa29945
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8774,7 +8774,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 65e0ba226abd017a41872d5d
+                  id: 65e1aee3ba4d12362a4356fa
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -8807,7 +8807,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0ba246abd017a41872d63
+                    id: 65e1aee4ba4d12362a435700
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -8823,10 +8823,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226532
-                    remote_created_at: 1709226532
-                    signed_up_at: 1709226532
-                    updated_at: 1709226532
+                    created_at: 1709289188
+                    remote_created_at: 1709289188
+                    signed_up_at: 1709289188
+                    updated_at: 1709289188
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8859,7 +8859,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: ffd9f817-89bd-496c-828d-7c72ee14b20c
+                    request_id: b3f8727b-077d-4a9a-ade8-eff3af34ac22
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8873,7 +8873,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 791182b8-df1f-455e-8bb6-44c4c9185e73
+                    request_id: a1566e7d-a95c-4a18-9929-1a4d53acee0a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8907,7 +8907,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0ba266abd017a41872d69
+                    id: 65e1aee6ba4d12362a435706
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -8923,10 +8923,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226534
-                    remote_created_at: 1709226534
-                    signed_up_at: 1709226534
-                    updated_at: 1709226534
+                    created_at: 1709289190
+                    remote_created_at: 1709289190
+                    signed_up_at: 1709289190
+                    updated_at: 1709289190
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -8959,7 +8959,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: ae844ba8-ceec-436f-a42c-416a439fe2bf
+                    request_id: 3a827e0d-7f1f-4adc-b9e3-995fee01915b
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -8973,7 +8973,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: eb4de280-fac7-497d-ba3c-3d2d9fbef909
+                    request_id: bd583d42-c9ba-43ae-9e26-be71b98fe6fe
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9006,7 +9006,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0ba286abd017a41872d6f
+                    id: 65e1aee7ba4d12362a43570c
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -9022,10 +9022,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226536
-                    remote_created_at: 1709226536
-                    signed_up_at: 1709226536
-                    updated_at: 1709226536
+                    created_at: 1709289191
+                    remote_created_at: 1709289191
+                    signed_up_at: 1709289191
+                    updated_at: 1709289192
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -9058,7 +9058,7 @@ paths:
                 Visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 50630bcc-4882-43d7-8c8f-2551a86f2aa2
+                    request_id: f961c8bd-1cfe-41c8-aeb6-3de3c5375828
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -9072,7 +9072,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7230c653-5e84-44af-b824-c5345430cc02
+                    request_id: 5180f4ac-dbd9-4732-bf38-d954f50164dd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9103,7 +9103,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0ba296abd017a41872d76
+                    id: 65e1aee9ba4d12362a435713
                     workspace_id: this_is_an_id633_that_should_be_at_least_
                     external_id:
                     role: user
@@ -9118,9 +9118,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226537
-                    updated_at: 1709226538
-                    signed_up_at: 1709226537
+                    created_at: 1709289193
+                    updated_at: 1709289194
+                    signed_up_at: 1709289193
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -9154,31 +9154,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba296abd017a41872d76/tags"
+                      url: "/contacts/65e1aee9ba4d12362a435713/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba296abd017a41872d76/notes"
+                      url: "/contacts/65e1aee9ba4d12362a435713/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba296abd017a41872d76/companies"
+                      url: "/contacts/65e1aee9ba4d12362a435713/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba296abd017a41872d76/subscriptions"
+                      url: "/contacts/65e1aee9ba4d12362a435713/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba296abd017a41872d76/subscriptions"
+                      url: "/contacts/65e1aee9ba4d12362a435713/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -9197,7 +9197,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: be6ad792-c726-4573-9180-a7b95eedc9f8
+                    request_id: 8928762c-27d3-46de-9825-cd7599bda03a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11407,7 +11407,8 @@ components:
       properties:
         type:
           type: string
-          description: This includes conversation, push, facebook, twitter and email.
+          description: This includes conversation, email, facebook, instagram, phone_call,
+            phone_switch, push, sms, twitter and whatsapp.
           example: conversation
         id:
           type: string

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991268258'
+                    id: '991267222'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1709050992
+                      created_at: 1709226549
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991268259'
+                    id: '991267223'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: b04006e3-ad42-4c07-9b0a-fbdbc1316452
+                    request_id: c73b9754-8e97-4b71-90ce-da97c2698fb1
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2aeb767d-fca1-4368-8b77-c6d90bdd93ab
+                    request_id: b87907a8-4a7d-42dc-bda9-65179f9a6b64
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: e17b27e4-2474-4c17-b548-27f69d912e17
+                    - id: d660eb1f-1414-478b-a0a4-61ffa599b119
                       performed_by:
                         type: admin
-                        id: '991268263'
+                        id: '991267227'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1709050999
+                      created_at: 1709226555
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: 0cb6a039-b808-4380-ae93-35e3b30325c4
+                    - id: 6c73d2b0-78d2-40a4-9f7e-6bf5e1cc02d8
                       performed_by:
                         type: admin
-                        id: '991268263'
+                        id: '991267227'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1709050999
+                      created_at: 1709226555
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fa62079d-fb6c-4d09-a69d-b5abd5120104
+                    request_id: '048db248-4907-48da-9d54-4881ddf15162'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991268265'
+                      id: '991267229'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5836a444-6a09-44d1-97e3-891f72218bb3
+                    request_id: e8c93084-5e5a-4576-b28f-6d7085ccd6df
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991268267'
+                    id: '991267231'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: fac8ff4e-edfa-4e10-8d36-135d1205ed21
+                    request_id: 73f7b86f-ceb5-40a7-bcc6-96050fb115c8
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: be64a78e-8368-480c-85e4-b2576afaebbf
+                    request_id: 7b9f961c-bfe4-40c4-9ccf-f5f242eaeb1e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -390,20 +390,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '71'
+                    - id: '40'
                       type: article
                       workspace_id: this_is_an_id22_that_should_be_at_least_4
-                      parent_id: 288
+                      parent_id: 149
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991268270
+                      author_id: 991267234
                       state: published
-                      created_at: 1709051004
-                      updated_at: 1709051004
-                      url: http://help-center.test/myapp-22/en/articles/71-this-is-the-article-title
+                      created_at: 1709226560
+                      updated_at: 1709226560
+                      url: http://help-center.test/myapp-22/en/articles/40-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -414,7 +414,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c4b52ef1-ce15-41f2-ae64-acce7995bb0f
+                    request_id: 03b00bcb-9326-4569-bb81-2728b4c94a2d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -439,10 +439,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '74'
+                    id: '43'
                     type: article
                     workspace_id: this_is_an_id26_that_should_be_at_least_4
-                    parent_id: 290
+                    parent_id: 151
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -456,11 +456,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991268275
+                    author_id: 991267239
                     state: published
-                    created_at: 1709051006
-                    updated_at: 1709051006
-                    url: http://help-center.test/myapp-26/en/articles/74-thanks-for-everything
+                    created_at: 1709226562
+                    updated_at: 1709226562
+                    url: http://help-center.test/myapp-26/en/articles/43-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -471,7 +471,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 8c24e06a-28ec-4be9-8862-ff0adbf09e5b
+                    request_id: 1c790ef6-bbd2-4586-af45-d8e755857575
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -486,7 +486,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6d56675d-78ae-4bfb-b281-b44a44260b6c
+                    request_id: b01354eb-3b85-4bfc-9801-461985e3628f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -504,16 +504,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991268275
+                  author_id: 991267239
                   state: published
-                  parent_id: 290
+                  parent_id: 151
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991268275
+                      author_id: 991267239
                       state: published
               bad_request:
                 summary: Bad Request
@@ -550,10 +550,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '77'
+                    id: '46'
                     type: article
                     workspace_id: this_is_an_id32_that_should_be_at_least_4
-                    parent_id: 293
+                    parent_id: 154
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -567,11 +567,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991268280
+                    author_id: 991267244
                     state: published
-                    created_at: 1709051008
-                    updated_at: 1709051008
-                    url: http://help-center.test/myapp-32/en/articles/77-this-is-the-article-title
+                    created_at: 1709226564
+                    updated_at: 1709226564
+                    url: http://help-center.test/myapp-32/en/articles/46-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -582,7 +582,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: bb30c726-343e-40a5-bc58-b5287e6f1f26
+                    request_id: 4e630872-d7e5-4447-a968-2bdfc8fe32ca
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -596,7 +596,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 16874435-ab4a-49a8-ab33-b1fbe2f2207c
+                    request_id: 4360f29e-a270-4798-a337-c203bfb8a602
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -629,10 +629,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '80'
+                    id: '49'
                     type: article
                     workspace_id: this_is_an_id38_that_should_be_at_least_4
-                    parent_id: 296
+                    parent_id: 157
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -646,11 +646,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991268286
+                    author_id: 991267250
                     state: published
-                    created_at: 1709051010
-                    updated_at: 1709051011
-                    url: http://help-center.test/myapp-38/en/articles/80-christmas-is-here
+                    created_at: 1709226566
+                    updated_at: 1709226567
+                    url: http://help-center.test/myapp-38/en/articles/49-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -661,7 +661,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: f4f3d6f1-bdca-44c4-8d51-65a8ef93c032
+                    request_id: d8d24f28-a8de-463a-bdab-571a6ff53343
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -675,7 +675,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6a13bd90-5577-462a-86d4-e0294b85d8f7
+                    request_id: '088d9eff-00ab-4d89-bfc6-58ae34fc518b'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -723,7 +723,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '83'
+                    id: '52'
                     object: article
                     deleted: true
               schema:
@@ -736,7 +736,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 79ec16c4-6f09-4881-a718-e8bad82dfdf8
+                    request_id: df66a981-1214-4651-a60f-df25411eb064
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -750,7 +750,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: eea8d556-d2b4-4613-93a1-15f5d0bc4ba2
+                    request_id: e9458c07-77b4-40fb-adf2-754c81261416
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -781,16 +781,16 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '304'
+                    - id: '165'
                       workspace_id: this_is_an_id52_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-52/collection-17
                       order: 17
-                      created_at: 1709051015
-                      updated_at: 1709051015
+                      created_at: 1709226572
+                      updated_at: 1709226572
                       description: english collection description
                       icon: bookmark
-                      help_center_id: 156
+                      help_center_id: 93
                       type: collection
                     total_count: 1
                     pages:
@@ -808,7 +808,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: baccc089-d7d9-4181-b71d-8fef75705c44
+                    request_id: e8645c80-326f-4021-88f1-c51251438157
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -833,16 +833,16 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '310'
+                    id: '171'
                     workspace_id: this_is_an_id56_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-56/
                     order: 1
-                    created_at: 1709051017
-                    updated_at: 1709051017
+                    created_at: 1709226573
+                    updated_at: 1709226573
                     description: ''
                     icon: book-bookmark
-                    help_center_id: 158
+                    help_center_id: 95
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -854,7 +854,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: dec35d47-6ba0-4387-8ea7-a6d47b1519e9
+                    request_id: 9eeab088-5b47-47f0-bf4e-5d0301bf848e
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -868,7 +868,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: db83df9e-34b9-4f47-9a0a-43311d62830b
+                    request_id: 6b94c487-5417-4461-8a8a-d3cc0fd3a6cf
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -916,16 +916,16 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '315'
+                    id: '176'
                     workspace_id: this_is_an_id62_that_should_be_at_least_4
                     name: English collection title
                     url: http://help-center.test/myapp-62/collection-22
                     order: 22
-                    created_at: 1709051018
-                    updated_at: 1709051018
+                    created_at: 1709226574
+                    updated_at: 1709226574
                     description: english collection description
                     icon: bookmark
-                    help_center_id: 161
+                    help_center_id: 98
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -937,7 +937,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: c943ffe0-1b7c-4e99-aa4b-f31be6dfe903
+                    request_id: 890faa12-c917-4c83-93e2-6bb5fd50e838
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -951,7 +951,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cd2953a9-18cc-4ae1-8f49-01008cd9a173
+                    request_id: 1ef4ec1f-f3c4-4322-8d2b-1bd67ebbedda
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -984,16 +984,16 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '321'
+                    id: '182'
                     workspace_id: this_is_an_id68_that_should_be_at_least_4
                     name: Update collection name
                     url: http://help-center.test/myapp-68/collection-25
                     order: 25
-                    created_at: 1709051020
-                    updated_at: 1709051020
+                    created_at: 1709226575
+                    updated_at: 1709226576
                     description: english collection description
                     icon: folder
-                    help_center_id: 164
+                    help_center_id: 101
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -1005,7 +1005,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: 5ac7d48c-2ca0-444b-af67-5046a8a291d8
+                    request_id: d4e3fa61-0f16-4db5-8e81-2714bf709976
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1019,7 +1019,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 934681a5-f7c7-4e7b-bd7d-daeec102e8bc
+                    request_id: a2816ff3-37c2-4279-8c0f-db12b80daf03
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1066,7 +1066,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '327'
+                    id: '188'
                     object: collection
                     deleted: true
               schema:
@@ -1079,7 +1079,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: 398cf9e0-dce1-456a-b7bc-1450bf332333
+                    request_id: 993f3f49-39e2-44d4-a64b-efd96ce86124
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1093,7 +1093,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d668f2ec-9d10-40c8-a1b4-1ef7834e4d7d
+                    request_id: 472cfa0b-778c-4413-a38e-4d9c81b6a8a3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1127,10 +1127,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '170'
+                    id: '107'
                     workspace_id: this_is_an_id80_that_should_be_at_least_4
-                    created_at: 1709051023
-                    updated_at: 1709051023
+                    created_at: 1709226579
+                    updated_at: 1709226579
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1144,7 +1144,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 79cb04e1-8829-4192-a550-0aff4111cff3
+                    request_id: c49fe8c6-3c71-49c7-b6d3-4ba6b89ed237
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1158,7 +1158,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cb8b0250-9f92-47e0-a498-6d7d35887096
+                    request_id: 795cd671-92ab-493d-a0b1-cb9ba55269cc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1196,7 +1196,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2361ce32-1d0d-4d10-ac03-95e27d5ff1c2
+                    request_id: 6ed2e121-cee4-4e2f-ade7-0c4c33cc6512
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1228,15 +1228,15 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '334'
+                    - id: '195'
                       workspace_id: this_is_an_id90_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-90/section-15
                       order: 15
-                      created_at: 1709051025
-                      updated_at: 1709051025
+                      created_at: 1709226581
+                      updated_at: 1709226581
                       type: section
-                      parent_id: 333
+                      parent_id: 194
                     total_count: 1
                     pages:
                       type: pages
@@ -1253,7 +1253,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 30555b64-215c-4b86-8817-e62267d5c9f2
+                    request_id: f32ef4a8-b5fa-43d4-b215-fcca5a297c21
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1278,15 +1278,15 @@ paths:
               examples:
                 section created:
                   value:
-                    id: '339'
+                    id: '200'
                     workspace_id: this_is_an_id94_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-94/
                     order: 1
-                    created_at: 1709051027
-                    updated_at: 1709051027
+                    created_at: 1709226582
+                    updated_at: 1709226582
                     type: section
-                    parent_id: '337'
+                    parent_id: '198'
               schema:
                 "$ref": "#/components/schemas/section"
         '401':
@@ -1297,7 +1297,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3eae157e-9c6a-47df-ab1b-3a3519fa08a6
+                    request_id: 765f7ee2-f274-4db3-9379-7640588d72e1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1313,7 +1313,7 @@ paths:
                 summary: section created
                 value:
                   name: Thanks for everything
-                  parent_id: 337
+                  parent_id: 198
   "/help_center/sections/{id}":
     get:
       summary: Retrieve a section
@@ -1342,15 +1342,15 @@ paths:
               examples:
                 Section found:
                   value:
-                    id: '343'
+                    id: '204'
                     workspace_id: this_is_an_id98_that_should_be_at_least_4
                     name: English section title
                     url: http://help-center.test/myapp-98/section-19
                     order: 19
-                    created_at: 1709051027
-                    updated_at: 1709051027
+                    created_at: 1709226583
+                    updated_at: 1709226583
                     type: section
-                    parent_id: 342
+                    parent_id: 203
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1361,7 +1361,7 @@ paths:
                 Section not found:
                   value:
                     type: error.list
-                    request_id: 86d66dfd-0b0c-4f41-b153-2479330b8c94
+                    request_id: a389c685-d02a-4e30-b434-673846e51796
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1375,7 +1375,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f2a433f9-b2c7-45ec-8a03-2af9872d5ad7
+                    request_id: b468fc68-35ce-44f1-9836-f554f7c01c02
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1408,15 +1408,15 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '349'
+                    id: '210'
                     workspace_id: this_is_an_id104_that_should_be_at_least_
                     name: Update section name
                     url: http://help-center.test/myapp-104/section-22
                     order: 22
-                    created_at: 1709051029
-                    updated_at: 1709051029
+                    created_at: 1709226584
+                    updated_at: 1709226584
                     type: section
-                    parent_id: '348'
+                    parent_id: '209'
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1427,7 +1427,7 @@ paths:
                 Section Not Found:
                   value:
                     type: error.list
-                    request_id: f979b13c-1d53-43dd-8c74-343d255bb3b0
+                    request_id: 7ee9d415-d886-409a-b75d-0b4e48bd0da6
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1441,7 +1441,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 97b4fe97-ad1f-4047-ab24-ac5a64878338
+                    request_id: 52949b20-f2a0-4707-ad10-151cf1ff4b25
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1457,12 +1457,12 @@ paths:
                 summary: successful
                 value:
                   name: Update section name
-                  parent_id: 348
+                  parent_id: 209
               section_not_found:
                 summary: Section Not Found
                 value:
                   name: Update section name
-                  parent_id: 350
+                  parent_id: 211
     delete:
       summary: Delete a section
       parameters:
@@ -1489,7 +1489,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '355'
+                    id: '216'
                     object: section
                     deleted: true
               schema:
@@ -1502,7 +1502,7 @@ paths:
                 section Not Found:
                   value:
                     type: error.list
-                    request_id: bb3af15f-37db-43e1-a552-318e07fafbfb
+                    request_id: 1608ce80-59ef-40d4-ab41-30373bc43e49
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1516,7 +1516,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dd21e615-4daa-4ce1-96e9-2050157bc04e
+                    request_id: 6d6a9a2a-0f52-4809-9881-770fc6f6d92c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1549,12 +1549,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 65de0c98ba4d1202813d21ff
+                    id: 65e0ba5c6abd017c52345fe9
                     app_id: this_is_an_id116_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1709051033
-                    updated_at: 1709051033
+                    created_at: 1709226588
+                    updated_at: 1709226588
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1591,7 +1591,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5839aa9f-f6a8-4cc1-8b6b-5e9a45acae0a
+                    request_id: 14c1970c-4416-46e6-adb2-0a55ad952e01
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1689,12 +1689,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0c9aba4d1202813d2207
+                      id: 65e0ba5d6abd017c52345ff1
                       app_id: this_is_an_id122_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709051034
-                      created_at: 1709051034
-                      updated_at: 1709051034
+                      remote_created_at: 1709226589
+                      created_at: 1709226589
+                      updated_at: 1709226589
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -1723,7 +1723,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 39faea02-b16f-45e0-9c76-2b3e19bcb0ed
+                    request_id: 89d5cb28-0183-4d2e-965d-457f13f8ac02
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1737,7 +1737,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 51aed303-cc23-44ef-b82e-bc137b2d5edc
+                    request_id: a17c88c5-7960-45e9-9fbb-48c635d8dab8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1772,12 +1772,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0c9dba4d1202813d2212
+                    id: 65e0ba606abd017c52345ffc
                     app_id: this_is_an_id128_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1709051037
-                    created_at: 1709051037
-                    updated_at: 1709051037
+                    remote_created_at: 1709226592
+                    created_at: 1709226592
+                    updated_at: 1709226592
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1799,7 +1799,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 0447bc23-dc4f-4ef3-b7be-0979f91750fd
+                    request_id: 8e7ec44d-a70f-4da7-85f0-5bd1054709c0
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1813,7 +1813,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 84a946b0-cb63-4eb9-a74a-4a575a4a266b
+                    request_id: 48de211c-01d0-4831-af65-e8aa6bde98df
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1847,12 +1847,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0c9fba4d1202813d221c
+                    id: 65e0ba626abd017c52346006
                     app_id: this_is_an_id134_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1709051039
-                    created_at: 1709051039
-                    updated_at: 1709051039
+                    remote_created_at: 1709226594
+                    created_at: 1709226594
+                    updated_at: 1709226594
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1874,7 +1874,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 51620496-40b9-4930-af17-9be17a0e2f97
+                    request_id: ef1e850e-f135-4860-af84-26366d12ce30
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1888,7 +1888,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 364652db-b94d-4a35-b1e4-62d4e1f22cad
+                    request_id: 3d131749-27a2-48f0-83b5-fbb4b9a8e6d8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1920,7 +1920,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 65de0ca1ba4d1202813d2226
+                    id: 65e0ba646abd017c52346010
                     object: company
                     deleted: true
               schema:
@@ -1933,7 +1933,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 24b58e48-b8e9-4106-ae5a-bb4a3010af8c
+                    request_id: 7cbf86f1-c23a-464a-b604-98edf209dc7e
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1947,7 +1947,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dfca74bc-3fcf-4385-bbee-3067268bb8e6
+                    request_id: '082de709-5df1-4c38-9a21-bb5af7285286'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1999,7 +1999,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: bf41b214-e524-4e6d-b84c-5bc55c1c9277
+                    request_id: 40b2c4aa-a40c-489b-8b1e-ed7b1c0a24e4
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2013,7 +2013,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1a92496b-1c9f-43dc-adf5-aa35e629c463
+                    request_id: 79fb849a-7235-437a-a947-4135e1df7b5d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2058,7 +2058,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 9944ac06-b270-4b34-85e5-3d04a9142b00
+                    request_id: 57aaa1af-e74b-429c-ab6b-81fafadee188
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2072,7 +2072,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2bbd10fb-62f4-42b6-8573-8de26c9aa3a3
+                    request_id: 2030c6a6-ad92-4cb9-98ac-5ba205bc181d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2129,12 +2129,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0ca6ba4d1202813d2242
+                      id: 65e0ba6a6abd017c5234602c
                       app_id: this_is_an_id158_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709051046
-                      created_at: 1709051046
-                      updated_at: 1709051046
+                      remote_created_at: 1709226602
+                      created_at: 1709226602
+                      updated_at: 1709226602
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2163,7 +2163,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 40206b09-0e4c-4884-add8-305725b955aa
+                    request_id: 3ac411ee-e236-4573-8a00-75b0889f4e08
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2215,12 +2215,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65de0ca8ba4d1202813d2248
+                      id: 65e0ba6c6abd017c52346032
                       app_id: this_is_an_id162_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709051048
-                      created_at: 1709051048
-                      updated_at: 1709051048
+                      remote_created_at: 1709226604
+                      created_at: 1709226604
+                      updated_at: 1709226604
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2234,7 +2234,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: f3c1adf2-246a-4760-9229-ab6e10c7ab91
+                    scroll_param: 746aa969-55d6-44c3-8939-f7bf3c39e91e
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2245,7 +2245,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2e7c3a4d-0ed8-4838-b71e-59c216a3a9f4
+                    request_id: 1309f095-7977-48a1-a534-33f73ca9e37a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2280,12 +2280,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0ca9ba4d1202813d2251
+                    id: 65e0ba6d6abd017c5234603b
                     app_id: this_is_an_id166_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1709051049
-                    created_at: 1709051049
-                    updated_at: 1709051049
+                    remote_created_at: 1709226605
+                    created_at: 1709226605
+                    updated_at: 1709226605
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2307,7 +2307,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 2f436fa3-ecb0-483f-bd88-c864defc286a
+                    request_id: 1b959dbd-6d4b-49e2-beb1-72f5b5dc87e6
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2321,7 +2321,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: e6e9a70d-436d-491c-b390-4d8ddae16820
+                    request_id: ebf19bdf-d5a6-4a5c-9f98-a8f67b2b8cf4
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2335,7 +2335,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 346e1e82-b235-4b55-b238-3f79d0151d0b
+                    request_id: 8e6015c8-5fd2-4a04-8c51-575f3dfb6d7a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2358,7 +2358,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 65de0ca9ba4d1202813d2251
+                  id: 65e0ba6d6abd017c5234603b
               bad_request:
                 summary: Bad Request
                 value:
@@ -2397,13 +2397,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 65de0cafba4d1202813d2272
+                      id: 65e0ba736abd017c5234605c
                       app_id: this_is_an_id182_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1709051055
-                      created_at: 1709051055
-                      updated_at: 1709051055
-                      last_request_at: 1708878255
+                      remote_created_at: 1709226611
+                      created_at: 1709226611
+                      updated_at: 1709226611
+                      last_request_at: 1709053811
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2432,7 +2432,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: dcd60b94-d378-4556-8f98-cbd82ad6d9f4
+                    request_id: 11d1697e-4d99-426d-8c4e-c5ef5a9c5840
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2446,7 +2446,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 923ebba7-8bef-4d34-bebe-3d916cdb88ca
+                    request_id: f6bf4863-1fff-442f-adc8-5caa361f1110
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2489,12 +2489,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65de0cacba4d1202813d2261
+                    id: 65e0ba706abd017c5234604b
                     app_id: this_is_an_id174_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1709051052
-                    created_at: 1709051052
-                    updated_at: 1709051052
+                    remote_created_at: 1709226608
+                    created_at: 1709226608
+                    updated_at: 1709226609
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2516,14 +2516,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 6e8a99dd-24e6-4c87-adcf-7222c8927a88
+                    request_id: 06b549b5-15ae-4432-b02e-6f54e7d35aac
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: e210bd8c-16cc-4aae-b1d6-0501686a45b6
+                    request_id: bd52cd8f-8d29-4597-ae3e-ac6a44057ecc
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2537,7 +2537,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6feeb51c-b356-4114-ad95-0a7dfc6b8e9e
+                    request_id: 71efb6ab-526d-46ec-bb25-25d76a23ef08
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2573,42 +2573,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '55'
-                      created_at: 1708446257
+                      id: '29'
+                      created_at: 1708621814
                       contact:
                         type: contact
-                        id: 65de0cb1ba4d1202813d227d
+                        id: 65e0ba766abd017c52346067
                       author:
                         type: admin
-                        id: '991268368'
+                        id: '991267332'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '54'
-                      created_at: 1708359857
+                      id: '28'
+                      created_at: 1708535414
                       contact:
                         type: contact
-                        id: 65de0cb1ba4d1202813d227d
+                        id: 65e0ba766abd017c52346067
                       author:
                         type: admin
-                        id: '991268368'
+                        id: '991267332'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '53'
-                      created_at: 1708359857
+                      id: '27'
+                      created_at: 1708535414
                       contact:
                         type: contact
-                        id: 65de0cb1ba4d1202813d227d
+                        id: 65e0ba766abd017c52346067
                       author:
                         type: admin
-                        id: '991268368'
+                        id: '991267332'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
@@ -2631,7 +2631,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: ca886f04-10ee-4916-b8b2-a8bc88b04627
+                    request_id: 3984b9be-d417-4708-b46c-506c2f43e187
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2665,14 +2665,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '60'
-                    created_at: 1709051059
+                    id: '34'
+                    created_at: 1709226615
                     contact:
                       type: contact
-                      id: 65de0cb2ba4d1202813d227f
+                      id: 65e0ba776abd017c52346069
                     author:
                       type: admin
-                      id: '991268370'
+                      id: '991267334'
                       name: Ciaran112 Lee
                       email: admin112@email.com
                       away_mode_enabled: false
@@ -2688,14 +2688,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: aef3adbc-0515-4d9b-a378-3162549eba69
+                    request_id: 21dd7a96-f283-45a4-8133-fcf71446abc1
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: bd517933-da79-4d8a-82cc-b135e6388c11
+                    request_id: 19889aa0-ad21-4744-bef7-dfe8718c0498
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2725,20 +2725,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 65de0cb2ba4d1202813d227f
-                  admin_id: 991268370
+                  contact_id: 65e0ba776abd017c52346069
+                  admin_id: 991267334
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 65de0cb3ba4d1202813d2280
+                  contact_id: 65e0ba776abd017c5234606a
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991268372
+                  admin_id: 991267336
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -2771,10 +2771,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 65de0cb4ba4d1202813d2282
+                      id: 65e0ba796abd017c5234606c
                       name: segment
-                      created_at: 1709051060
-                      updated_at: 1709051060
+                      created_at: 1709226617
+                      updated_at: 1709226617
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -2786,7 +2786,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: e0483528-0b71-488a-b4cb-2e63183442df
+                    request_id: 0f632ccb-622c-4f1a-8415-1988bf2f5b15
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2800,7 +2800,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6bfd293b-3e83-4a50-b722-5ffc9c4a523c
+                    request_id: 8d432a2e-eef7-4d54-af1b-6d81e69c39e7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2844,7 +2844,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '185'
+                      id: '93'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -2858,7 +2858,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '187'
+                      id: '95'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -2881,7 +2881,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 4bf782c9-c5d9-4c02-8b01-f450ac2d70e3
+                    request_id: 7e62d7cc-9d11-4ef0-a7f8-2fd7b2d8b04f
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2895,7 +2895,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 22c00e79-48c0-40e3-b900-5c070ecdb4ee
+                    request_id: 73c042c7-fef9-4b67-b0b8-7872ce3ca858
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2936,7 +2936,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '200'
+                    id: '108'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -2959,14 +2959,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 75bac51b-b23b-4fb1-98ac-f55a40d09448
+                    request_id: 47a894d3-acf3-4a90-a92d-77c8cdd630f1
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 84c58316-6b3c-463a-8c77-1d2595d53cb9
+                    request_id: 756ccc30-7825-4472-84bf-eec6663ff35a
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -2980,7 +2980,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f13783e0-6e09-4d3b-83fd-03ed128c4361
+                    request_id: 396a86c8-dc17-4e0a-8a4e-61a21813a23d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3008,12 +3008,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 200
+                  id: 108
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 204
+                  id: 112
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -3059,7 +3059,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '216'
+                    id: '124'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3082,14 +3082,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: cf539662-26a7-4b59-b7a8-10e65b08be89
+                    request_id: 1070efaa-5527-418f-a09d-9598a9e11d52
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 85bc8532-cb41-43f6-9853-95a3ebb47372
+                    request_id: 1857f54f-890a-4490-9d26-4b72f0192d22
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3103,7 +3103,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8a87249a-bdd0-4e0c-a096-d9944b3e06de
+                    request_id: 2cb56b4f-68d2-4c9c-ba46-1e54b5aa17d3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3141,7 +3141,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '170'
+                      id: '83'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -3153,7 +3153,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: a8f18670-4e7d-445a-8625-57d8c9411412
+                    request_id: fcc6b834-53aa-4a2a-819e-edbbdaa9f6a0
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3167,7 +3167,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 442adb39-e9f3-4f2d-b74b-365b5220764a
+                    request_id: a3a12ccb-c8d4-4f0a-83dd-9f393c828139
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3202,7 +3202,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '171'
+                    id: '84'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3214,14 +3214,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: dbc74d5c-b70f-4bcc-9a1d-fa17c0cd88b2
+                    request_id: fd3fd08a-0b67-436b-80b4-bbf8b8438a98
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: ed1b2931-f968-42af-8766-e7b12d041f8e
+                    request_id: d933b04e-b143-4488-a8f3-90e9ac042a2f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3235,7 +3235,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bfdeb2c6-15df-4cb3-a58b-5fc5d2e962a5
+                    request_id: 76849cf6-fc70-42a9-906e-3b2fc833dd54
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3258,11 +3258,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 171
+                  id: 84
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 172
+                  id: 85
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3304,7 +3304,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '174'
+                    id: '87'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3316,14 +3316,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 30299f2b-7c2f-4fd7-96e0-4db346b5859b
+                    request_id: 80830263-b52f-4dd7-929b-a4528e422c86
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: cf7ed16c-7326-4ad8-b751-f4e2e87e1fb0
+                    request_id: d522ac0c-045c-42bb-9bbe-38e0b29c24dc
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3337,7 +3337,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 150ccc68-f45d-487e-a775-92c1cb4fe847
+                    request_id: 892d14ed-c5c6-4a92-8717-f066122eef0d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3371,7 +3371,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0cc2ba4d1202813d2299
+                    id: 65e0ba876abd017c52346083
                     workspace_id: this_is_an_id248_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3386,9 +3386,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709051074
-                    updated_at: 1709051075
-                    signed_up_at: 1709051074
+                    created_at: 1709226631
+                    updated_at: 1709226631
+                    signed_up_at: 1709226631
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3422,31 +3422,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc2ba4d1202813d2299/tags"
+                      url: "/contacts/65e0ba876abd017c52346083/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc2ba4d1202813d2299/notes"
+                      url: "/contacts/65e0ba876abd017c52346083/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc2ba4d1202813d2299/companies"
+                      url: "/contacts/65e0ba876abd017c52346083/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc2ba4d1202813d2299/subscriptions"
+                      url: "/contacts/65e0ba876abd017c52346083/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc2ba4d1202813d2299/subscriptions"
+                      url: "/contacts/65e0ba876abd017c52346083/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3465,7 +3465,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 698e030e-d5bb-404a-b5a0-d9fc35b790f0
+                    request_id: 365d431a-5dab-44ba-9291-46e3ccfafd3f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3510,7 +3510,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0cc4ba4d1202813d229a
+                    id: 65e0ba886abd017c52346084
                     workspace_id: this_is_an_id252_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3525,9 +3525,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709051076
-                    updated_at: 1709051076
-                    signed_up_at: 1709051076
+                    created_at: 1709226632
+                    updated_at: 1709226632
+                    signed_up_at: 1709226632
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3561,31 +3561,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc4ba4d1202813d229a/tags"
+                      url: "/contacts/65e0ba886abd017c52346084/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc4ba4d1202813d229a/notes"
+                      url: "/contacts/65e0ba886abd017c52346084/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc4ba4d1202813d229a/companies"
+                      url: "/contacts/65e0ba886abd017c52346084/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc4ba4d1202813d229a/subscriptions"
+                      url: "/contacts/65e0ba886abd017c52346084/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc4ba4d1202813d229a/subscriptions"
+                      url: "/contacts/65e0ba886abd017c52346084/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3604,7 +3604,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: be8d3b37-cd0e-48c0-9453-392f1a98b8ac
+                    request_id: b03b9f9e-7db5-4c43-9d43-f58f481c778e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3635,7 +3635,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de0cc5ba4d1202813d229b
+                    id: 65e0ba8a6abd017c52346085
                     object: contact
                     deleted: true
               schema:
@@ -3648,7 +3648,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f917d5b7-14cb-4441-9626-0d6b0e175812
+                    request_id: 24491086-9f51-4db0-8b56-350971f921ca
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3676,7 +3676,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0cc6ba4d1202813d229d
+                    id: 65e0ba8b6abd017c52346087
                     workspace_id: this_is_an_id260_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3691,9 +3691,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709051078
-                    updated_at: 1709051079
-                    signed_up_at: 1709051078
+                    created_at: 1709226635
+                    updated_at: 1709226635
+                    signed_up_at: 1709226635
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3727,31 +3727,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc6ba4d1202813d229d/tags"
+                      url: "/contacts/65e0ba8b6abd017c52346087/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc6ba4d1202813d229d/notes"
+                      url: "/contacts/65e0ba8b6abd017c52346087/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc6ba4d1202813d229d/companies"
+                      url: "/contacts/65e0ba8b6abd017c52346087/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc6ba4d1202813d229d/subscriptions"
+                      url: "/contacts/65e0ba8b6abd017c52346087/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0cc6ba4d1202813d229d/subscriptions"
+                      url: "/contacts/65e0ba8b6abd017c52346087/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3770,7 +3770,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7bb7724a-19d7-4494-89b7-056cf6ad0782
+                    request_id: c2c0fbf3-f94c-431b-a4ed-246f14e8ebe9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3785,8 +3785,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 65de0cc6ba4d1202813d229c
-                  into: 65de0cc6ba4d1202813d229d
+                  from: 65e0ba8b6abd017c52346086
+                  into: 65e0ba8b6abd017c52346087
   "/contacts/search":
     post:
       summary: Search contacts
@@ -3915,7 +3915,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d19b7a58-edce-4227-b9ee-bb230870f394
+                    request_id: c668a6a0-2b61-4fd4-9f71-fb01d883f54b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3935,15 +3935,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: 65de0cc8ba4d1202813d22a0
+                      value: 65e0ba8d6abd017c5234608a
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: 65de0cc8ba4d1202813d22a0
+                        value: 65e0ba8d6abd017c5234608a
                       - field: id
                         operator: "="
-                        value: 65de0cc8ba4d1202813d22a0
+                        value: 65e0ba8d6abd017c5234608a
   "/contacts":
     get:
       summary: List all contacts
@@ -3982,7 +3982,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 47baab69-2d99-408e-b14f-d08d457983c6
+                    request_id: 42d55057-8b82-4d55-b92c-fd09e9f0c7c8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4008,7 +4008,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0ccaba4d1202813d22a2
+                    id: 65e0ba8f6abd017c5234608c
                     workspace_id: this_is_an_id272_that_should_be_at_least_
                     external_id:
                     role: user
@@ -4023,8 +4023,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709051082
-                    updated_at: 1709051082
+                    created_at: 1709226639
+                    updated_at: 1709226639
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -4059,31 +4059,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0ccaba4d1202813d22a2/tags"
+                      url: "/contacts/65e0ba8f6abd017c5234608c/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0ccaba4d1202813d22a2/notes"
+                      url: "/contacts/65e0ba8f6abd017c5234608c/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0ccaba4d1202813d22a2/companies"
+                      url: "/contacts/65e0ba8f6abd017c5234608c/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0ccaba4d1202813d22a2/subscriptions"
+                      url: "/contacts/65e0ba8f6abd017c5234608c/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0ccaba4d1202813d22a2/subscriptions"
+                      url: "/contacts/65e0ba8f6abd017c5234608c/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4102,7 +4102,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6e90717a-7cbd-4010-98fa-7df0a6cb7023
+                    request_id: 8ffc7f40-0263-4d97-ab2d-3f7a392a19fe
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4146,7 +4146,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de0ccbba4d1202813d22a3
+                    id: 65e0ba906abd017c5234608d
                     object: contact
                     archived: true
               schema:
@@ -4178,7 +4178,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65de0cccba4d1202813d22a4
+                    id: 65e0ba916abd017c5234608e
                     object: contact
                     archived: false
               schema:
@@ -4213,7 +4213,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '176'
+                    id: '89'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4225,7 +4225,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 270a4871-d2f0-44b2-8c53-706b7ab91af2
+                    request_id: 0ce8b463-1f5d-434e-b9b5-9ea9dd054938
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4239,7 +4239,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ce97ebca-74bd-4e85-9db0-376b3455da9f
+                    request_id: 3693e691-a217-4ff8-a5cd-ce7d71dae432
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4268,13 +4268,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 176
-                  admin_id: 991268403
+                  id: 89
+                  admin_id: 991267367
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 177
-                  admin_id: 991268405
+                  id: 90
+                  admin_id: 991267369
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4312,7 +4312,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '179'
+                    id: '92'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4324,14 +4324,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 39c3518a-bb0d-49cd-b640-bbcc99ceea86
+                    request_id: 852806de-e888-452e-b547-57061e5c03da
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 86ebd842-5d1f-4848-a685-8b26587cb8b7
+                    request_id: d5fa19f2-238a-44c1-bd40-2e64040ab09a
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4345,7 +4345,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4c3029ca-425a-4fa0-bc56-e2a0fda50cd3
+                    request_id: d699cd0e-f863-4a8d-a86b-82e9237b9c51
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4368,15 +4368,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991268407
+                  admin_id: 991267371
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991268409
+                  admin_id: 991267373
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991268410
+                  admin_id: 991267374
   "/conversations":
     get:
       summary: List all conversations
@@ -4423,20 +4423,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '569'
-                      created_at: 1709051093
-                      updated_at: 1709051093
+                      id: '280'
+                      created_at: 1709226649
+                      updated_at: 1709226649
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918396'
+                        id: '403918228'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991268413'
+                          id: '991267377'
                           name: Ciaran152 Lee
                           email: admin152@email.com
                         attachments: []
@@ -4446,7 +4446,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de0cd5ba4d1202813d22a8
+                          id: 65e0ba986abd017c52346092
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -4475,7 +4475,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9aeb7949-3763-4da2-91e2-e5d5cc9d8f46
+                    request_id: fad3c282-dfe7-49c6-a4f2-a75a823c88b6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4489,7 +4489,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 7b4374eb-3b91-4fb3-b013-5495f3c9f3f9
+                    request_id: 671137f4-b4fd-4974-82d6-9d478e1db5db
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4505,13 +4505,17 @@ paths:
       tags:
       - Conversations
       operationId: createConversation
-      description: "You can create a conversation that has been initiated by a contact
-        (ie. user or lead).\nThe conversation can be an in-app message only.\n\n>
-        \U0001F4D8 Sending for visitors\n>\n> You can also send a message from a visitor
-        by specifying their `user_id` or `id` value in the `from` field, along with
-        a `type` field value of `contact`.\n> This visitor will be automatically converted
-        to a contact with a lead role once the conversation is created.\n\nThis will
-        return the Message model that has been created.\n\n"
+      description: |+
+        You can create a conversation that has been initiated by a contact (ie. user or lead).
+        The conversation can be an in-app message only.
+
+        {% admonition type="info" name="Sending for visitors" %}
+        You can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.
+        This visitor will be automatically converted to a contact with a lead role once the conversation is created.
+        {% /admonition %}
+
+        This will return the Message model that has been created.
+
       responses:
         '200':
           description: conversation created
@@ -4521,11 +4525,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918406'
-                    created_at: 1709051118
+                    id: '403918238'
+                    created_at: 1709226671
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '594'
+                    conversation_id: '305'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -4536,7 +4540,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: e6c5acc5-db70-4c1e-bfce-3d691394e8d8
+                    request_id: 66d07e59-b59a-4a03-b416-ba106b731425
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -4550,7 +4554,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 14597fb3-5101-4a95-b7b7-28877711fd7a
+                    request_id: f39f4bda-9c38-483e-a768-57f8d11ff12b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4564,7 +4568,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: fb53ed6e-3655-46fb-812e-110bade416e2
+                    request_id: 4595736a-0e0a-41ed-b21c-1f42a8c4fa33
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4581,7 +4585,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65de0cecba4d1202813d22bd
+                    id: 65e0baae6abd017c523460a7
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -4615,15 +4619,21 @@ paths:
       tags:
       - Conversations
       operationId: retrieveConversation
-      description: "\nYou can fetch the details of a single conversation.\n\nThis
-        will return a single Conversation model with all its conversation parts.\n\n>
-        \U0001F6A7 Hard limit of 500 parts\n>\n> The maximum number of conversation
-        parts that can be returned via the API is 500. If you have more than that
-        we will return the 500 most recent conversation parts.\n\n> \U0001F4D8 Bot
-        name in conversation parts\n>\n> For conversation parts generated by a bot,
-        bot name will depend on the following:\n- Customers that never turned on AI
-        answers will have `operator` as the bot name\n- Customers that have turned
-        on AI answers at some point will have `fin` as the bot name\n"
+      description: |2
+
+        You can fetch the details of a single conversation.
+
+        This will return a single Conversation model with all its conversation parts.
+
+        {% admonition type="warning" name="Hard limit of 500 parts" %}
+        The maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.
+        {% /admonition %}
+
+        ### Bot Name in Conversation Parts
+
+        For conversation parts generated by a bot, bot name will depend on the following:
+        - Customers that never turned on AI answers will have `operator` as the bot name
+        - Customers that have turned on AI answers at some point will have `fin` as the bot name
       responses:
         '200':
           description: conversation found
@@ -4633,20 +4643,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '598'
-                    created_at: 1709051123
-                    updated_at: 1709051123
+                    id: '309'
+                    created_at: 1709226678
+                    updated_at: 1709226678
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918410'
+                      id: '403918242'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268427'
+                        id: '991267391'
                         name: Ciaran159 Lee
                         email: admin159@email.com
                       attachments: []
@@ -4656,7 +4666,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0cf3ba4d1202813d22c1
+                        id: 65e0bab66abd017c523460ab
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4689,7 +4699,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: ae359b0e-331e-442c-87b1-3e22fa05bad9
+                    request_id: af4e92d4-75b5-40c2-9cfb-15b2a6d48323
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4703,7 +4713,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c850756f-508c-4268-a0c9-2be9d2a76e7a
+                    request_id: 3c7b4ae8-9bea-42a5-9657-f15dbae7f680
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4717,7 +4727,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: e1f3a3c6-6c52-4998-98d0-be9e82861359
+                    request_id: 5134203c-daac-48c4-b161-fed393e7e945
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4747,10 +4757,14 @@ paths:
       tags:
       - Conversations
       operationId: updateConversation
-      description: "\nYou can update an existing conversation.\n\n> \U0001F4D8\n>\n>
-        If you want to update a conversation with either a reply (or actions such
-        as assign, unassign, open, close or snooze) then take a look at their own
-        sections respectively as they currently require different endpoints and parameters.\n\n"
+      description: |2+
+
+        You can update an existing conversation.
+
+        {% admonition type="info" name="Replying and other actions" %}
+        If you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.
+        {% /admonition %}
+
       responses:
         '200':
           description: conversation found
@@ -4760,20 +4774,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '602'
-                    created_at: 1709051128
-                    updated_at: 1709051130
+                    id: '313'
+                    created_at: 1709226683
+                    updated_at: 1709226685
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918414'
+                      id: '403918246'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268435'
+                        id: '991267399'
                         name: Ciaran163 Lee
                         email: admin163@email.com
                       attachments: []
@@ -4783,7 +4797,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0cf8ba4d1202813d22c5
+                        id: 65e0babb6abd017c523460af
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4808,15 +4822,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '127'
+                        id: '56'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709051130
-                        updated_at: 1709051130
-                        notified_at: 1709051130
+                        created_at: 1709226684
+                        updated_at: 1709226684
+                        notified_at: 1709226684
                         assigned_to:
                         author:
-                          id: '991268436'
+                          id: '991267400'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4824,15 +4838,15 @@ paths:
                         external_id:
                         redacted: false
                       - type: conversation_part
-                        id: '128'
+                        id: '57'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709051130
-                        updated_at: 1709051130
-                        notified_at: 1709051130
+                        created_at: 1709226685
+                        updated_at: 1709226685
+                        notified_at: 1709226685
                         assigned_to:
                         author:
-                          id: '991268436'
+                          id: '991267400'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4850,7 +4864,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 93e7c7e1-ccf6-4ed3-8692-7ae7d2b64057
+                    request_id: 86f5f6b2-779c-4393-9408-1271ff5bc6d5
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4864,7 +4878,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: df03af1a-0813-4814-8e2e-9fdfc86c18f6
+                    request_id: 396125cd-c7a5-46c9-95b6-9bc1b9772e24
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4878,7 +4892,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 1ff295b2-0bc4-4087-9763-f6decd012b8c
+                    request_id: 3d0c9768-98b1-4837-9b4c-53f2c800893e
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5018,20 +5032,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '609'
-                      created_at: 1709051139
-                      updated_at: 1709051139
+                      id: '320'
+                      created_at: 1709226694
+                      updated_at: 1709226694
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918421'
+                        id: '403918253'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991268465'
+                          id: '991267429'
                           name: Ciaran186 Lee
                           email: admin186@email.com
                         attachments: []
@@ -5041,7 +5055,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65de0d03ba4d1202813d22cc
+                          id: 65e0bac56abd017c523460b6
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -5076,15 +5090,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '609'
+                      value: '320'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '609'
+                        value: '320'
                       - field: id
                         operator: "="
-                        value: '609'
+                        value: '320'
   "/conversations/{id}/reply":
     post:
       summary: Reply to a conversation
@@ -5096,19 +5110,11 @@ paths:
       - name: id
         in: path
         required: true
+        description: The Intercom provisioned identifier for the conversation or the
+          string "last" to reply to the last part of the conversation
+        example: 123 or "last"
         schema:
-          oneOf:
-          - title: Conversation ID
-            type: string
-            description: The id of the conversation to target.
-            example: '123'
-          - title: The most recent conversation
-            type: string
-            enum:
-            - last
-            description: You can also reply to the most recent conversation on a workspace
-              by specifying `last` as the string.
-            example: last
+          type: string
       tags:
       - Conversations
       operationId: replyConversation
@@ -5123,20 +5129,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '617'
-                    created_at: 1709051146
-                    updated_at: 1709051147
-                    waiting_since: 1709051147
+                    id: '328'
+                    created_at: 1709226700
+                    updated_at: 1709226701
+                    waiting_since: 1709226701
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918424'
+                      id: '403918256'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268467'
+                        id: '991267431'
                         name: Ciaran187 Lee
                         email: admin187@email.com
                       attachments: []
@@ -5146,9 +5152,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0d0aba4d1202813d22d3
+                        id: 65e0bacc6abd017c523460bd
                     first_contact_reply:
-                      created_at: 1709051147
+                      created_at: 1709226701
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5172,15 +5178,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '130'
+                        id: '59'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709051147
-                        updated_at: 1709051147
-                        notified_at: 1709051147
+                        created_at: 1709226701
+                        updated_at: 1709226701
+                        notified_at: 1709226701
                         assigned_to:
                         author:
-                          id: 65de0d0aba4d1202813d22d3
+                          id: 65e0bacc6abd017c523460bd
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5191,20 +5197,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '618'
-                    created_at: 1709051148
-                    updated_at: 1709051150
+                    id: '329'
+                    created_at: 1709226703
+                    updated_at: 1709226704
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918425'
+                      id: '403918257'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268469'
+                        id: '991267433'
                         name: Ciaran188 Lee
                         email: admin188@email.com
                       attachments: []
@@ -5214,7 +5220,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0d0cba4d1202813d22d4
+                        id: 65e0bace6abd017c523460be
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5237,7 +5243,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '131'
+                        id: '60'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5252,12 +5258,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1709051150
-                        updated_at: 1709051150
-                        notified_at: 1709051150
+                        created_at: 1709226704
+                        updated_at: 1709226704
+                        notified_at: 1709226704
                         assigned_to:
                         author:
-                          id: '991268469'
+                          id: '991267433'
                           type: admin
                           name: Ciaran188 Lee
                           email: admin188@email.com
@@ -5268,20 +5274,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '620'
-                    created_at: 1709051152
-                    updated_at: 1709051153
-                    waiting_since: 1709051153
+                    id: '331'
+                    created_at: 1709226706
+                    updated_at: 1709226707
+                    waiting_since: 1709226707
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918427'
+                      id: '403918259'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268473'
+                        id: '991267437'
                         name: Ciaran190 Lee
                         email: admin190@email.com
                       attachments: []
@@ -5291,9 +5297,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0d10ba4d1202813d22d6
+                        id: 65e0bad26abd017c523460c0
                     first_contact_reply:
-                      created_at: 1709051153
+                      created_at: 1709226707
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5317,15 +5323,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '132'
+                        id: '61'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709051153
-                        updated_at: 1709051153
-                        notified_at: 1709051153
+                        created_at: 1709226707
+                        updated_at: 1709226707
+                        notified_at: 1709226707
                         assigned_to:
                         author:
-                          id: 65de0d10ba4d1202813d22d6
+                          id: 65e0bad26abd017c523460c0
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5343,7 +5349,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: df630fa9-2233-4d79-ac28-24c369b619ff
+                    request_id: 9e1d22b7-de95-42f2-98ff-b4aa714271a1
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5357,7 +5363,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6c98ac2a-25bb-4ce1-82de-a1de5f98071e
+                    request_id: 1c747b55-c34d-45f4-936f-eb35d9449165
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5371,7 +5377,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 4d3c8ba1-3d15-4edc-8b36-42f7b4f4ea4d
+                    request_id: acccb090-ff78-4097-8a64-e46985c1fd35
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5388,14 +5394,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0d0aba4d1202813d22d3
+                  intercom_user_id: 65e0bacc6abd017c523460bd
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991268469
+                  admin_id: 991267433
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -5405,14 +5411,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0d10ba4d1202813d22d6
+                  intercom_user_id: 65e0bad26abd017c523460c0
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65de0d12ba4d1202813d22d7
+                  intercom_user_id: 65e0bad46abd017c523460c1
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -5433,10 +5439,11 @@ paths:
       - Conversations
       operationId: manageConversation
       description: |
-        You can close a conversation.
-        You can snooze a conversation to reopen on a future date.
-        You can open a conversation which is `snoozed` or `closed`.
-        You can assign a conversation to an admin and/or team.
+        For managing conversations you can:
+        - Close a conversation
+        - Snooze a conversation to reopen on a future date
+        - Open a conversation which is `snoozed` or `closed`
+        - Assign a conversation to an admin and/or team.
       responses:
         '200':
           description: Assign a conversation
@@ -5446,20 +5453,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '624'
-                    created_at: 1709051160
-                    updated_at: 1709051161
+                    id: '335'
+                    created_at: 1709226713
+                    updated_at: 1709226713
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918431'
+                      id: '403918263'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268481'
+                        id: '991267445'
                         name: Ciaran194 Lee
                         email: admin194@email.com
                       attachments: []
@@ -5469,7 +5476,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0d17ba4d1202813d22da
+                        id: 65e0bad86abd017c523460c4
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5492,15 +5499,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '133'
+                        id: '62'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1709051161
-                        updated_at: 1709051161
-                        notified_at: 1709051161
+                        created_at: 1709226713
+                        updated_at: 1709226713
+                        notified_at: 1709226713
                         assigned_to:
                         author:
-                          id: '991268481'
+                          id: '991267445'
                           type: admin
                           name: Ciaran194 Lee
                           email: admin194@email.com
@@ -5511,20 +5518,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '625'
-                    created_at: 1709051162
-                    updated_at: 1709051163
+                    id: '336'
+                    created_at: 1709226714
+                    updated_at: 1709226715
                     waiting_since:
-                    snoozed_until: 1709054763
+                    snoozed_until: 1709230315
                     source:
                       type: conversation
-                      id: '403918432'
+                      id: '403918264'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268483'
+                        id: '991267447'
                         name: Ciaran195 Lee
                         email: admin195@email.com
                       attachments: []
@@ -5534,7 +5541,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0d1aba4d1202813d22db
+                        id: 65e0bada6abd017c523460c5
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5557,15 +5564,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '134'
+                        id: '63'
                         part_type: snoozed
                         body:
-                        created_at: 1709051163
-                        updated_at: 1709051163
-                        notified_at: 1709051163
+                        created_at: 1709226715
+                        updated_at: 1709226715
+                        notified_at: 1709226715
                         assigned_to:
                         author:
-                          id: '991268483'
+                          id: '991267447'
                           type: admin
                           name: Ciaran195 Lee
                           email: admin195@email.com
@@ -5576,20 +5583,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '630'
-                    created_at: 1709051162
-                    updated_at: 1709051172
+                    id: '341'
+                    created_at: 1709226713
+                    updated_at: 1709226722
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918433'
+                      id: '403918265'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268485'
+                        id: '991267449'
                         name: Ciaran196 Lee
                         email: admin196@email.com
                       attachments: []
@@ -5599,7 +5606,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0d1fba4d1202813d22e0
+                        id: 65e0badf6abd017c523460ca
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5622,15 +5629,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '136'
+                        id: '65'
                         part_type: open
                         body:
-                        created_at: 1709051172
-                        updated_at: 1709051172
-                        notified_at: 1709051172
+                        created_at: 1709226722
+                        updated_at: 1709226722
+                        notified_at: 1709226722
                         assigned_to:
                         author:
-                          id: '991268485'
+                          id: '991267449'
                           type: admin
                           name: Ciaran196 Lee
                           email: admin196@email.com
@@ -5641,20 +5648,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '634'
-                    created_at: 1709051173
-                    updated_at: 1709051174
+                    id: '345'
+                    created_at: 1709226723
+                    updated_at: 1709226724
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918436'
+                      id: '403918268'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268487'
+                        id: '991267451'
                         name: Ciaran197 Lee
                         email: admin197@email.com
                       attachments: []
@@ -5664,9 +5671,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0d25ba4d1202813d22e3
+                        id: 65e0bae36abd017c523460cd
                     first_contact_reply:
-                    admin_assignee_id: 991268487
+                    admin_assignee_id: 991267451
                     team_assignee_id:
                     open: true
                     state: open
@@ -5687,17 +5694,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '137'
+                        id: '66'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1709051174
-                        updated_at: 1709051174
-                        notified_at: 1709051174
+                        created_at: 1709226724
+                        updated_at: 1709226724
+                        notified_at: 1709226724
                         assigned_to:
                           type: admin
-                          id: '991268487'
+                          id: '991267451'
                         author:
-                          id: '991268487'
+                          id: '991267451'
                           type: admin
                           name: Ciaran197 Lee
                           email: admin197@email.com
@@ -5715,7 +5722,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 29563338-6549-4fd2-8eab-b211d7b4ec4f
+                    request_id: 13ba7fae-3e6f-4026-a5a1-ed40b4865574
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5729,7 +5736,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4a19faa7-54a0-4640-b900-a444ca1ca55a
+                    request_id: d2093d6b-657b-48a4-a23e-302de88265fa
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5743,7 +5750,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 453e9da8-5278-40dc-a983-0851b4a0582c
+                    request_id: 940d79d2-138c-434e-bced-82566c394475
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5764,32 +5771,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991268481
+                  admin_id: 991267445
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991268483
-                  snoozed_until: 1709054763
+                  admin_id: 991267447
+                  snoozed_until: 1709230315
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991268485
+                  admin_id: 991267449
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991268487
-                  assignee_id: 991268487
+                  admin_id: 991267451
+                  assignee_id: 991267451
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991268489
+                  admin_id: 991267453
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -5820,20 +5827,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '638'
-                    created_at: 1709051180
-                    updated_at: 1709051181
+                    id: '349'
+                    created_at: 1709226729
+                    updated_at: 1709226730
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918440'
+                      id: '403918272'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268495'
+                        id: '991267459'
                         name: Ciaran201 Lee
                         email: admin201@email.com
                       attachments: []
@@ -5843,7 +5850,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0d2bba4d1202813d22e7
+                        id: 65e0bae96abd017c523460d1
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5866,17 +5873,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '138'
+                        id: '67'
                         part_type: default_assignment
                         body:
-                        created_at: 1709051181
-                        updated_at: 1709051181
-                        notified_at: 1709051181
+                        created_at: 1709226730
+                        updated_at: 1709226730
+                        notified_at: 1709226730
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991268496'
+                          id: '991267460'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id357_that_should_be_at_least_@intercom.io
@@ -5894,7 +5901,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: aa93af13-928c-4c12-9514-9c822899c063
+                    request_id: 4158d661-b91f-4fc9-b43b-898247b1bc34
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5908,7 +5915,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 506121a7-47c2-4e1f-82e5-3facca238480
+                    request_id: 1cddbff0-92a8-45a7-96f0-60ce46e56528
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5922,7 +5929,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 85b6b9d9-ea1d-4262-98af-1c7f7ef6c35d
+                    request_id: 404444a6-ba4c-4e4b-b294-9b49a32ec3b4
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5946,11 +5953,13 @@ paths:
       tags:
       - Conversations
       operationId: attachContactToConversation
-      description: "You can add participants who are contacts to a conversation, on
-        behalf of either another contact or an admin.\n\n> \U0001F6A7 Note about contacts
-        without an email\n>\n> If you add a contact via the email parameter and there
-        is no user/lead found on that workspace with he given email, then we will
-        create a new contact with `role` set to `lead`.\n\n"
+      description: |+
+        You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.
+
+        {% admonition type="attention" name="Contacts without an email" %}
+        If you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.
+        {% /admonition %}
+
       responses:
         '200':
           description: Attach a contact to a conversation
@@ -5961,7 +5970,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65de0d33ba4d1202813d22eb
+                      id: 65e0baef6abd017c523460d5
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -5972,7 +5981,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: a0bda71b-e2c7-4b83-8558-d776ce9ec1e3
+                    request_id: 38898694-3695-4d55-87f7-3d4c10705fe8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5986,7 +5995,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 83adfddd-4ae2-4e68-9be2-875bd72a4bb6
+                    request_id: 6c7d347e-d3c2-4292-9153-8cfae5a8020b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6000,7 +6009,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 2d0809be-d311-46c2-8671-e951d78ff569
+                    request_id: ef367699-bf60-411a-8741-a60d24bc7c20
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6015,15 +6024,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991268503
+                  admin_id: 991267467
                   customer:
-                    intercom_user_id: 65de0d33ba4d1202813d22eb
+                    intercom_user_id: 65e0baef6abd017c523460d5
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991268505
+                  admin_id: 991267469
                   customer:
-                    intercom_user_id: 65de0d34ba4d1202813d22ec
+                    intercom_user_id: 65e0baf16abd017c523460d6
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -6049,11 +6058,13 @@ paths:
       tags:
       - Conversations
       operationId: detachContactFromConversation
-      description: "You can add participants who are contacts to a conversation, on
-        behalf of either another contact or an admin.\n\n> \U0001F6A7 Note about contacts
-        without an email\n>\n> If you add a contact via the email parameter and there
-        is no user/lead found on that workspace with he given email, then we will
-        create a new contact with `role` set to `lead`.\n\n"
+      description: |+
+        You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.
+
+        {% admonition type="attention" name="Contacts without an email" %}
+        If you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.
+        {% /admonition %}
+
       responses:
         '200':
           description: Detach a contact from a group conversation
@@ -6064,7 +6075,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65de0d41ba4d1202813d22f6
+                      id: 65e0bafc6abd017c523460e0
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6075,14 +6086,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: f0fcb555-1415-45bc-adac-772abefba016
+                    request_id: 0d8c70cc-9b90-428e-8de8-d5496ad4ea5f
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 48c9ea95-9b3a-4a42-9855-5e1193f63bf3
+                    request_id: 595f75fc-cff0-420c-a83a-efd4c860f480
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -6096,7 +6107,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: b49051e9-fa87-41c1-b504-43b9b877bef6
+                    request_id: '08a80af4-f1cb-4934-8714-5946581154b4'
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -6110,7 +6121,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 71b26257-ede7-4e33-8b51-9ac4229c890e
+                    request_id: b0366588-3e21-442f-b276-af4ddfcfc5ec
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6124,7 +6135,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 6d1c2319-b518-4f6a-a445-dceb9576eef9
+                    request_id: f3f08c0d-fef0-4367-986d-40afd49cb3d1
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6139,27 +6150,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991268511
+                  admin_id: 991267475
                   customer:
-                    intercom_user_id: 65de0d39ba4d1202813d22ef
+                    intercom_user_id: 65e0baf56abd017c523460d9
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991268513
+                  admin_id: 991267477
                   customer:
-                    intercom_user_id: 65de0d42ba4d1202813d22f7
+                    intercom_user_id: 65e0bafd6abd017c523460e1
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991268515
+                  admin_id: 991267479
                   customer:
-                    intercom_user_id: 65de0d4aba4d1202813d22fe
+                    intercom_user_id: 65e0bb056abd017c523460e8
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991268517
+                  admin_id: 991267481
                   customer:
-                    intercom_user_id: 65de0d52ba4d1202813d2305
+                    intercom_user_id: 65e0bb0e6abd017c523460ef
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6171,12 +6182,13 @@ paths:
       tags:
       - Conversations
       operationId: redactConversation
-      description: "You can redact a conversation part or the source message of a
-        conversation (as seen in the source object).\n\n> \U0001F4D8 Which parts and
-        source messages can I redact?\n>\n> If you are redacting a conversation part,
-        it must have a `body`.\n> If you are redacting a source message, it must have
-        been created by a contact.\n> We will return a `conversation_part_not_redactable`
-        error if these criteria are not met.\n\n"
+      description: |+
+        You can redact a conversation part or the source message of a conversation (as seen in the source object).
+
+        {% admonition type="info" name="Redacting parts and messages" %}
+        If you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.
+        {% /admonition %}
+
       responses:
         '200':
           description: Redact a conversation part
@@ -6186,20 +6198,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '694'
-                    created_at: 1709051242
-                    updated_at: 1709051244
-                    waiting_since: 1709051243
+                    id: '405'
+                    created_at: 1709226789
+                    updated_at: 1709226790
+                    waiting_since: 1709226789
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918466'
+                      id: '403918298'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991268523'
+                        id: '991267487'
                         name: Ciaran215 Lee
                         email: admin215@email.com
                       attachments: []
@@ -6209,9 +6221,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65de0d6aba4d1202813d231a
+                        id: 65e0bb256abd017c52346104
                     first_contact_reply:
-                      created_at: 1709051243
+                      created_at: 1709226789
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6235,15 +6247,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '146'
+                        id: '75'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1709051243
-                        updated_at: 1709051244
-                        notified_at: 1709051243
+                        created_at: 1709226789
+                        updated_at: 1709226790
+                        notified_at: 1709226789
                         assigned_to:
                         author:
-                          id: 65de0d6aba4d1202813d231a
+                          id: 65e0bb256abd017c52346104
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6261,7 +6273,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: '0860faa8-4a7a-44d7-9d74-7ffa07a0079a'
+                    request_id: 4f65275d-a0e4-4720-944a-b0f23c029e65
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -6275,7 +6287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bf1ede42-afc5-4dca-9477-98e4bedd1a36
+                    request_id: cabb3057-cad5-4384-83fc-d4a7d4ce85c5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6291,8 +6303,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 694
-                  conversation_part_id: 146
+                  conversation_id: 405
+                  conversation_part_id: 75
               not_found:
                 summary: Not found
                 value:
@@ -6479,7 +6491,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 66
+                    - id: 34
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -6492,9 +6504,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991268548'
-                      created_at: 1709051257
-                      updated_at: 1709051257
+                      admin_id: '991267512'
+                      created_at: 1709226801
+                      updated_at: 1709226801
                       model: company
                     - type: data_attribute
                       name: id
@@ -6566,7 +6578,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d6ac76a9-e909-4dc1-94c8-073c0d11ae90
+                    request_id: 01fc7d5c-ef53-4dbb-9026-df13e32d6a89
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6591,7 +6603,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 69
+                    id: 37
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -6602,9 +6614,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991268550'
-                    created_at: 1709051258
-                    updated_at: 1709051258
+                    admin_id: '991267514'
+                    created_at: 1709226803
+                    updated_at: 1709226803
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6616,7 +6628,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: 5622f501-1a89-4ceb-9f90-3f40f6d8c619
+                    request_id: 135dfc99-1eca-44e3-bf11-dcc3fc256e35
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6624,7 +6636,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: 9bfb8ca6-1dfb-4383-acac-30f8c660ffeb
+                    request_id: 556d6960-9122-43c3-98f9-91d1bbb42cc0
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -6632,7 +6644,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: 3127dd55-30f5-4d01-b787-853e85796deb
+                    request_id: 4366bcb9-3f70-46aa-9e63-5096e75eb539
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6640,14 +6652,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: cd97924c-eaa6-4cbb-a7c5-8a3674b01b53
+                    request_id: 6d8bfc75-1520-4f18-8009-1530fee4c1fc
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: c653f511-2383-402b-a903-7f6f83ff7e3a
+                    request_id: 36007549-f343-4ae3-8444-f5f8fa265efd
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -6662,7 +6674,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b3e8364b-d772-45d7-9e20-723a63af7dd7
+                    request_id: e2d36021-ade8-459e-8eff-f61704652d1d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6741,7 +6753,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 76
+                    id: 44
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -6756,9 +6768,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991268557'
-                    created_at: 1709051261
-                    updated_at: 1709051261
+                    admin_id: '991267521'
+                    created_at: 1709226806
+                    updated_at: 1709226806
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6770,7 +6782,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: 025ffa7a-670a-49c9-b62e-cf11657afcd7
+                    request_id: 6c360620-9694-4930-87ab-aebfb8b02353
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -6784,7 +6796,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: '08e024d7-4faa-406d-8e8f-83b20ccb8afe'
+                    request_id: 73c85185-0615-4b81-bc99-9356a51c8af4
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -6798,7 +6810,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: a5ffcbbd-05df-40f1-827e-e99226a8d6db
+                    request_id: 5658dc41-5b44-4ff0-9bdd-2ead2ce81fc5
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -6813,7 +6825,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6be16652-d145-45a2-867b-adee2d1bb7d8
+                    request_id: 917794f4-1376-472c-bfe9-59fc0d4bb3f9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6918,7 +6930,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5e97b6af-8968-42c7-a773-9d6f2ee9efee
+                    request_id: 0c2f537d-4814-486b-a6c7-d9d99231dc3b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7005,7 +7017,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 65de0d81ba4d1202813d2323
+                    intercom_user_id: 65e0bb3a6abd017c5234610d
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -7017,7 +7029,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3e495883-2c39-45f9-8603-2372cb90e940
+                    request_id: 2a94cd5d-1ead-4a61-a34e-c0142eb3d2e8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7048,7 +7060,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a3a781bf-c9b2-425e-82d0-9978be22b32c
+                    request_id: 1a790422-e998-4264-b8d7-ae0a23109a21
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7092,7 +7104,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: vo3mewk3ye7da3c3
+                    job_identifier: rp5yj4x997clha91
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7107,8 +7119,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1709033267
-                  created_at_before: 1709051267
+                  created_at_after: 1709208812
+                  created_at_before: 1709226812
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -7142,7 +7154,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: h2exjkf6l2lvh107
+                    job_identifier: 9r292lvxbubsso3b
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7174,7 +7186,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: j4x5auxofr1xeh9s
+                    job_identifier: r89vgdehqca008ed
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -7235,30 +7247,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918471'
-                    created_at: 1709051270
+                    id: '403918303'
+                    created_at: 1709226815
                     body: heyy
                     message_type: inapp
-                    conversation_id: '699'
+                    conversation_id: '410'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918472'
-                    created_at: 1709051271
+                    id: '403918304'
+                    created_at: 1709226816
                     body: heyy
                     message_type: inapp
-                    conversation_id: '700'
+                    conversation_id: '411'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '25'
-                    created_at: 1709051272
+                    id: '15'
+                    created_at: 1709226817
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991268580'
+                      id: '991267544'
                       name: Ciaran265 Lee
                       email: admin265@email.com
                       away_mode_enabled: false
@@ -7273,14 +7285,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: 1d219bab-2c5a-425e-b0bb-3e1c0577a5b0
+                    request_id: d23842e9-924a-470a-b79b-d88512cd5381
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: 7c373892-fab9-49c9-b9da-a0609fc7b009
+                    request_id: e601dc61-d26f-4422-97ff-d4e030b7ac9d
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -7294,7 +7306,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: c08f6ef4-fdbe-4734-b82a-9d5f864e3d79
+                    request_id: fc911d8a-c746-47e5-9969-64e616cd5688
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -7308,7 +7320,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4eeb225b-d177-4bac-b013-99a9f87a570f
+                    request_id: 4e815e12-ba5f-477d-9161-375857802850
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7322,7 +7334,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: fddc5173-c4a0-44ab-90e6-07e2f9ada77d
+                    request_id: 252bee6a-b234-4e7f-ba89-832cc97e0e05
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -7339,7 +7351,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65de0d85ba4d1202813d2328
+                    id: 65e0bb3f6abd017c52346112
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -7347,7 +7359,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 65de0d86ba4d1202813d2329
+                    id: 65e0bb406abd017c52346113
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -7355,10 +7367,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268580'
+                    id: '991267544'
                   to:
                     type: user
-                    id: 65de0d87ba4d1202813d232a
+                    id: 65e0bb416abd017c52346114
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -7366,10 +7378,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268582'
+                    id: '991267546'
                   to:
                     type: user
-                    id: 65de0d88ba4d1202813d232b
+                    id: 65e0bb426abd017c52346115
                   message_type: inapp
                   body:
                   subject: heyy
@@ -7378,7 +7390,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268583'
+                    id: '991267547'
                   to:
                     type: user
                     user_id: '70'
@@ -7389,10 +7401,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991268584'
+                    id: '991267548'
                   to:
                     type: user
-                    id: 65de0d8aba4d1202813d232d
+                    id: 65e0bb436abd017c52346117
                   message_type: email
                   body:
                   subject: heyy
@@ -7423,12 +7435,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '56'
+                    - id: '29'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991268589
+                      sender_id: 991267553
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7438,15 +7450,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709051276
-                      updated_at: 1709051276
+                      created_at: 1709226821
+                      updated_at: 1709226821
                       newsfeed_assignments: []
-                    - id: '57'
+                    - id: '30'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991268591
+                      sender_id: 991267555
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7456,8 +7468,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709051276
-                      updated_at: 1709051276
+                      created_at: 1709226821
+                      updated_at: 1709226821
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -7470,7 +7482,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d907e35a-6e64-4533-96dc-f9215c3ab894
+                    request_id: 5b9c9578-1e54-4e85-9cb7-ebcbf69c7597
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7495,12 +7507,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '60'
+                    id: '33'
                     type: news-item
                     workspace_id: this_is_an_id483_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991268598
+                    sender_id: 991267562
                     state: live
                     labels:
                     - New
@@ -7511,10 +7523,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1709051278
-                    updated_at: 1709051278
+                    created_at: 1709226823
+                    updated_at: 1709226823
                     newsfeed_assignments:
-                    - newsfeed_id: 103
+                    - newsfeed_id: 53
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7526,7 +7538,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: aab9d976-c1a0-42ad-89bb-c81a522802b7
+                    request_id: 0112dc89-506a-4352-a54a-6b2cbfd590d4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7547,14 +7559,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991268598
+                  sender_id: 991267562
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 103
+                  - newsfeed_id: 53
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -7583,12 +7595,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '61'
+                    id: '34'
                     type: news-item
                     workspace_id: this_is_an_id487_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991268601
+                    sender_id: 991267565
                     state: live
                     labels: []
                     cover_image_url:
@@ -7598,11 +7610,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1709051279
-                    updated_at: 1709051279
+                    created_at: 1709226824
+                    updated_at: 1709226824
                     newsfeed_assignments:
-                    - newsfeed_id: 105
-                      published_at: 1709051279
+                    - newsfeed_id: 55
+                      published_at: 1709226824
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -7613,7 +7625,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 5bea5db7-cb6d-4fb7-9a24-952efa525afb
+                    request_id: c12b7db4-d849-4092-9a18-435a24a30904
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7627,7 +7639,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 553bf351-300f-411c-b73c-a0a4194c67fd
+                    request_id: 1408fb1c-caf3-47b1-8704-cbfe9aeeef01
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7658,12 +7670,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '64'
+                    id: '37'
                     type: news-item
                     workspace_id: this_is_an_id493_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991268609
+                    sender_id: 991267573
                     state: live
                     labels: []
                     cover_image_url:
@@ -7671,8 +7683,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1709051281
-                    updated_at: 1709051281
+                    created_at: 1709226825
+                    updated_at: 1709226826
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7684,7 +7696,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: ed852ac9-9de5-4aca-a530-423cf0893218
+                    request_id: b0209861-67d5-442d-a623-62195311b07e
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7698,7 +7710,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d69d9b58-07ce-48eb-bfe6-e69c84430592
+                    request_id: 5df59db7-9e0a-4e2c-96ad-f804c1060ca7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7715,7 +7727,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991268609
+                  sender_id: 991267573
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7724,7 +7736,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991268612
+                  sender_id: 991267576
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7754,7 +7766,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '67'
+                    id: '40'
                     object: news-item
                     deleted: true
               schema:
@@ -7767,7 +7779,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: d852f475-5a0b-41b1-88b8-86f99e55679f
+                    request_id: 6557d54b-0615-4668-8d2b-5599fd650114
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7781,7 +7793,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c352057b-5434-4a74-9f25-353e6ce71393
+                    request_id: a9a3f27a-0ddb-471a-850b-c0ac6a697e98
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7834,7 +7846,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0cf47c2d-bffd-486d-908e-309f6b7cfdd2
+                    request_id: f8bdb468-2bb0-42f2-aa8d-cc60d23f0b7b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7867,16 +7879,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '118'
+                    - id: '68'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709051286
-                      updated_at: 1709051286
-                    - id: '119'
+                      created_at: 1709226831
+                      updated_at: 1709226831
+                    - id: '69'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709051286
-                      updated_at: 1709051286
+                      created_at: 1709226831
+                      updated_at: 1709226831
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -7888,7 +7900,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fdeb01cf-d229-43b1-892a-701309069763
+                    request_id: 7ea04aec-2f95-46b4-be38-1c7dc07098c4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7922,11 +7934,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '122'
+                    id: '72'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1709051287
-                    updated_at: 1709051287
+                    created_at: 1709226832
+                    updated_at: 1709226832
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -7937,7 +7949,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5d68504c-1d10-4ea8-b086-73883b922e6f
+                    request_id: 4257b130-3e9a-417a-9e45-055739033aaa
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7971,14 +7983,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '63'
-                    created_at: 1708360087
+                    id: '37'
+                    created_at: 1708535633
                     contact:
                       type: contact
-                      id: 65de0d97ba4d1202813d2330
+                      id: 65e0bb516abd017c5234611a
                     author:
                       type: admin
-                      id: '991268628'
+                      id: '991267592'
                       name: Ciaran312 Lee
                       email: admin312@email.com
                       away_mode_enabled: false
@@ -7994,7 +8006,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: 2128fd0d-00d3-4111-8baa-8f5dd9d2770f
+                    request_id: 98eb1b6b-a6f7-47b9-b466-2fcc319ad75b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8008,7 +8020,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 58dd7568-6111-4361-b682-8ca98e4cb8c6
+                    request_id: e18a3d71-0415-406b-87be-6b788cb2500d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8044,16 +8056,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 65de0d99ba4d1202813d2333
+                      id: 65e0bb526abd017c5234611d
                       name: John segment
-                      created_at: 1709051289
-                      updated_at: 1709051289
+                      created_at: 1709226834
+                      updated_at: 1709226834
                       person_type: user
                     - type: segment
-                      id: 65de0d99ba4d1202813d2334
+                      id: 65e0bb526abd017c5234611e
                       name: Jane segment
-                      created_at: 1709051289
-                      updated_at: 1709051289
+                      created_at: 1709226834
+                      updated_at: 1709226834
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -8065,7 +8077,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bad9d216-1368-4a37-a936-2d4327ac56ce
+                    request_id: 4e6cb3e6-9033-4ade-b9e6-02175b36488c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8099,10 +8111,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 65de0d9aba4d1202813d2337
+                    id: 65e0bb536abd017c52346121
                     name: John segment
-                    created_at: 1709051290
-                    updated_at: 1709051290
+                    created_at: 1709226835
+                    updated_at: 1709226835
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -8114,7 +8126,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: 1d563ada-31d4-46c3-9b86-cc290714ac00
+                    request_id: f70b7201-3e11-48f3-8b44-aee9dc290ef6
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8128,7 +8140,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 67fd6b9e-b561-4e8a-8c44-ef2a1f52c74d
+                    request_id: 64811e02-5294-429d-b7bd-2934ef6a7486
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8158,7 +8170,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '229'
+                      id: '137'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -8181,7 +8193,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 862cfd4c-4093-4e07-ac66-8f658306295f
+                    request_id: 6cea578d-4d58-496e-8cb1-a87b93e2ac55
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8211,7 +8223,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/f61076e3-b0eb-4a42-b9d6-31c11d468e6d
+                    url: http://via.intercom.io/msgr/5a2076da-98fb-4564-b666-235eaefb13cc
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -8244,7 +8256,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3af7cf3d-df6a-4d0b-9ad7-b855821493ca
+                    request_id: 59bf043c-715e-4d9f-b9a3-820d6223bcdd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8307,7 +8319,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '192'
+                      id: '105'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -8319,7 +8331,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7516037d-1495-4c92-9924-efe6ac79c3d6
+                    request_id: a64767a3-4c98-413a-b133-2c26b156fb8b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8358,7 +8370,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '195'
+                    id: '108'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8370,7 +8382,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: 07ee36a0-18fc-47e6-a5bc-2f9f1c1b595c
+                    request_id: af7e4d4f-1bd7-4c75-88c3-1911001ee775
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -8384,14 +8396,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: d932e0ce-f098-4bfb-a032-c438b057d894
+                    request_id: 03b04a49-ea07-48a6-b283-7b2582814a24
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: 448a1ae7-42eb-4087-bb56-b0bc04225d1f
+                    request_id: 230779ae-8183-4411-b7be-8eb9f8590054
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -8405,7 +8417,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1eea9954-c22c-49fa-95c6-94a141b26648
+                    request_id: b3686524-4185-48cf-9c4f-ea5f043b7216
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8471,7 +8483,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '203'
+                    id: '116'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8483,7 +8495,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 478ee677-eab2-49d9-9ab9-03bcf6ac398a
+                    request_id: 8d4a2db9-42e4-478a-b767-e411bdf6ebd4
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8497,7 +8509,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e43b3bc8-8333-4769-ba7d-49bbe46a7407
+                    request_id: f0702b70-c7ef-4a0d-9857-a5806e2867bd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8533,7 +8545,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 1bfafe6b-4904-41b4-aa83-83e37ce5687a
+                    request_id: cd91ab2e-5ddd-4436-ac9d-45b574ae5092
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8547,7 +8559,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: 173fba60-f8e7-4f06-b73c-a2e570408f21
+                    request_id: 465678a6-4a23-47e3-9a20-194c7e2d040c
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -8562,7 +8574,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: afffb1f4-5002-42ba-af7c-b760487b8321
+                    request_id: 751c4843-b446-43d4-9453-331e41cb0845
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8600,7 +8612,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 68177eb2-5cba-49dd-940e-ce0be92faa4d
+                    request_id: 13c05757-4879-4107-a16e-aa69a53cb5f8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8635,7 +8647,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991268666'
+                    id: '991267630'
                     name: team 1
                     admin_ids: []
               schema:
@@ -8648,7 +8660,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: fb3c017d-f272-417b-80f2-77cada1b9822
+                    request_id: 819e044f-4d1b-44a2-9958-11cc23583dc8
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -8662,7 +8674,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0ad3d897-03b8-44e6-a238-331083f82a83
+                    request_id: a1ac2cd8-4c1c-4150-bdfc-dc0296b76ea2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8695,7 +8707,7 @@ paths:
                 Ticket Type Attribute created:
                   value:
                     type: ticket_type_attribute
-                    id: '303'
+                    id: '151'
                     workspace_id: this_is_an_id585_that_should_be_at_least_
                     name: Attribute Title
                     description: Attribute Description
@@ -8708,10 +8720,10 @@ paths:
                     visible_on_create: true
                     visible_to_contacts: true
                     default: false
-                    ticket_type_id: 103
+                    ticket_type_id: 45
                     archived: false
-                    created_at: 1709051309
-                    updated_at: 1709051309
+                    created_at: 1709226854
+                    updated_at: 1709226854
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -8722,7 +8734,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4fea3b03-305f-478f-a5f5-993239063991
+                    request_id: 13c39bcc-2542-47e8-8c1f-3ca7aae82a9f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8775,7 +8787,7 @@ paths:
                 Ticket Type Attribute updated:
                   value:
                     type: ticket_type_attribute
-                    id: '308'
+                    id: '156'
                     workspace_id: this_is_an_id589_that_should_be_at_least_
                     name: name
                     description: New Attribute Description
@@ -8786,10 +8798,10 @@ paths:
                     visible_on_create: false
                     visible_to_contacts: false
                     default: false
-                    ticket_type_id: 105
+                    ticket_type_id: 47
                     archived: false
-                    created_at: 1709051310
-                    updated_at: 1709051310
+                    created_at: 1709226854
+                    updated_at: 1709226855
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -8800,7 +8812,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5a147cf8-1076-4149-8dc9-b5a49a1cfe4d
+                    request_id: d8c278d9-58c1-4220-bfc7-45ebe4d339cc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8839,20 +8851,20 @@ paths:
                     type: list
                     data:
                     - type: ticket_type
-                      id: '107'
+                      id: '49'
                       name: Bug Report
                       description: Bug Report Template
                       icon: "\U0001F39F️"
                       workspace_id: this_is_an_id593_that_should_be_at_least_
                       archived: false
-                      created_at: 1709051311
-                      updated_at: 1709051311
+                      created_at: 1709226855
+                      updated_at: 1709226855
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '311'
+                          id: '159'
                           workspace_id: this_is_an_id593_that_should_be_at_least_
                           name: _default_title_
                           description: ''
@@ -8865,12 +8877,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 107
+                          ticket_type_id: 49
                           archived: false
-                          created_at: 1709051311
-                          updated_at: 1709051311
+                          created_at: 1709226855
+                          updated_at: 1709226855
                         - type: ticket_type_attribute
-                          id: '313'
+                          id: '161'
                           workspace_id: this_is_an_id593_that_should_be_at_least_
                           name: name
                           description: description
@@ -8882,12 +8894,12 @@ paths:
                           visible_on_create: false
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 107
+                          ticket_type_id: 49
                           archived: false
-                          created_at: 1709051311
-                          updated_at: 1709051311
+                          created_at: 1709226855
+                          updated_at: 1709226855
                         - type: ticket_type_attribute
-                          id: '312'
+                          id: '160'
                           workspace_id: this_is_an_id593_that_should_be_at_least_
                           name: _default_description_
                           description: ''
@@ -8900,10 +8912,10 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 107
+                          ticket_type_id: 49
                           archived: false
-                          created_at: 1709051311
-                          updated_at: 1709051311
+                          created_at: 1709226855
+                          updated_at: 1709226855
               schema:
                 "$ref": "#/components/schemas/ticket_type_list"
         '401':
@@ -8914,7 +8926,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 349c1247-5175-4eb6-8c09-d2604472bd64
+                    request_id: 769ff726-c0ec-4583-b802-4f4d2b067826
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8943,20 +8955,20 @@ paths:
                 Ticket type created:
                   value:
                     type: ticket_type
-                    id: '110'
+                    id: '52'
                     name: Customer Issue
                     description: Customer Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id597_that_should_be_at_least_
                     archived: false
-                    created_at: 1709051312
-                    updated_at: 1709051312
+                    created_at: 1709226857
+                    updated_at: 1709226857
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '320'
+                        id: '168'
                         workspace_id: this_is_an_id597_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -8969,12 +8981,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 110
+                        ticket_type_id: 52
                         archived: false
-                        created_at: 1709051312
-                        updated_at: 1709051312
+                        created_at: 1709226857
+                        updated_at: 1709226857
                       - type: ticket_type_attribute
-                        id: '321'
+                        id: '169'
                         workspace_id: this_is_an_id597_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -8987,10 +8999,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 110
+                        ticket_type_id: 52
                         archived: false
-                        created_at: 1709051312
-                        updated_at: 1709051312
+                        created_at: 1709226857
+                        updated_at: 1709226857
               schema:
                 "$ref": "#/components/schemas/ticket_type"
         '401':
@@ -9001,7 +9013,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2422d9d8-37f6-4e35-a815-ca7f0a62f8f9
+                    request_id: 2adafcb6-fde0-4129-b70a-84bd490bcf54
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9046,20 +9058,20 @@ paths:
                 Ticket type found:
                   value:
                     type: ticket_type
-                    id: '112'
+                    id: '54'
                     name: Bug Report
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id601_that_should_be_at_least_
                     archived: false
-                    created_at: 1709051313
-                    updated_at: 1709051313
+                    created_at: 1709226858
+                    updated_at: 1709226858
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '325'
+                        id: '173'
                         workspace_id: this_is_an_id601_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -9072,12 +9084,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 112
+                        ticket_type_id: 54
                         archived: false
-                        created_at: 1709051313
-                        updated_at: 1709051313
+                        created_at: 1709226858
+                        updated_at: 1709226858
                       - type: ticket_type_attribute
-                        id: '327'
+                        id: '175'
                         workspace_id: this_is_an_id601_that_should_be_at_least_
                         name: name
                         description: description
@@ -9089,12 +9101,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 112
+                        ticket_type_id: 54
                         archived: false
-                        created_at: 1709051313
-                        updated_at: 1709051313
+                        created_at: 1709226858
+                        updated_at: 1709226858
                       - type: ticket_type_attribute
-                        id: '326'
+                        id: '174'
                         workspace_id: this_is_an_id601_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -9107,10 +9119,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 112
+                        ticket_type_id: 54
                         archived: false
-                        created_at: 1709051313
-                        updated_at: 1709051313
+                        created_at: 1709226858
+                        updated_at: 1709226858
               schema:
                 "$ref": "#/components/schemas/ticket_type"
         '401':
@@ -9121,7 +9133,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 27514daa-002c-41e0-81bd-21373d3ef319
+                    request_id: 3f54f1f0-0024-468a-981f-29c09172943a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9154,20 +9166,20 @@ paths:
                 Ticket type updated:
                   value:
                     type: ticket_type
-                    id: '114'
+                    id: '56'
                     name: Bug Report 2
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id605_that_should_be_at_least_
                     archived: false
-                    created_at: 1709051314
-                    updated_at: 1709051314
+                    created_at: 1709226859
+                    updated_at: 1709226859
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '331'
+                        id: '179'
                         workspace_id: this_is_an_id605_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -9180,12 +9192,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 114
+                        ticket_type_id: 56
                         archived: false
-                        created_at: 1709051314
-                        updated_at: 1709051314
+                        created_at: 1709226859
+                        updated_at: 1709226859
                       - type: ticket_type_attribute
-                        id: '333'
+                        id: '181'
                         workspace_id: this_is_an_id605_that_should_be_at_least_
                         name: name
                         description: description
@@ -9197,12 +9209,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 114
+                        ticket_type_id: 56
                         archived: false
-                        created_at: 1709051314
-                        updated_at: 1709051314
+                        created_at: 1709226859
+                        updated_at: 1709226859
                       - type: ticket_type_attribute
-                        id: '332'
+                        id: '180'
                         workspace_id: this_is_an_id605_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -9215,10 +9227,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 114
+                        ticket_type_id: 56
                         archived: false
-                        created_at: 1709051314
-                        updated_at: 1709051314
+                        created_at: 1709226859
+                        updated_at: 1709226859
               schema:
                 "$ref": "#/components/schemas/ticket_type"
         '401':
@@ -9229,7 +9241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c9ed4fbc-0c36-4835-a462-95e2f043591f
+                    request_id: d879cda4-57d4-4367-a767-a9e8c263ff88
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9274,7 +9286,7 @@ paths:
                 Admin note reply:
                   value:
                     type: ticket_part
-                    id: '151'
+                    id: '80'
                     part_type: note
                     body: |-
                       <h2>An Unordered HTML List</h2>
@@ -9289,10 +9301,10 @@ paths:
                       <li>Tea</li>
                       <li>Milk</li>
                       </ol>
-                    created_at: 1709051317
-                    updated_at: 1709051317
+                    created_at: 1709226862
+                    updated_at: 1709226862
                     author:
-                      id: '991268692'
+                      id: '991267656'
                       type: admin
                       name: Ciaran371 Lee
                       email: admin371@email.com
@@ -9308,7 +9320,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ea79d320-1cde-4ff1-b049-8f75e3952d2e
+                    request_id: 3381897b-e57e-4d3f-b996-b1824ba3272a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9325,7 +9337,7 @@ paths:
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991268692
+                  admin_id: 991267656
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -9351,27 +9363,27 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '703'
+                    id: '414'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '121'
+                      id: '63'
                       name: my-ticket-type-6
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id619_that_should_be_at_least_
                       archived: false
-                      created_at: 1709051321
-                      updated_at: 1709051321
+                      created_at: 1709226865
+                      updated_at: 1709226865
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '343'
+                          id: '191'
                           workspace_id: this_is_an_id619_that_should_be_at_least_
                           name: title
                           description: ola
@@ -9383,12 +9395,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 121
+                          ticket_type_id: 63
                           archived: false
-                          created_at: 1709051321
-                          updated_at: 1709051321
+                          created_at: 1709226866
+                          updated_at: 1709226866
                         - type: ticket_type_attribute
-                          id: '344'
+                          id: '192'
                           workspace_id: this_is_an_id619_that_should_be_at_least_
                           name: description
                           description: ola
@@ -9400,31 +9412,31 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 121
+                          ticket_type_id: 63
                           archived: false
-                          created_at: 1709051321
-                          updated_at: 1709051321
+                          created_at: 1709226866
+                          updated_at: 1709226866
                     contacts:
                       type: contact.list
                       contacts:
-                      - id: 65de0db9ba4d1202813d235a
+                      - id: 65e0bb726abd017c52346144
                         role: user
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709051321
-                    updated_at: 1709051322
+                    created_at: 1709226866
+                    updated_at: 1709226867
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '152'
+                        id: '81'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709051322
-                        updated_at: 1709051322
+                        created_at: 1709226867
+                        updated_at: 1709226867
                         author:
-                          id: '991268712'
+                          id: '991267676'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id619_that_should_be_at_least_@intercom.io
@@ -9441,7 +9453,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 84ede365-4cbb-4117-8dd9-6b33ea8ea91d
+                    request_id: 1ef64853-c3dc-46e9-8dc2-fcab40489865
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9456,9 +9468,9 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  ticket_type_id: 121
+                  ticket_type_id: 63
                   contacts:
-                  - id: 65de0db9ba4d1202813d235a
+                  - id: 65e0bb726abd017c52346144
                   ticket_attributes:
                     title: example
                     description: there is a problem
@@ -9489,27 +9501,27 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '704'
+                    id: '415'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: in_progress
                     ticket_type:
                       type: ticket_type
-                      id: '123'
+                      id: '65'
                       name: my-ticket-type-8
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id623_that_should_be_at_least_
                       archived: false
-                      created_at: 1709051323
-                      updated_at: 1709051323
+                      created_at: 1709226868
+                      updated_at: 1709226868
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '348'
+                          id: '196'
                           workspace_id: this_is_an_id623_that_should_be_at_least_
                           name: title
                           description: ola
@@ -9521,12 +9533,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 123
+                          ticket_type_id: 65
                           archived: false
-                          created_at: 1709051323
-                          updated_at: 1709051323
+                          created_at: 1709226868
+                          updated_at: 1709226868
                         - type: ticket_type_attribute
-                          id: '349'
+                          id: '197'
                           workspace_id: this_is_an_id623_that_should_be_at_least_
                           name: description
                           description: ola
@@ -9538,84 +9550,84 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 123
+                          ticket_type_id: 65
                           archived: false
-                          created_at: 1709051324
-                          updated_at: 1709051324
+                          created_at: 1709226868
+                          updated_at: 1709226868
                     contacts:
                       type: contact.list
                       contacts:
-                      - id: 65de0dbcba4d1202813d235b
+                      - id: 65e0bb756abd017c52346145
                         role: lead
-                    admin_assignee_id: '991268726'
+                    admin_assignee_id: '991267690'
                     team_assignee_id: '0'
-                    created_at: 1709051324
-                    updated_at: 1709051326
+                    created_at: 1709226869
+                    updated_at: 1709226871
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '153'
+                        id: '82'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709051324
-                        updated_at: 1709051324
+                        created_at: 1709226869
+                        updated_at: 1709226869
                         author:
-                          id: '991268724'
+                          id: '991267688'
                           type: admin
                           name: Ciaran401 Lee
                           email: admin401@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '154'
+                        id: '83'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709051325
-                        updated_at: 1709051325
+                        created_at: 1709226870
+                        updated_at: 1709226870
                         author:
-                          id: '991268725'
+                          id: '991267689'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id623_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '155'
+                        id: '84'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709051325
-                        updated_at: 1709051325
+                        created_at: 1709226870
+                        updated_at: 1709226870
                         author:
-                          id: '991268725'
+                          id: '991267689'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id623_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '156'
+                        id: '85'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: in_progress
                         previous_ticket_state: submitted
-                        created_at: 1709051326
-                        updated_at: 1709051326
+                        created_at: 1709226871
+                        updated_at: 1709226871
                         author:
-                          id: '991268725'
+                          id: '991267689'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id623_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '157'
+                        id: '86'
                         part_type: assignment
-                        created_at: 1709051326
-                        updated_at: 1709051326
+                        created_at: 1709226871
+                        updated_at: 1709226871
                         assigned_to:
                           type: admin
-                          id: '991268726'
+                          id: '991267690'
                         author:
-                          id: '991268724'
+                          id: '991267688'
                           type: admin
                           name: Ciaran401 Lee
                           email: admin401@email.com
@@ -9632,14 +9644,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 9dd1006f-5413-4324-a11c-8406a400933d
+                    request_id: 98fd3baf-0f29-4f0b-92ef-934641fa88cb
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
                 Assignee not found:
                   value:
                     type: error.list
-                    request_id: 6d132968-3ee6-4963-aa2e-0e95ae9dfbd4
+                    request_id: 8f91e3f3-4f50-4b47-aa64-f4b9112d26d9
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
@@ -9651,7 +9663,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b9d8f0bc-1891-4a13-984f-b79ebcbf7e61
+                    request_id: be6a4314-69ed-45de-9fcf-906b7ef3e7d8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9671,8 +9683,8 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991268724'
-                    assignee_id: '991268726'
+                    admin_id: '991267688'
+                    assignee_id: '991267690'
                   open: true
                   snoozed_until: 1673609604
               admin_not_found:
@@ -9684,7 +9696,7 @@ paths:
                   state: in_progress
                   assignment:
                     admin_id: '123'
-                    assignee_id: '991268734'
+                    assignee_id: '991267698'
               assignee_not_found:
                 summary: Assignee not found
                 value:
@@ -9693,7 +9705,7 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991268740'
+                    admin_id: '991267704'
                     assignee_id: '456'
     get:
       summary: Retrieve a ticket
@@ -9721,27 +9733,27 @@ paths:
                 Ticket found:
                   value:
                     type: ticket
-                    id: '707'
+                    id: '418'
                     ticket_attributes:
                       title: attribute_value
                       description:
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '127'
+                      id: '69'
                       name: my-ticket-type-12
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id631_that_should_be_at_least_
                       archived: false
-                      created_at: 1709051332
-                      updated_at: 1709051332
+                      created_at: 1709226878
+                      updated_at: 1709226878
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '359'
+                          id: '207'
                           workspace_id: this_is_an_id631_that_should_be_at_least_
                           name: title
                           description: ola
@@ -9753,12 +9765,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 127
+                          ticket_type_id: 69
                           archived: false
-                          created_at: 1709051332
-                          updated_at: 1709051332
+                          created_at: 1709226878
+                          updated_at: 1709226878
                         - type: ticket_type_attribute
-                          id: '360'
+                          id: '208'
                           workspace_id: this_is_an_id631_that_should_be_at_least_
                           name: description
                           description: ola
@@ -9770,31 +9782,31 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 127
+                          ticket_type_id: 69
                           archived: false
-                          created_at: 1709051333
-                          updated_at: 1709051333
+                          created_at: 1709226878
+                          updated_at: 1709226878
                     contacts:
                       type: contact.list
                       contacts:
-                      - id: 65de0dc5ba4d1202813d235e
+                      - id: 65e0bb7e6abd017c52346148
                         role: lead
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709051333
-                    updated_at: 1709051334
+                    created_at: 1709226878
+                    updated_at: 1709226879
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '160'
+                        id: '89'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709051334
-                        updated_at: 1709051334
+                        created_at: 1709226879
+                        updated_at: 1709226879
                         author:
-                          id: '991268753'
+                          id: '991267717'
                           type: admin
                           name: Ciaran427 Lee
                           email: admin427@email.com
@@ -9811,7 +9823,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cc3ca093-93fa-4937-901a-e86a61a2df8b
+                    request_id: 97572bcd-ab4b-430c-981b-c27a09c94707
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9843,26 +9855,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0dc8ba4d1202813d2361
+                    id: 65e0bb826abd017c5234614b
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Blue Cup
+                    pseudonym: Turquoise Glasses
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/blue-cup.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/turquoise-glasses.png
                     app_id: this_is_an_id638_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709051337
-                    remote_created_at: 1709051336
-                    signed_up_at: 1709051336
-                    updated_at: 1709051337
+                    created_at: 1709226882
+                    remote_created_at: 1709226882
+                    signed_up_at: 1709226882
+                    updated_at: 1709226883
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -9895,7 +9907,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: d9687c68-d74a-43c6-baa0-cb055a47a6be
+                    request_id: 9b8da192-5537-4f1b-b3fc-5f873d81aec4
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -9909,7 +9921,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b294f322-1694-4181-ac11-db09b6060d30
+                    request_id: 5d5ac1ec-10cb-4226-9665-705bfe471628
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9924,7 +9936,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 65de0dc8ba4d1202813d2361
+                  id: 65e0bb826abd017c5234614b
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -9957,7 +9969,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0dcaba4d1202813d2367
+                    id: 65e0bb846abd017c52346151
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -9973,10 +9985,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709051338
-                    remote_created_at: 1709051338
-                    signed_up_at: 1709051338
-                    updated_at: 1709051338
+                    created_at: 1709226884
+                    remote_created_at: 1709226884
+                    signed_up_at: 1709226884
+                    updated_at: 1709226884
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10009,7 +10021,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: '09d8d649-f6f1-40a0-a736-e2b631e3efd5'
+                    request_id: b9e5f19b-e423-4308-a02b-0944b3d69c8b
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -10023,7 +10035,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8142e972-e4d6-436a-b052-3eb8b25f32e8
+                    request_id: 1522a80d-fbfc-4236-9862-968f6f1d3f82
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10057,7 +10069,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0dccba4d1202813d236d
+                    id: 65e0bb866abd017c52346157
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -10073,10 +10085,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709051340
-                    remote_created_at: 1709051340
-                    signed_up_at: 1709051340
-                    updated_at: 1709051340
+                    created_at: 1709226886
+                    remote_created_at: 1709226886
+                    signed_up_at: 1709226886
+                    updated_at: 1709226886
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10109,7 +10121,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: 11f486fe-83e1-44b0-ae3d-cb58865b6e4d
+                    request_id: 0d2fb504-f7c3-453a-949a-db30cb3b1b0d
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -10123,7 +10135,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4e1b9f24-b08a-4342-9066-368050d00646
+                    request_id: 58e1bb43-04ec-4acc-b8e6-059eba9a0153
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10156,7 +10168,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65de0dcdba4d1202813d2373
+                    id: 65e0bb876abd017c5234615d
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -10172,10 +10184,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709051341
-                    remote_created_at: 1709051341
-                    signed_up_at: 1709051341
-                    updated_at: 1709051342
+                    created_at: 1709226887
+                    remote_created_at: 1709226887
+                    signed_up_at: 1709226887
+                    updated_at: 1709226888
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10208,7 +10220,7 @@ paths:
                 Visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 4bedcb2a-b297-4488-aa84-ee974a875439
+                    request_id: 1fb95927-0b4a-4669-ba1d-8e173d6f7c9a
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -10222,7 +10234,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a34a4f52-1c3f-47d0-956a-d68360624f39
+                    request_id: 06fca336-f59b-4b68-b4e1-0a8ce03466c6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10253,7 +10265,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65de0dcfba4d1202813d237a
+                    id: 65e0bb8a6abd017c52346164
                     workspace_id: this_is_an_id662_that_should_be_at_least_
                     external_id:
                     role: user
@@ -10268,9 +10280,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709051343
-                    updated_at: 1709051344
-                    signed_up_at: 1709051343
+                    created_at: 1709226890
+                    updated_at: 1709226890
+                    signed_up_at: 1709226889
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -10304,31 +10316,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65de0dcfba4d1202813d237a/tags"
+                      url: "/contacts/65e0bb8a6abd017c52346164/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65de0dcfba4d1202813d237a/notes"
+                      url: "/contacts/65e0bb8a6abd017c52346164/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65de0dcfba4d1202813d237a/companies"
+                      url: "/contacts/65e0bb8a6abd017c52346164/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0dcfba4d1202813d237a/subscriptions"
+                      url: "/contacts/65e0bb8a6abd017c52346164/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65de0dcfba4d1202813d237a/subscriptions"
+                      url: "/contacts/65e0bb8a6abd017c52346164/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -10347,7 +10359,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9f9e97f7-f56b-44e9-bebe-13b35f7bd3ad
+                    request_id: 49ecae63-47d0-4182-8fa8-143c0fd0392d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10639,12 +10651,32 @@ components:
           description: The id of the admin who is authoring the comment.
           example: '3156780'
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -11982,12 +12014,32 @@ components:
           type: string
           description: The email you have defined for the user.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -12015,12 +12067,32 @@ components:
           type: string
           description: The identifier for the contact as given by Intercom.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type
@@ -12048,12 +12120,32 @@ components:
           type: string
           description: The external_id you have defined for the contact.
         attachment_urls:
+          title: Attachment URLs
           type: array
           description: A list of image URLs that will be added as attachments. You
             can include up to 5 URLs.
           items:
             type: string
             format: uri
+          maxItems: 5
+        attachment_files:
+          title: Attachment Files
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 5 files.
+          items:
+            title: Attachment File
+            type: object
+            properties:
+              content-type:
+                type: string
+                description: The content type of the file.
+              data:
+                type: string
+                description: The base64 encoded file data.
+              name:
+                type: string
+                description: The name of the file.
           maxItems: 5
       required:
       - message_type

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991267222'
+                    id: '991269584'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1709226549
+                      created_at: 1709289735
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991267223'
+                    id: '991269585'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: c73b9754-8e97-4b71-90ce-da97c2698fb1
+                    request_id: 0535dcdc-01bc-46b2-825b-000d18fed074
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b87907a8-4a7d-42dc-bda9-65179f9a6b64
+                    request_id: 0c2b8565-3e90-4162-80f8-d8e4bf039bac
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: d660eb1f-1414-478b-a0a4-61ffa599b119
+                    - id: 377f575d-2a68-4ee3-991e-f7e10e6ab2d2
                       performed_by:
                         type: admin
-                        id: '991267227'
+                        id: '991269589'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1709226555
+                      created_at: 1709289741
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: 6c73d2b0-78d2-40a4-9f7e-6bf5e1cc02d8
+                    - id: 2b4d000f-a245-4873-b42d-afcab07ae623
                       performed_by:
                         type: admin
-                        id: '991267227'
+                        id: '991269589'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1709226555
+                      created_at: 1709289741
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '048db248-4907-48da-9d54-4881ddf15162'
+                    request_id: 5a7cb24b-5909-45d6-9abb-6a2528279f53
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991267229'
+                      id: '991269591'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e8c93084-5e5a-4576-b28f-6d7085ccd6df
+                    request_id: eecfb36a-9aea-4f96-a3f2-a7f322723a38
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991267231'
+                    id: '991269593'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 73f7b86f-ceb5-40a7-bcc6-96050fb115c8
+                    request_id: b6e639f4-5f8d-45cb-96e5-50f974b3d33c
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7b9f961c-bfe4-40c4-9ccf-f5f242eaeb1e
+                    request_id: cf00ef20-cd74-46ea-be68-b1a353e9fa1c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -390,20 +390,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '40'
+                    - id: '144'
                       type: article
                       workspace_id: this_is_an_id22_that_should_be_at_least_4
-                      parent_id: 149
+                      parent_id: 516
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991267234
+                      author_id: 991269596
                       state: published
-                      created_at: 1709226560
-                      updated_at: 1709226560
-                      url: http://help-center.test/myapp-22/en/articles/40-this-is-the-article-title
+                      created_at: 1709289746
+                      updated_at: 1709289746
+                      url: http://help-center.test/myapp-22/en/articles/144-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -414,7 +414,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 03b00bcb-9326-4569-bb81-2728b4c94a2d
+                    request_id: a02f123e-3614-4a09-bedd-36a5fc1f5f71
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -439,10 +439,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '43'
+                    id: '147'
                     type: article
                     workspace_id: this_is_an_id26_that_should_be_at_least_4
-                    parent_id: 151
+                    parent_id: 518
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -456,11 +456,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991267239
+                    author_id: 991269601
                     state: published
-                    created_at: 1709226562
-                    updated_at: 1709226562
-                    url: http://help-center.test/myapp-26/en/articles/43-thanks-for-everything
+                    created_at: 1709289748
+                    updated_at: 1709289748
+                    url: http://help-center.test/myapp-26/en/articles/147-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -471,7 +471,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 1c790ef6-bbd2-4586-af45-d8e755857575
+                    request_id: 979286ae-dd9a-4a2c-a2e6-a0f2c3a682fa
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -486,7 +486,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b01354eb-3b85-4bfc-9801-461985e3628f
+                    request_id: 0a93025a-07ac-49ac-9761-83144ddc5dbe
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -504,16 +504,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991267239
+                  author_id: 991269601
                   state: published
-                  parent_id: 151
+                  parent_id: 518
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991267239
+                      author_id: 991269601
                       state: published
               bad_request:
                 summary: Bad Request
@@ -550,10 +550,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '46'
+                    id: '150'
                     type: article
                     workspace_id: this_is_an_id32_that_should_be_at_least_4
-                    parent_id: 154
+                    parent_id: 521
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -567,11 +567,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991267244
+                    author_id: 991269606
                     state: published
-                    created_at: 1709226564
-                    updated_at: 1709226564
-                    url: http://help-center.test/myapp-32/en/articles/46-this-is-the-article-title
+                    created_at: 1709289750
+                    updated_at: 1709289750
+                    url: http://help-center.test/myapp-32/en/articles/150-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -582,7 +582,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: 4e630872-d7e5-4447-a968-2bdfc8fe32ca
+                    request_id: a3e7035f-22d2-4a39-ba39-5e79317577d2
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -596,7 +596,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4360f29e-a270-4798-a337-c203bfb8a602
+                    request_id: 71e6d3f3-7448-4753-a14f-397fd1a24aa0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -629,10 +629,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '49'
+                    id: '153'
                     type: article
                     workspace_id: this_is_an_id38_that_should_be_at_least_4
-                    parent_id: 157
+                    parent_id: 524
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -646,11 +646,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991267250
+                    author_id: 991269612
                     state: published
-                    created_at: 1709226566
-                    updated_at: 1709226567
-                    url: http://help-center.test/myapp-38/en/articles/49-christmas-is-here
+                    created_at: 1709289753
+                    updated_at: 1709289753
+                    url: http://help-center.test/myapp-38/en/articles/153-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -661,7 +661,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: d8d24f28-a8de-463a-bdab-571a6ff53343
+                    request_id: ffdd6722-a210-44a8-8533-619816bc7636
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -675,7 +675,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '088d9eff-00ab-4d89-bfc6-58ae34fc518b'
+                    request_id: 799fbbdb-dbf2-40a0-a58b-ede75ef964cf
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -723,7 +723,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '52'
+                    id: '156'
                     object: article
                     deleted: true
               schema:
@@ -736,7 +736,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: df66a981-1214-4651-a60f-df25411eb064
+                    request_id: e1368fdd-310b-44ce-a864-fad9e9e7d406
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -750,7 +750,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e9458c07-77b4-40fb-adf2-754c81261416
+                    request_id: d60c6e97-eb29-4612-80fc-47981ab6116d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -781,16 +781,16 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '165'
+                    - id: '532'
                       workspace_id: this_is_an_id52_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-52/collection-17
                       order: 17
-                      created_at: 1709226572
-                      updated_at: 1709226572
+                      created_at: 1709289759
+                      updated_at: 1709289759
                       description: english collection description
                       icon: bookmark
-                      help_center_id: 93
+                      help_center_id: 264
                       type: collection
                     total_count: 1
                     pages:
@@ -808,7 +808,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e8645c80-326f-4021-88f1-c51251438157
+                    request_id: e3de58ff-11a0-4f90-8a17-8965a632eb37
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -833,16 +833,16 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '171'
+                    id: '538'
                     workspace_id: this_is_an_id56_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-56/
                     order: 1
-                    created_at: 1709226573
-                    updated_at: 1709226573
+                    created_at: 1709289761
+                    updated_at: 1709289761
                     description: ''
                     icon: book-bookmark
-                    help_center_id: 95
+                    help_center_id: 266
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -854,7 +854,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 9eeab088-5b47-47f0-bf4e-5d0301bf848e
+                    request_id: f87366a6-3f7a-47fa-a6b5-5718bd6e25f6
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -868,7 +868,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6b94c487-5417-4461-8a8a-d3cc0fd3a6cf
+                    request_id: 740ec8b4-79ef-4eaf-97e2-3e3902fe9a9e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -916,16 +916,16 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '176'
+                    id: '543'
                     workspace_id: this_is_an_id62_that_should_be_at_least_4
                     name: English collection title
                     url: http://help-center.test/myapp-62/collection-22
                     order: 22
-                    created_at: 1709226574
-                    updated_at: 1709226574
+                    created_at: 1709289762
+                    updated_at: 1709289762
                     description: english collection description
                     icon: bookmark
-                    help_center_id: 98
+                    help_center_id: 269
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -937,7 +937,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 890faa12-c917-4c83-93e2-6bb5fd50e838
+                    request_id: 8c5d1b8f-9e48-4b22-b6c7-aa3cf436bc7f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -951,7 +951,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1ef4ec1f-f3c4-4322-8d2b-1bd67ebbedda
+                    request_id: dfdd17e3-f371-48a1-969a-e1f08023949b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -984,16 +984,16 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '182'
+                    id: '549'
                     workspace_id: this_is_an_id68_that_should_be_at_least_4
                     name: Update collection name
                     url: http://help-center.test/myapp-68/collection-25
                     order: 25
-                    created_at: 1709226575
-                    updated_at: 1709226576
+                    created_at: 1709289764
+                    updated_at: 1709289764
                     description: english collection description
                     icon: folder
-                    help_center_id: 101
+                    help_center_id: 272
                     type: collection
               schema:
                 "$ref": "#/components/schemas/collection"
@@ -1005,7 +1005,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: d4e3fa61-0f16-4db5-8e81-2714bf709976
+                    request_id: f812cf8b-4663-4c8c-9516-91d6500d719a
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1019,7 +1019,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a2816ff3-37c2-4279-8c0f-db12b80daf03
+                    request_id: 1b620ed2-5b07-4392-a32c-e0bd70b60f9d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1066,7 +1066,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '188'
+                    id: '555'
                     object: collection
                     deleted: true
               schema:
@@ -1079,7 +1079,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: 993f3f49-39e2-44d4-a64b-efd96ce86124
+                    request_id: 8d1e6684-c0f2-4003-a57d-7cb796637791
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1093,7 +1093,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 472cfa0b-778c-4413-a38e-4d9c81b6a8a3
+                    request_id: 15fe33e5-36eb-4e17-b9f5-800a3e03b043
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1127,10 +1127,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '107'
+                    id: '278'
                     workspace_id: this_is_an_id80_that_should_be_at_least_4
-                    created_at: 1709226579
-                    updated_at: 1709226579
+                    created_at: 1709289767
+                    updated_at: 1709289767
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1144,7 +1144,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: c49fe8c6-3c71-49c7-b6d3-4ba6b89ed237
+                    request_id: 5e9ce7e3-338e-49fb-916e-1c4c0903ec54
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1158,7 +1158,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 795cd671-92ab-493d-a0b1-cb9ba55269cc
+                    request_id: bf68d9da-145f-4914-b031-f59752aac8da
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1196,7 +1196,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6ed2e121-cee4-4e2f-ade7-0c4c33cc6512
+                    request_id: 1c906f23-5069-461b-af39-cf330b53bdea
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1228,15 +1228,15 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '195'
+                    - id: '562'
                       workspace_id: this_is_an_id90_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-90/section-15
                       order: 15
-                      created_at: 1709226581
-                      updated_at: 1709226581
+                      created_at: 1709289769
+                      updated_at: 1709289769
                       type: section
-                      parent_id: 194
+                      parent_id: 561
                     total_count: 1
                     pages:
                       type: pages
@@ -1253,7 +1253,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f32ef4a8-b5fa-43d4-b215-fcca5a297c21
+                    request_id: 1d9544da-101f-47d1-a3c8-293e1dc4bbf9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1278,15 +1278,15 @@ paths:
               examples:
                 section created:
                   value:
-                    id: '200'
+                    id: '567'
                     workspace_id: this_is_an_id94_that_should_be_at_least_4
                     name: Thanks for everything
                     url: http://help-center.test/myapp-94/
                     order: 1
-                    created_at: 1709226582
-                    updated_at: 1709226582
+                    created_at: 1709289770
+                    updated_at: 1709289770
                     type: section
-                    parent_id: '198'
+                    parent_id: '565'
               schema:
                 "$ref": "#/components/schemas/section"
         '401':
@@ -1297,7 +1297,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 765f7ee2-f274-4db3-9379-7640588d72e1
+                    request_id: 7f6016fe-d536-4982-94fc-3101e42780b2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1313,7 +1313,7 @@ paths:
                 summary: section created
                 value:
                   name: Thanks for everything
-                  parent_id: 198
+                  parent_id: 565
   "/help_center/sections/{id}":
     get:
       summary: Retrieve a section
@@ -1342,15 +1342,15 @@ paths:
               examples:
                 Section found:
                   value:
-                    id: '204'
+                    id: '571'
                     workspace_id: this_is_an_id98_that_should_be_at_least_4
                     name: English section title
                     url: http://help-center.test/myapp-98/section-19
                     order: 19
-                    created_at: 1709226583
-                    updated_at: 1709226583
+                    created_at: 1709289771
+                    updated_at: 1709289771
                     type: section
-                    parent_id: 203
+                    parent_id: 570
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1361,7 +1361,7 @@ paths:
                 Section not found:
                   value:
                     type: error.list
-                    request_id: a389c685-d02a-4e30-b434-673846e51796
+                    request_id: 04d38d75-19e1-401c-9dde-b26413faa427
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1375,7 +1375,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b468fc68-35ce-44f1-9836-f554f7c01c02
+                    request_id: 8a8e9579-fa92-4dcb-9305-9c9dd1eda72c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1408,15 +1408,15 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '210'
+                    id: '577'
                     workspace_id: this_is_an_id104_that_should_be_at_least_
                     name: Update section name
                     url: http://help-center.test/myapp-104/section-22
                     order: 22
-                    created_at: 1709226584
-                    updated_at: 1709226584
+                    created_at: 1709289773
+                    updated_at: 1709289773
                     type: section
-                    parent_id: '209'
+                    parent_id: '576'
               schema:
                 "$ref": "#/components/schemas/section"
         '404':
@@ -1427,7 +1427,7 @@ paths:
                 Section Not Found:
                   value:
                     type: error.list
-                    request_id: 7ee9d415-d886-409a-b75d-0b4e48bd0da6
+                    request_id: 2988b0c3-a963-4cc5-9596-d8bb7e5dde1a
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1441,7 +1441,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 52949b20-f2a0-4707-ad10-151cf1ff4b25
+                    request_id: 1d052db5-81c1-4822-be9d-c690fada077d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1457,12 +1457,12 @@ paths:
                 summary: successful
                 value:
                   name: Update section name
-                  parent_id: 209
+                  parent_id: 576
               section_not_found:
                 summary: Section Not Found
                 value:
                   name: Update section name
-                  parent_id: 211
+                  parent_id: 578
     delete:
       summary: Delete a section
       parameters:
@@ -1489,7 +1489,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '216'
+                    id: '583'
                     object: section
                     deleted: true
               schema:
@@ -1502,7 +1502,7 @@ paths:
                 section Not Found:
                   value:
                     type: error.list
-                    request_id: 1608ce80-59ef-40d4-ab41-30373bc43e49
+                    request_id: 3efa333e-5b01-48a4-b18e-1cda15720a3d
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1516,7 +1516,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6d6a9a2a-0f52-4809-9881-770fc6f6d92c
+                    request_id: 1d85de88-589f-4da5-a9d9-aedb54402a83
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1549,12 +1549,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 65e0ba5c6abd017c52345fe9
+                    id: 65e1b130ba4d1239c7e51935
                     app_id: this_is_an_id116_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1709226588
-                    updated_at: 1709226588
+                    created_at: 1709289776
+                    updated_at: 1709289776
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1591,7 +1591,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 14c1970c-4416-46e6-adb2-0a55ad952e01
+                    request_id: fe8adb6c-4163-40d7-ba2d-d56ba12cc886
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1689,12 +1689,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0ba5d6abd017c52345ff1
+                      id: 65e1b132ba4d1239c7e5193d
                       app_id: this_is_an_id122_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709226589
-                      created_at: 1709226589
-                      updated_at: 1709226589
+                      remote_created_at: 1709289778
+                      created_at: 1709289778
+                      updated_at: 1709289778
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -1723,7 +1723,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 89d5cb28-0183-4d2e-965d-457f13f8ac02
+                    request_id: 9237a5da-257a-4d1e-b02c-09a5f757f7bb
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1737,7 +1737,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a17c88c5-7960-45e9-9fbb-48c635d8dab8
+                    request_id: '09353c71-2ac6-4c1d-b026-849626d274dd'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1772,12 +1772,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0ba606abd017c52345ffc
+                    id: 65e1b135ba4d1239c7e51948
                     app_id: this_is_an_id128_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1709226592
-                    created_at: 1709226592
-                    updated_at: 1709226592
+                    remote_created_at: 1709289781
+                    created_at: 1709289781
+                    updated_at: 1709289781
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1799,7 +1799,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 8e7ec44d-a70f-4da7-85f0-5bd1054709c0
+                    request_id: d23ac53a-4df1-4a61-b386-1c336bd3eb1b
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1813,7 +1813,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 48de211c-01d0-4831-af65-e8aa6bde98df
+                    request_id: cda8cddb-dabf-4a90-a6f6-c5adac613cdb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1847,12 +1847,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0ba626abd017c52346006
+                    id: 65e1b137ba4d1239c7e51952
                     app_id: this_is_an_id134_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1709226594
-                    created_at: 1709226594
-                    updated_at: 1709226594
+                    remote_created_at: 1709289783
+                    created_at: 1709289783
+                    updated_at: 1709289783
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -1874,7 +1874,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: ef1e850e-f135-4860-af84-26366d12ce30
+                    request_id: 6ab6133b-790d-4df9-a612-69f55993d3a0
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1888,7 +1888,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3d131749-27a2-48f0-83b5-fbb4b9a8e6d8
+                    request_id: 2bf133f0-7148-426a-85e0-e2047b606d05
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1920,7 +1920,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 65e0ba646abd017c52346010
+                    id: 65e1b13aba4d1239c7e5195c
                     object: company
                     deleted: true
               schema:
@@ -1933,7 +1933,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 7cbf86f1-c23a-464a-b604-98edf209dc7e
+                    request_id: 2d28bc85-dcce-4ec5-b42e-7077e7001a7f
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -1947,7 +1947,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '082de709-5df1-4c38-9a21-bb5af7285286'
+                    request_id: 6fde8223-3f99-4543-a2b6-4841bfff1475
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1999,7 +1999,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 40b2c4aa-a40c-489b-8b1e-ed7b1c0a24e4
+                    request_id: 53a6d2be-8f79-46c8-86dc-38414f6156dd
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2013,7 +2013,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 79fb849a-7235-437a-a947-4135e1df7b5d
+                    request_id: 42f07ddc-2a41-4ce9-817d-811d652a85db
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2058,7 +2058,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 57aaa1af-e74b-429c-ab6b-81fafadee188
+                    request_id: a559f3ee-7cff-4101-b5a7-bcce233f4174
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2072,7 +2072,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2030c6a6-ad92-4cb9-98ac-5ba205bc181d
+                    request_id: 0ca8de63-e980-4415-b0af-0507f8fcee82
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2129,12 +2129,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0ba6a6abd017c5234602c
+                      id: 65e1b140ba4d1239c7e51978
                       app_id: this_is_an_id158_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709226602
-                      created_at: 1709226602
-                      updated_at: 1709226602
+                      remote_created_at: 1709289792
+                      created_at: 1709289792
+                      updated_at: 1709289792
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2163,7 +2163,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3ac411ee-e236-4573-8a00-75b0889f4e08
+                    request_id: ab09afbc-0bcd-4602-80a4-7695c6e073ea
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2215,12 +2215,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 65e0ba6c6abd017c52346032
+                      id: 65e1b141ba4d1239c7e5197e
                       app_id: this_is_an_id162_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1709226604
-                      created_at: 1709226604
-                      updated_at: 1709226604
+                      remote_created_at: 1709289793
+                      created_at: 1709289793
+                      updated_at: 1709289793
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2234,7 +2234,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: 746aa969-55d6-44c3-8939-f7bf3c39e91e
+                    scroll_param: 820a6790-888d-41c0-964d-80e29a683cb3
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2245,7 +2245,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1309f095-7977-48a1-a534-33f73ca9e37a
+                    request_id: 8fc81143-eab6-4f8c-a709-d0f098803e56
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2280,12 +2280,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0ba6d6abd017c5234603b
+                    id: 65e1b143ba4d1239c7e51987
                     app_id: this_is_an_id166_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1709226605
-                    created_at: 1709226605
-                    updated_at: 1709226605
+                    remote_created_at: 1709289795
+                    created_at: 1709289795
+                    updated_at: 1709289795
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2307,7 +2307,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 1b959dbd-6d4b-49e2-beb1-72f5b5dc87e6
+                    request_id: 284344eb-b3fc-4dfa-8f82-3b08173ff600
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2321,7 +2321,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: ebf19bdf-d5a6-4a5c-9f98-a8f67b2b8cf4
+                    request_id: 2e8bd404-f849-47c2-b6d4-d7128bcd23ec
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2335,7 +2335,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8e6015c8-5fd2-4a04-8c51-575f3dfb6d7a
+                    request_id: 3b3183d2-2639-4787-8c23-da61a37de51a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2358,7 +2358,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 65e0ba6d6abd017c5234603b
+                  id: 65e1b143ba4d1239c7e51987
               bad_request:
                 summary: Bad Request
                 value:
@@ -2397,13 +2397,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 65e0ba736abd017c5234605c
+                      id: 65e1b14aba4d1239c7e519a8
                       app_id: this_is_an_id182_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1709226611
-                      created_at: 1709226611
-                      updated_at: 1709226611
-                      last_request_at: 1709053811
+                      remote_created_at: 1709289802
+                      created_at: 1709289802
+                      updated_at: 1709289802
+                      last_request_at: 1709117002
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2432,7 +2432,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 11d1697e-4d99-426d-8c4e-c5ef5a9c5840
+                    request_id: 2d136e03-51f7-4691-a7e8-509a1f826069
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2446,7 +2446,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f6bf4863-1fff-442f-adc8-5caa361f1110
+                    request_id: b8e21236-0910-4dbe-8868-becdf9dcda23
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2489,12 +2489,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 65e0ba706abd017c5234604b
+                    id: 65e1b146ba4d1239c7e51997
                     app_id: this_is_an_id174_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1709226608
-                    created_at: 1709226608
-                    updated_at: 1709226609
+                    remote_created_at: 1709289798
+                    created_at: 1709289798
+                    updated_at: 1709289799
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2516,14 +2516,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 06b549b5-15ae-4432-b02e-6f54e7d35aac
+                    request_id: d6a4118a-b722-4dd3-a15c-d89d0706bc56
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: bd52cd8f-8d29-4597-ae3e-ac6a44057ecc
+                    request_id: b51523ec-9851-452a-a59c-c3a697e01d43
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2537,7 +2537,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 71efb6ab-526d-46ec-bb25-25d76a23ef08
+                    request_id: 3b5328d2-d85f-4427-a893-b5aaeb989503
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2573,42 +2573,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '29'
-                      created_at: 1708621814
+                      id: '91'
+                      created_at: 1708685005
                       contact:
                         type: contact
-                        id: 65e0ba766abd017c52346067
+                        id: 65e1b14dba4d1239c7e519b3
                       author:
                         type: admin
-                        id: '991267332'
+                        id: '991269694'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '28'
-                      created_at: 1708535414
+                      id: '90'
+                      created_at: 1708598605
                       contact:
                         type: contact
-                        id: 65e0ba766abd017c52346067
+                        id: 65e1b14dba4d1239c7e519b3
                       author:
                         type: admin
-                        id: '991267332'
+                        id: '991269694'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '27'
-                      created_at: 1708535414
+                      id: '89'
+                      created_at: 1708598604
                       contact:
                         type: contact
-                        id: 65e0ba766abd017c52346067
+                        id: 65e1b14dba4d1239c7e519b3
                       author:
                         type: admin
-                        id: '991267332'
+                        id: '991269694'
                         name: Ciaran110 Lee
                         email: admin110@email.com
                         away_mode_enabled: false
@@ -2631,7 +2631,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 3984b9be-d417-4708-b46c-506c2f43e187
+                    request_id: ece73f79-bd02-4b31-99a1-a861f98a4e50
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2665,14 +2665,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '34'
-                    created_at: 1709226615
+                    id: '96'
+                    created_at: 1709289806
                     contact:
                       type: contact
-                      id: 65e0ba776abd017c52346069
+                      id: 65e1b14eba4d1239c7e519b5
                     author:
                       type: admin
-                      id: '991267334'
+                      id: '991269696'
                       name: Ciaran112 Lee
                       email: admin112@email.com
                       away_mode_enabled: false
@@ -2688,14 +2688,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 21dd7a96-f283-45a4-8133-fcf71446abc1
+                    request_id: 8f4af4b6-6685-438c-900f-c99099adde62
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 19889aa0-ad21-4744-bef7-dfe8718c0498
+                    request_id: d2744216-f274-4edc-aad9-10e0ead9a2db
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2725,20 +2725,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 65e0ba776abd017c52346069
-                  admin_id: 991267334
+                  contact_id: 65e1b14eba4d1239c7e519b5
+                  admin_id: 991269696
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 65e0ba776abd017c5234606a
+                  contact_id: 65e1b14eba4d1239c7e519b6
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991267336
+                  admin_id: 991269698
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -2771,10 +2771,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 65e0ba796abd017c5234606c
+                      id: 65e1b150ba4d1239c7e519b8
                       name: segment
-                      created_at: 1709226617
-                      updated_at: 1709226617
+                      created_at: 1709289808
+                      updated_at: 1709289808
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -2786,7 +2786,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 0f632ccb-622c-4f1a-8415-1988bf2f5b15
+                    request_id: f5751165-c2b9-4366-a9e7-b708b305b505
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2800,7 +2800,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8d432a2e-eef7-4d54-af1b-6d81e69c39e7
+                    request_id: 7909bce4-8477-4b8e-81e2-775469a2b7dc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2844,7 +2844,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '93'
+                      id: '321'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -2858,7 +2858,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '95'
+                      id: '323'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -2881,7 +2881,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 7e62d7cc-9d11-4ef0-a7f8-2fd7b2d8b04f
+                    request_id: d12dcdd1-4225-4433-8328-58e083886412
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2895,7 +2895,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 73c042c7-fef9-4b67-b0b8-7872ce3ca858
+                    request_id: 206674cf-2ad6-4d65-acad-2223b518b895
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2936,7 +2936,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '108'
+                    id: '336'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -2959,14 +2959,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 47a894d3-acf3-4a90-a92d-77c8cdd630f1
+                    request_id: b3105e47-4419-4a54-83fa-d40637a8e9d1
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 756ccc30-7825-4472-84bf-eec6663ff35a
+                    request_id: c548e0d8-8a3c-4283-8db8-aa156ff26bd2
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -2980,7 +2980,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 396a86c8-dc17-4e0a-8a4e-61a21813a23d
+                    request_id: c334bc4a-ac4f-46d2-83c5-8186acc1366c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3008,12 +3008,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 108
+                  id: 336
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 112
+                  id: 340
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -3059,7 +3059,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '124'
+                    id: '352'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3082,14 +3082,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 1070efaa-5527-418f-a09d-9598a9e11d52
+                    request_id: debe22bf-8c98-4ac3-84b2-1fa2da014e0e
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 1857f54f-890a-4490-9d26-4b72f0192d22
+                    request_id: 21bbd86d-8544-4a13-8dbd-cdecde8c972e
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3103,7 +3103,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2cb56b4f-68d2-4c9c-ba46-1e54b5aa17d3
+                    request_id: b0ac1aa2-5620-44e8-b600-318c0952a74e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3141,7 +3141,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '83'
+                      id: '271'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -3153,7 +3153,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: fcc6b834-53aa-4a2a-819e-edbbdaa9f6a0
+                    request_id: 94e6e598-2b4c-48a4-beeb-3bc2678596c8
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3167,7 +3167,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a3a12ccb-c8d4-4f0a-83dd-9f393c828139
+                    request_id: 312f2786-b498-41b7-b7aa-33dce1896137
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3202,7 +3202,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '84'
+                    id: '272'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3214,14 +3214,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: fd3fd08a-0b67-436b-80b4-bbf8b8438a98
+                    request_id: cb624fd3-5d21-44e4-ae8b-1966f0b2a2f5
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: d933b04e-b143-4488-a8f3-90e9ac042a2f
+                    request_id: 8105a9e3-8213-40ff-bf47-260197ccb290
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3235,7 +3235,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 76849cf6-fc70-42a9-906e-3b2fc833dd54
+                    request_id: b748d414-6546-4c6e-a34d-d6eca2ea435e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3258,11 +3258,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 84
+                  id: 272
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 85
+                  id: 273
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3304,7 +3304,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '87'
+                    id: '275'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3316,14 +3316,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 80830263-b52f-4dd7-929b-a4528e422c86
+                    request_id: 94b5a772-db12-4745-afd1-1aca8ac5fc64
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: d522ac0c-045c-42bb-9bbe-38e0b29c24dc
+                    request_id: d5ccf344-f7e4-4db1-a4aa-064c6131acd1
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3337,7 +3337,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 892d14ed-c5c6-4a92-8717-f066122eef0d
+                    request_id: 46ad8062-c2bc-46a1-a121-5bbec6e5471f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3371,7 +3371,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0ba876abd017c52346083
+                    id: 65e1b15eba4d1239c7e519cf
                     workspace_id: this_is_an_id248_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3386,9 +3386,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226631
-                    updated_at: 1709226631
-                    signed_up_at: 1709226631
+                    created_at: 1709289822
+                    updated_at: 1709289823
+                    signed_up_at: 1709289822
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3422,31 +3422,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba876abd017c52346083/tags"
+                      url: "/contacts/65e1b15eba4d1239c7e519cf/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba876abd017c52346083/notes"
+                      url: "/contacts/65e1b15eba4d1239c7e519cf/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba876abd017c52346083/companies"
+                      url: "/contacts/65e1b15eba4d1239c7e519cf/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba876abd017c52346083/subscriptions"
+                      url: "/contacts/65e1b15eba4d1239c7e519cf/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba876abd017c52346083/subscriptions"
+                      url: "/contacts/65e1b15eba4d1239c7e519cf/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3465,7 +3465,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 365d431a-5dab-44ba-9291-46e3ccfafd3f
+                    request_id: de797215-60d9-43c2-8133-b88ded68765d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3510,7 +3510,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0ba886abd017c52346084
+                    id: 65e1b160ba4d1239c7e519d0
                     workspace_id: this_is_an_id252_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3525,9 +3525,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226632
-                    updated_at: 1709226632
-                    signed_up_at: 1709226632
+                    created_at: 1709289824
+                    updated_at: 1709289824
+                    signed_up_at: 1709289824
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3561,31 +3561,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba886abd017c52346084/tags"
+                      url: "/contacts/65e1b160ba4d1239c7e519d0/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba886abd017c52346084/notes"
+                      url: "/contacts/65e1b160ba4d1239c7e519d0/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba886abd017c52346084/companies"
+                      url: "/contacts/65e1b160ba4d1239c7e519d0/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba886abd017c52346084/subscriptions"
+                      url: "/contacts/65e1b160ba4d1239c7e519d0/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba886abd017c52346084/subscriptions"
+                      url: "/contacts/65e1b160ba4d1239c7e519d0/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3604,7 +3604,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b03b9f9e-7db5-4c43-9d43-f58f481c778e
+                    request_id: 12bf49ec-2b15-4d0e-b7d9-ba2ea66db236
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3635,7 +3635,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0ba8a6abd017c52346085
+                    id: 65e1b161ba4d1239c7e519d1
                     object: contact
                     deleted: true
               schema:
@@ -3648,7 +3648,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 24491086-9f51-4db0-8b56-350971f921ca
+                    request_id: 65260095-91c8-4bac-972b-baf0b64cc4d6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3676,7 +3676,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0ba8b6abd017c52346087
+                    id: 65e1b163ba4d1239c7e519d3
                     workspace_id: this_is_an_id260_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3691,9 +3691,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226635
-                    updated_at: 1709226635
-                    signed_up_at: 1709226635
+                    created_at: 1709289827
+                    updated_at: 1709289827
+                    signed_up_at: 1709289827
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3727,31 +3727,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba8b6abd017c52346087/tags"
+                      url: "/contacts/65e1b163ba4d1239c7e519d3/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba8b6abd017c52346087/notes"
+                      url: "/contacts/65e1b163ba4d1239c7e519d3/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba8b6abd017c52346087/companies"
+                      url: "/contacts/65e1b163ba4d1239c7e519d3/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba8b6abd017c52346087/subscriptions"
+                      url: "/contacts/65e1b163ba4d1239c7e519d3/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba8b6abd017c52346087/subscriptions"
+                      url: "/contacts/65e1b163ba4d1239c7e519d3/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3770,7 +3770,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c2c0fbf3-f94c-431b-a4ed-246f14e8ebe9
+                    request_id: 99f3976d-e784-478e-a40a-c8cb95f08cf3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3785,8 +3785,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 65e0ba8b6abd017c52346086
-                  into: 65e0ba8b6abd017c52346087
+                  from: 65e1b163ba4d1239c7e519d2
+                  into: 65e1b163ba4d1239c7e519d3
   "/contacts/search":
     post:
       summary: Search contacts
@@ -3915,7 +3915,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c668a6a0-2b61-4fd4-9f71-fb01d883f54b
+                    request_id: a63ca99d-6ed0-4b27-a6d0-19a5206a08bf
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3935,15 +3935,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: 65e0ba8d6abd017c5234608a
+                      value: 65e1b165ba4d1239c7e519d6
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: 65e0ba8d6abd017c5234608a
+                        value: 65e1b165ba4d1239c7e519d6
                       - field: id
                         operator: "="
-                        value: 65e0ba8d6abd017c5234608a
+                        value: 65e1b165ba4d1239c7e519d6
   "/contacts":
     get:
       summary: List all contacts
@@ -3982,7 +3982,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 42d55057-8b82-4d55-b92c-fd09e9f0c7c8
+                    request_id: 2d38659e-1677-40f9-9c9e-1852eeb8c2e5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4008,7 +4008,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0ba8f6abd017c5234608c
+                    id: 65e1b168ba4d1239c7e519d8
                     workspace_id: this_is_an_id272_that_should_be_at_least_
                     external_id:
                     role: user
@@ -4023,8 +4023,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226639
-                    updated_at: 1709226639
+                    created_at: 1709289832
+                    updated_at: 1709289832
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -4059,31 +4059,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba8f6abd017c5234608c/tags"
+                      url: "/contacts/65e1b168ba4d1239c7e519d8/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba8f6abd017c5234608c/notes"
+                      url: "/contacts/65e1b168ba4d1239c7e519d8/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba8f6abd017c5234608c/companies"
+                      url: "/contacts/65e1b168ba4d1239c7e519d8/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba8f6abd017c5234608c/subscriptions"
+                      url: "/contacts/65e1b168ba4d1239c7e519d8/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0ba8f6abd017c5234608c/subscriptions"
+                      url: "/contacts/65e1b168ba4d1239c7e519d8/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4102,7 +4102,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8ffc7f40-0263-4d97-ab2d-3f7a392a19fe
+                    request_id: cbd401d3-3de5-4716-be0a-9361764b97aa
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4146,7 +4146,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0ba906abd017c5234608d
+                    id: 65e1b169ba4d1239c7e519d9
                     object: contact
                     archived: true
               schema:
@@ -4178,7 +4178,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 65e0ba916abd017c5234608e
+                    id: 65e1b16aba4d1239c7e519da
                     object: contact
                     archived: false
               schema:
@@ -4213,7 +4213,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '89'
+                    id: '277'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4225,7 +4225,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 0ce8b463-1f5d-434e-b9b5-9ea9dd054938
+                    request_id: ad4dcb14-3b1b-40d1-8dda-b1431acf399a
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4239,7 +4239,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3693e691-a217-4ff8-a5cd-ce7d71dae432
+                    request_id: 164c1edd-574a-48a1-8382-108ce43bae90
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4268,13 +4268,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 89
-                  admin_id: 991267367
+                  id: 277
+                  admin_id: 991269729
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 90
-                  admin_id: 991267369
+                  id: 278
+                  admin_id: 991269731
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4312,7 +4312,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '92'
+                    id: '280'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4324,14 +4324,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 852806de-e888-452e-b547-57061e5c03da
+                    request_id: b362e892-2c10-4cab-afe0-b1c8cb03e2fb
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: d5fa19f2-238a-44c1-bd40-2e64040ab09a
+                    request_id: 7a5eb970-d01b-44d2-a30f-e5c0422a9bfc
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4345,7 +4345,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d699cd0e-f863-4a8d-a86b-82e9237b9c51
+                    request_id: 51715963-9f48-4fb3-a208-622258c1fb42
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4368,15 +4368,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991267371
+                  admin_id: 991269733
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991267373
+                  admin_id: 991269735
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991267374
+                  admin_id: 991269736
   "/conversations":
     get:
       summary: List all conversations
@@ -4423,20 +4423,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '280'
-                      created_at: 1709226649
-                      updated_at: 1709226649
+                      id: '878'
+                      created_at: 1709289844
+                      updated_at: 1709289844
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918228'
+                        id: '403918575'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991267377'
+                          id: '991269739'
                           name: Ciaran152 Lee
                           email: admin152@email.com
                         attachments: []
@@ -4446,7 +4446,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0ba986abd017c52346092
+                          id: 65e1b174ba4d1239c7e519de
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -4475,7 +4475,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fad3c282-dfe7-49c6-a4f2-a75a823c88b6
+                    request_id: d17285e4-21ee-4f4f-9eae-971966c8f4e5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4489,7 +4489,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 671137f4-b4fd-4974-82d6-9d478e1db5db
+                    request_id: 78856659-42f6-4ec9-88ca-7e1f01dc2e4d
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4525,11 +4525,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918238'
-                    created_at: 1709226671
+                    id: '403918585'
+                    created_at: 1709289884
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '305'
+                    conversation_id: '903'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -4540,7 +4540,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 66d07e59-b59a-4a03-b416-ba106b731425
+                    request_id: 22971eda-db70-4c38-a0ae-759046e76a6c
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -4554,7 +4554,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f39f4bda-9c38-483e-a768-57f8d11ff12b
+                    request_id: 597c1e99-4966-453e-b499-6e1c4d815135
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4568,7 +4568,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 4595736a-0e0a-41ed-b21c-1f42a8c4fa33
+                    request_id: 69375b30-1aed-43fb-9322-088cbde04c99
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4585,7 +4585,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65e0baae6abd017c523460a7
+                    id: 65e1b19aba4d1239c7e519f3
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -4643,20 +4643,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '309'
-                    created_at: 1709226678
-                    updated_at: 1709226678
+                    id: '907'
+                    created_at: 1709289893
+                    updated_at: 1709289893
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918242'
+                      id: '403918589'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267391'
+                        id: '991269753'
                         name: Ciaran159 Lee
                         email: admin159@email.com
                       attachments: []
@@ -4666,7 +4666,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bab66abd017c523460ab
+                        id: 65e1b1a4ba4d1239c7e519f7
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4699,7 +4699,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: af4e92d4-75b5-40c2-9cfb-15b2a6d48323
+                    request_id: 99075f58-0a36-4629-8ad7-f7511d690f47
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4713,7 +4713,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3c7b4ae8-9bea-42a5-9657-f15dbae7f680
+                    request_id: fdab8e7d-7065-4a7a-bbd2-0832836f374f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4727,7 +4727,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 5134203c-daac-48c4-b161-fed393e7e945
+                    request_id: 6d2faba1-7942-4ce8-b252-f1c81cf61dfb
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4774,20 +4774,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '313'
-                    created_at: 1709226683
-                    updated_at: 1709226685
+                    id: '911'
+                    created_at: 1709289901
+                    updated_at: 1709289903
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918246'
+                      id: '403918593'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267399'
+                        id: '991269761'
                         name: Ciaran163 Lee
                         email: admin163@email.com
                       attachments: []
@@ -4797,7 +4797,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0babb6abd017c523460af
+                        id: 65e1b1adba4d1239c7e519fb
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -4822,15 +4822,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '56'
+                        id: '217'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709226684
-                        updated_at: 1709226684
-                        notified_at: 1709226684
+                        created_at: 1709289903
+                        updated_at: 1709289903
+                        notified_at: 1709289903
                         assigned_to:
                         author:
-                          id: '991267400'
+                          id: '991269762'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4838,15 +4838,15 @@ paths:
                         external_id:
                         redacted: false
                       - type: conversation_part
-                        id: '57'
+                        id: '218'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1709226685
-                        updated_at: 1709226685
-                        notified_at: 1709226685
+                        created_at: 1709289903
+                        updated_at: 1709289903
+                        notified_at: 1709289903
                         assigned_to:
                         author:
-                          id: '991267400'
+                          id: '991269762'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id316_that_should_be_at_least_@intercom.io
@@ -4864,7 +4864,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 86f5f6b2-779c-4393-9408-1271ff5bc6d5
+                    request_id: 82c4c3ba-2787-4d7a-b4a5-67dec64ae8d2
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -4878,7 +4878,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 396125cd-c7a5-46c9-95b6-9bc1b9772e24
+                    request_id: 8b95d35f-8030-42ae-a2b9-1bf8bcf58406
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4892,7 +4892,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 3d0c9768-98b1-4837-9b4c-53f2c800893e
+                    request_id: 6f606ee9-4e77-4bfe-bb78-9151684c1941
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -4947,57 +4947,57 @@ paths:
 
         Most keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `"foorbar"`).
 
-        | Field                                     | Type                                                                                     |
-        | :---------------------------------------- | :--------------------------------------------------------------------------------------- |
-        | id                                        | String                                                                                   |
-        | created_at                                | Date (UNIX timestamp)                                                                    |
-        | updated_at                                | Date (UNIX timestamp)                                                                    |
-        | source.type                               | String<br>Accepted fields are `conversation`, `push`, `facebook`, `twitter` and `email`. |
-        | source.id                                 | String                                                                                   |
-        | source.delivered_as                       | String                                                                                   |
-        | source.subject                            | String                                                                                   |
-        | source.body                               | String                                                                                   |
-        | source.author.id                          | String                                                                                   |
-        | source.author.type                        | String                                                                                   |
-        | source.author.name                        | String                                                                                   |
-        | source.author.email                       | String                                                                                   |
-        | source.url                                | String                                                                                   |
-        | contact_ids                               | String                                                                                   |
-        | teammate_ids                              | String                                                                                   |
-        | admin_assignee_id                         | String                                                                                   |
-        | team_assignee_id                          | String                                                                                   |
-        | channel_initiated                         | String                                                                                   |
-        | open                                      | Boolean                                                                                  |
-        | read                                      | Boolean                                                                                  |
-        | state                                     | String                                                                                   |
-        | waiting_since                             | Date (UNIX timestamp)                                                                    |
-        | snoozed_until                             | Date (UNIX timestamp)                                                                    |
-        | tag_ids                                   | String                                                                                   |
-        | priority                                  | String                                                                                   |
-        | statistics.time_to_assignment             | Integer                                                                                  |
-        | statistics.time_to_admin_reply            | Integer                                                                                  |
-        | statistics.time_to_first_close            | Integer                                                                                  |
-        | statistics.time_to_last_close             | Integer                                                                                  |
-        | statistics.median_time_to_reply           | Integer                                                                                  |
-        | statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                    |
-        | statistics.first_assignment_at            | Date (UNIX timestamp)                                                                    |
-        | statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                    |
-        | statistics.first_close_at                 | Date (UNIX timestamp)                                                                    |
-        | statistics.last_assignment_at             | Date (UNIX timestamp)                                                                    |
-        | statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                    |
-        | statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                    |
-        | statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                    |
-        | statistics.last_close_at                  | Date (UNIX timestamp)                                                                    |
-        | statistics.last_closed_by_id              | String                                                                                   |
-        | statistics.count_reopens                  | Integer                                                                                  |
-        | statistics.count_assignments              | Integer                                                                                  |
-        | statistics.count_conversation_parts       | Integer                                                                                  |
-        | conversation_rating.requested_at          | Date (UNIX timestamp)                                                                    |
-        | conversation_rating.replied_at            | Date (UNIX timestamp)                                                                    |
-        | conversation_rating.score                 | Integer                                                                                  |
-        | conversation_rating.remark                | String                                                                                   |
-        | conversation_rating.contact_id            | String                                                                                   |
-        | conversation_rating.admin_d               | String                                                                                   |
+        | Field                                     | Type                                                                                                                                                   |
+        | :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
+        | id                                        | String                                                                                                                                                 |
+        | created_at                                | Date (UNIX timestamp)                                                                                                                                  |
+        | updated_at                                | Date (UNIX timestamp)                                                                                                                                  |
+        | source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |
+        | source.id                                 | String                                                                                                                                                 |
+        | source.delivered_as                       | String                                                                                                                                                 |
+        | source.subject                            | String                                                                                                                                                 |
+        | source.body                               | String                                                                                                                                                 |
+        | source.author.id                          | String                                                                                                                                                 |
+        | source.author.type                        | String                                                                                                                                                 |
+        | source.author.name                        | String                                                                                                                                                 |
+        | source.author.email                       | String                                                                                                                                                 |
+        | source.url                                | String                                                                                                                                                 |
+        | contact_ids                               | String                                                                                                                                                 |
+        | teammate_ids                              | String                                                                                                                                                 |
+        | admin_assignee_id                         | String                                                                                                                                                 |
+        | team_assignee_id                          | String                                                                                                                                                 |
+        | channel_initiated                         | String                                                                                                                                                 |
+        | open                                      | Boolean                                                                                                                                                |
+        | read                                      | Boolean                                                                                                                                                |
+        | state                                     | String                                                                                                                                                 |
+        | waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |
+        | snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |
+        | tag_ids                                   | String                                                                                                                                                 |
+        | priority                                  | String                                                                                                                                                 |
+        | statistics.time_to_assignment             | Integer                                                                                                                                                |
+        | statistics.time_to_admin_reply            | Integer                                                                                                                                                |
+        | statistics.time_to_first_close            | Integer                                                                                                                                                |
+        | statistics.time_to_last_close             | Integer                                                                                                                                                |
+        | statistics.median_time_to_reply           | Integer                                                                                                                                                |
+        | statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |
+        | statistics.last_closed_by_id              | String                                                                                                                                                 |
+        | statistics.count_reopens                  | Integer                                                                                                                                                |
+        | statistics.count_assignments              | Integer                                                                                                                                                |
+        | statistics.count_conversation_parts       | Integer                                                                                                                                                |
+        | conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |
+        | conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |
+        | conversation_rating.score                 | Integer                                                                                                                                                |
+        | conversation_rating.remark                | String                                                                                                                                                 |
+        | conversation_rating.contact_id            | String                                                                                                                                                 |
+        | conversation_rating.admin_d               | String                                                                                                                                                 |
 
         ### Accepted Operators
 
@@ -5032,20 +5032,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '320'
-                      created_at: 1709226694
-                      updated_at: 1709226694
+                      id: '918'
+                      created_at: 1709289919
+                      updated_at: 1709289919
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918253'
+                        id: '403918600'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991267429'
+                          id: '991269791'
                           name: Ciaran186 Lee
                           email: admin186@email.com
                         attachments: []
@@ -5055,7 +5055,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 65e0bac56abd017c523460b6
+                          id: 65e1b1beba4d1239c7e51a02
                       first_contact_reply:
                       admin_assignee_id:
                       team_assignee_id:
@@ -5090,15 +5090,15 @@ paths:
                     value:
                     - field: id
                       operator: "="
-                      value: '320'
+                      value: '918'
                     - operator: OR
                       value:
                       - field: id
                         operator: "="
-                        value: '320'
+                        value: '918'
                       - field: id
                         operator: "="
-                        value: '320'
+                        value: '918'
   "/conversations/{id}/reply":
     post:
       summary: Reply to a conversation
@@ -5129,20 +5129,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '328'
-                    created_at: 1709226700
-                    updated_at: 1709226701
-                    waiting_since: 1709226701
+                    id: '926'
+                    created_at: 1709289932
+                    updated_at: 1709289934
+                    waiting_since: 1709289934
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918256'
+                      id: '403918603'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267431'
+                        id: '991269793'
                         name: Ciaran187 Lee
                         email: admin187@email.com
                       attachments: []
@@ -5152,9 +5152,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bacc6abd017c523460bd
+                        id: 65e1b1ccba4d1239c7e51a09
                     first_contact_reply:
-                      created_at: 1709226701
+                      created_at: 1709289934
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5178,15 +5178,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '59'
+                        id: '220'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709226701
-                        updated_at: 1709226701
-                        notified_at: 1709226701
+                        created_at: 1709289934
+                        updated_at: 1709289934
+                        notified_at: 1709289934
                         assigned_to:
                         author:
-                          id: 65e0bacc6abd017c523460bd
+                          id: 65e1b1ccba4d1239c7e51a09
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5197,20 +5197,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '329'
-                    created_at: 1709226703
-                    updated_at: 1709226704
+                    id: '927'
+                    created_at: 1709289935
+                    updated_at: 1709289936
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918257'
+                      id: '403918604'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267433'
+                        id: '991269795'
                         name: Ciaran188 Lee
                         email: admin188@email.com
                       attachments: []
@@ -5220,7 +5220,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bace6abd017c523460be
+                        id: 65e1b1cfba4d1239c7e51a0a
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5243,7 +5243,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '60'
+                        id: '221'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5258,12 +5258,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1709226704
-                        updated_at: 1709226704
-                        notified_at: 1709226704
+                        created_at: 1709289936
+                        updated_at: 1709289936
+                        notified_at: 1709289936
                         assigned_to:
                         author:
-                          id: '991267433'
+                          id: '991269795'
                           type: admin
                           name: Ciaran188 Lee
                           email: admin188@email.com
@@ -5274,20 +5274,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '331'
-                    created_at: 1709226706
-                    updated_at: 1709226707
-                    waiting_since: 1709226707
+                    id: '929'
+                    created_at: 1709289940
+                    updated_at: 1709289942
+                    waiting_since: 1709289942
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918259'
+                      id: '403918606'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267437'
+                        id: '991269799'
                         name: Ciaran190 Lee
                         email: admin190@email.com
                       attachments: []
@@ -5297,9 +5297,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bad26abd017c523460c0
+                        id: 65e1b1d3ba4d1239c7e51a0c
                     first_contact_reply:
-                      created_at: 1709226707
+                      created_at: 1709289942
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5323,15 +5323,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '61'
+                        id: '222'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1709226707
-                        updated_at: 1709226707
-                        notified_at: 1709226707
+                        created_at: 1709289942
+                        updated_at: 1709289942
+                        notified_at: 1709289942
                         assigned_to:
                         author:
-                          id: 65e0bad26abd017c523460c0
+                          id: 65e1b1d3ba4d1239c7e51a0c
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5349,7 +5349,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 9e1d22b7-de95-42f2-98ff-b4aa714271a1
+                    request_id: 2ae68294-1882-41ad-936f-5955a6825578
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5363,7 +5363,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1c747b55-c34d-45f4-936f-eb35d9449165
+                    request_id: 12074064-343a-431c-92cd-1122507585fd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5377,7 +5377,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: acccb090-ff78-4097-8a64-e46985c1fd35
+                    request_id: d579b959-9bc9-488c-932c-1b481ed53307
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5394,14 +5394,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bacc6abd017c523460bd
+                  intercom_user_id: 65e1b1ccba4d1239c7e51a09
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991267433
+                  admin_id: 991269795
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -5411,14 +5411,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bad26abd017c523460c0
+                  intercom_user_id: 65e1b1d3ba4d1239c7e51a0c
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 65e0bad46abd017c523460c1
+                  intercom_user_id: 65e1b1d7ba4d1239c7e51a0d
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -5453,20 +5453,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '335'
-                    created_at: 1709226713
-                    updated_at: 1709226713
+                    id: '933'
+                    created_at: 1709289949
+                    updated_at: 1709289951
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918263'
+                      id: '403918610'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267445'
+                        id: '991269807'
                         name: Ciaran194 Lee
                         email: admin194@email.com
                       attachments: []
@@ -5476,7 +5476,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bad86abd017c523460c4
+                        id: 65e1b1ddba4d1239c7e51a10
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5499,15 +5499,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '62'
+                        id: '223'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1709226713
-                        updated_at: 1709226713
-                        notified_at: 1709226713
+                        created_at: 1709289951
+                        updated_at: 1709289951
+                        notified_at: 1709289951
                         assigned_to:
                         author:
-                          id: '991267445'
+                          id: '991269807'
                           type: admin
                           name: Ciaran194 Lee
                           email: admin194@email.com
@@ -5518,20 +5518,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '336'
-                    created_at: 1709226714
-                    updated_at: 1709226715
+                    id: '934'
+                    created_at: 1709289952
+                    updated_at: 1709289954
                     waiting_since:
-                    snoozed_until: 1709230315
+                    snoozed_until: 1709293554
                     source:
                       type: conversation
-                      id: '403918264'
+                      id: '403918611'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267447'
+                        id: '991269809'
                         name: Ciaran195 Lee
                         email: admin195@email.com
                       attachments: []
@@ -5541,7 +5541,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bada6abd017c523460c5
+                        id: 65e1b1e0ba4d1239c7e51a11
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5564,15 +5564,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '63'
+                        id: '224'
                         part_type: snoozed
                         body:
-                        created_at: 1709226715
-                        updated_at: 1709226715
-                        notified_at: 1709226715
+                        created_at: 1709289954
+                        updated_at: 1709289954
+                        notified_at: 1709289954
                         assigned_to:
                         author:
-                          id: '991267447'
+                          id: '991269809'
                           type: admin
                           name: Ciaran195 Lee
                           email: admin195@email.com
@@ -5583,20 +5583,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '341'
-                    created_at: 1709226713
-                    updated_at: 1709226722
+                    id: '939'
+                    created_at: 1709289953
+                    updated_at: 1709289966
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918265'
+                      id: '403918612'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267449'
+                        id: '991269811'
                         name: Ciaran196 Lee
                         email: admin196@email.com
                       attachments: []
@@ -5606,7 +5606,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0badf6abd017c523460ca
+                        id: 65e1b1e7ba4d1239c7e51a16
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5629,15 +5629,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '65'
+                        id: '226'
                         part_type: open
                         body:
-                        created_at: 1709226722
-                        updated_at: 1709226722
-                        notified_at: 1709226722
+                        created_at: 1709289966
+                        updated_at: 1709289966
+                        notified_at: 1709289966
                         assigned_to:
                         author:
-                          id: '991267449'
+                          id: '991269811'
                           type: admin
                           name: Ciaran196 Lee
                           email: admin196@email.com
@@ -5648,20 +5648,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '345'
-                    created_at: 1709226723
-                    updated_at: 1709226724
+                    id: '943'
+                    created_at: 1709289967
+                    updated_at: 1709289969
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918268'
+                      id: '403918615'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267451'
+                        id: '991269813'
                         name: Ciaran197 Lee
                         email: admin197@email.com
                       attachments: []
@@ -5671,9 +5671,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bae36abd017c523460cd
+                        id: 65e1b1efba4d1239c7e51a19
                     first_contact_reply:
-                    admin_assignee_id: 991267451
+                    admin_assignee_id: 991269813
                     team_assignee_id:
                     open: true
                     state: open
@@ -5694,17 +5694,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '66'
+                        id: '227'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1709226724
-                        updated_at: 1709226724
-                        notified_at: 1709226724
+                        created_at: 1709289969
+                        updated_at: 1709289969
+                        notified_at: 1709289969
                         assigned_to:
                           type: admin
-                          id: '991267451'
+                          id: '991269813'
                         author:
-                          id: '991267451'
+                          id: '991269813'
                           type: admin
                           name: Ciaran197 Lee
                           email: admin197@email.com
@@ -5722,7 +5722,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 13ba7fae-3e6f-4026-a5a1-ed40b4865574
+                    request_id: 25e00d2a-fb56-4019-afa3-f2cede8877de
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5736,7 +5736,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d2093d6b-657b-48a4-a23e-302de88265fa
+                    request_id: 46415af5-2986-4799-a616-03c53784420f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5750,7 +5750,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 940d79d2-138c-434e-bced-82566c394475
+                    request_id: 12b7f2ee-ded9-47c4-8765-b03b6cfac117
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5771,32 +5771,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991267445
+                  admin_id: 991269807
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991267447
-                  snoozed_until: 1709230315
+                  admin_id: 991269809
+                  snoozed_until: 1709293554
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991267449
+                  admin_id: 991269811
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991267451
-                  assignee_id: 991267451
+                  admin_id: 991269813
+                  assignee_id: 991269813
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991267453
+                  admin_id: 991269815
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -5827,20 +5827,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '349'
-                    created_at: 1709226729
-                    updated_at: 1709226730
+                    id: '947'
+                    created_at: 1709289977
+                    updated_at: 1709289978
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918272'
+                      id: '403918619'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267459'
+                        id: '991269821'
                         name: Ciaran201 Lee
                         email: admin201@email.com
                       attachments: []
@@ -5850,7 +5850,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bae96abd017c523460d1
+                        id: 65e1b1f9ba4d1239c7e51a1d
                     first_contact_reply:
                     admin_assignee_id:
                     team_assignee_id:
@@ -5873,17 +5873,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '67'
+                        id: '228'
                         part_type: default_assignment
                         body:
-                        created_at: 1709226730
-                        updated_at: 1709226730
-                        notified_at: 1709226730
+                        created_at: 1709289978
+                        updated_at: 1709289978
+                        notified_at: 1709289978
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991267460'
+                          id: '991269822'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id357_that_should_be_at_least_@intercom.io
@@ -5901,7 +5901,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 4158d661-b91f-4fc9-b43b-898247b1bc34
+                    request_id: 13b958f6-255f-491c-a6d4-876b3508b61e
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5915,7 +5915,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1cddbff0-92a8-45a7-96f0-60ce46e56528
+                    request_id: 77382ce5-1da8-42a6-bf88-5951f1d91b2b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5929,7 +5929,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 404444a6-ba4c-4e4b-b294-9b49a32ec3b4
+                    request_id: fbda63d5-3e6f-4c88-86f1-141808dbe46d
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5970,7 +5970,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65e0baef6abd017c523460d5
+                      id: 65e1b202ba4d1239c7e51a21
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -5981,7 +5981,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 38898694-3695-4d55-87f7-3d4c10705fe8
+                    request_id: 2065ddc8-2bc4-4305-a13f-07de9f559daa
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5995,7 +5995,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6c7d347e-d3c2-4292-9153-8cfae5a8020b
+                    request_id: fab7a6c4-575b-4f15-b1d6-dea05992021a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6009,7 +6009,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: ef367699-bf60-411a-8741-a60d24bc7c20
+                    request_id: e749fb41-3c1e-46b6-8fd2-c3c3ab38dd1b
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6024,15 +6024,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991267467
+                  admin_id: 991269829
                   customer:
-                    intercom_user_id: 65e0baef6abd017c523460d5
+                    intercom_user_id: 65e1b202ba4d1239c7e51a21
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991267469
+                  admin_id: 991269831
                   customer:
-                    intercom_user_id: 65e0baf16abd017c523460d6
+                    intercom_user_id: 65e1b204ba4d1239c7e51a22
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -6075,7 +6075,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 65e0bafc6abd017c523460e0
+                      id: 65e1b214ba4d1239c7e51a2c
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6086,14 +6086,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 0d8c70cc-9b90-428e-8de8-d5496ad4ea5f
+                    request_id: d4e5a989-ce0f-49a4-ab75-1e80e470181b
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 595f75fc-cff0-420c-a83a-efd4c860f480
+                    request_id: 99eae6e3-e495-432b-beae-90c57e37e7ee
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -6107,7 +6107,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: '08a80af4-f1cb-4934-8714-5946581154b4'
+                    request_id: 7dc33b3a-03ee-40f5-909c-128000768952
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -6121,7 +6121,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b0366588-3e21-442f-b276-af4ddfcfc5ec
+                    request_id: 40968edb-2cea-4830-9725-4081015432cc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6135,7 +6135,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: f3f08c0d-fef0-4367-986d-40afd49cb3d1
+                    request_id: be525675-2ca1-467d-9186-895f47da662c
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6150,27 +6150,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991267475
+                  admin_id: 991269837
                   customer:
-                    intercom_user_id: 65e0baf56abd017c523460d9
+                    intercom_user_id: 65e1b20aba4d1239c7e51a25
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991267477
+                  admin_id: 991269839
                   customer:
-                    intercom_user_id: 65e0bafd6abd017c523460e1
+                    intercom_user_id: 65e1b215ba4d1239c7e51a2d
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991267479
+                  admin_id: 991269841
                   customer:
-                    intercom_user_id: 65e0bb056abd017c523460e8
+                    intercom_user_id: 65e1b221ba4d1239c7e51a34
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991267481
+                  admin_id: 991269843
                   customer:
-                    intercom_user_id: 65e0bb0e6abd017c523460ef
+                    intercom_user_id: 65e1b22cba4d1239c7e51a3b
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6198,20 +6198,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '405'
-                    created_at: 1709226789
-                    updated_at: 1709226790
-                    waiting_since: 1709226789
+                    id: '1003'
+                    created_at: 1709290065
+                    updated_at: 1709290068
+                    waiting_since: 1709290067
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918298'
+                      id: '403918645'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267487'
+                        id: '991269849'
                         name: Ciaran215 Lee
                         email: admin215@email.com
                       attachments: []
@@ -6221,9 +6221,9 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 65e0bb256abd017c52346104
+                        id: 65e1b251ba4d1239c7e51a50
                     first_contact_reply:
-                      created_at: 1709226789
+                      created_at: 1709290067
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6247,15 +6247,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '75'
+                        id: '236'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1709226789
-                        updated_at: 1709226790
-                        notified_at: 1709226789
+                        created_at: 1709290067
+                        updated_at: 1709290068
+                        notified_at: 1709290067
                         assigned_to:
                         author:
-                          id: 65e0bb256abd017c52346104
+                          id: 65e1b251ba4d1239c7e51a50
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6273,7 +6273,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 4f65275d-a0e4-4720-944a-b0f23c029e65
+                    request_id: adadb0da-7acf-442c-8e1b-598467ad4222
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -6287,7 +6287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cabb3057-cad5-4384-83fc-d4a7d4ce85c5
+                    request_id: d1d97cf1-0c2b-4811-a3f4-2e2cfda3c71e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6303,8 +6303,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 405
-                  conversation_part_id: 75
+                  conversation_id: 1003
+                  conversation_part_id: 236
               not_found:
                 summary: Not found
                 value:
@@ -6491,7 +6491,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 34
+                    - id: 99
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -6504,9 +6504,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991267512'
-                      created_at: 1709226801
-                      updated_at: 1709226801
+                      admin_id: '991269874'
+                      created_at: 1709290086
+                      updated_at: 1709290086
                       model: company
                     - type: data_attribute
                       name: id
@@ -6578,7 +6578,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 01fc7d5c-ef53-4dbb-9026-df13e32d6a89
+                    request_id: 52a4cddc-e733-4a63-80f8-1df98ddb5c95
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6603,7 +6603,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 37
+                    id: 102
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -6614,9 +6614,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991267514'
-                    created_at: 1709226803
-                    updated_at: 1709226803
+                    admin_id: '991269876'
+                    created_at: 1709290088
+                    updated_at: 1709290088
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6628,7 +6628,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: 135dfc99-1eca-44e3-bf11-dcc3fc256e35
+                    request_id: bf04e6a3-394d-477b-a3e4-642e04a2da50
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6636,7 +6636,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: 556d6960-9122-43c3-98f9-91d1bbb42cc0
+                    request_id: 42a84359-8e6b-43d0-9770-ef1e4a26bf24
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -6644,7 +6644,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: 4366bcb9-3f70-46aa-9e63-5096e75eb539
+                    request_id: 95a7b91e-45dd-47b7-b30e-144f13efdafb
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -6652,14 +6652,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: 6d8bfc75-1520-4f18-8009-1530fee4c1fc
+                    request_id: 6e384ecc-7444-4256-9d69-47ff762fa6c9
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: 36007549-f343-4ae3-8444-f5f8fa265efd
+                    request_id: 4decc5de-9226-4af6-b268-1e10530f2a37
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -6674,7 +6674,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e2d36021-ade8-459e-8eff-f61704652d1d
+                    request_id: c6255162-ffe2-4bd5-b9af-6a62b0b68566
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6753,7 +6753,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 44
+                    id: 109
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -6768,9 +6768,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991267521'
-                    created_at: 1709226806
-                    updated_at: 1709226806
+                    admin_id: '991269883'
+                    created_at: 1709290091
+                    updated_at: 1709290091
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -6782,7 +6782,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: 6c360620-9694-4930-87ab-aebfb8b02353
+                    request_id: ce37be1e-d504-4162-a6d3-91f59df29e45
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -6796,7 +6796,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: 73c85185-0615-4b81-bc99-9356a51c8af4
+                    request_id: 9a598355-9f37-40e0-aa4e-6b5b8516b92b
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -6810,7 +6810,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: 5658dc41-5b44-4ff0-9bdd-2ead2ce81fc5
+                    request_id: 606a6ee9-130f-4a13-beda-2e5f6010a311
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -6825,7 +6825,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 917794f4-1376-472c-bfe9-59fc0d4bb3f9
+                    request_id: d91213c4-844e-45dc-8683-988f9400dc8a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6930,7 +6930,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0c2f537d-4814-486b-a6c7-d9d99231dc3b
+                    request_id: 3ed1e2c1-4c38-472d-90e1-9ddbca556f25
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7017,7 +7017,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 65e0bb3a6abd017c5234610d
+                    intercom_user_id: 65e1b26fba4d1239c7e51a59
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -7029,7 +7029,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2a94cd5d-1ead-4a61-a34e-c0142eb3d2e8
+                    request_id: 15f06de5-60e1-4682-a449-e926f2c8cbf9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7060,7 +7060,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1a790422-e998-4264-b8d7-ae0a23109a21
+                    request_id: 69d18052-661e-4bce-bfcc-1300f55b3d98
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7104,7 +7104,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: rp5yj4x997clha91
+                    job_identifier: cdy9ibpmthrp3ppi
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7119,8 +7119,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1709208812
-                  created_at_before: 1709226812
+                  created_at_after: 1709272097
+                  created_at_before: 1709290097
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -7154,7 +7154,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: 9r292lvxbubsso3b
+                    job_identifier: b9hclfb4l31y9i0e
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -7186,7 +7186,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: r89vgdehqca008ed
+                    job_identifier: 5ex0n10f4ot575nw
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -7247,30 +7247,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918303'
-                    created_at: 1709226815
+                    id: '403918650'
+                    created_at: 1709290100
                     body: heyy
                     message_type: inapp
-                    conversation_id: '410'
+                    conversation_id: '1008'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918304'
-                    created_at: 1709226816
+                    id: '403918651'
+                    created_at: 1709290101
                     body: heyy
                     message_type: inapp
-                    conversation_id: '411'
+                    conversation_id: '1009'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '15'
-                    created_at: 1709226817
+                    id: '35'
+                    created_at: 1709290102
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991267544'
+                      id: '991269906'
                       name: Ciaran265 Lee
                       email: admin265@email.com
                       away_mode_enabled: false
@@ -7285,14 +7285,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: d23842e9-924a-470a-b79b-d88512cd5381
+                    request_id: 6690fa24-f38b-4185-928f-350efd058831
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: e601dc61-d26f-4422-97ff-d4e030b7ac9d
+                    request_id: 531b208e-217a-4ac7-8e54-21afcfd327c9
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -7306,7 +7306,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: fc911d8a-c746-47e5-9969-64e616cd5688
+                    request_id: 47736a27-0e6f-4c12-89be-04e8e4a37cff
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -7320,7 +7320,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4e815e12-ba5f-477d-9161-375857802850
+                    request_id: ffe6b8e7-575a-4213-801f-5a4193bc5a55
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7334,7 +7334,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 252bee6a-b234-4e7f-ba89-832cc97e0e05
+                    request_id: cf67a3af-8de8-4404-8ce4-43131f690fbe
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -7351,7 +7351,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 65e0bb3f6abd017c52346112
+                    id: 65e1b274ba4d1239c7e51a5e
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -7359,7 +7359,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 65e0bb406abd017c52346113
+                    id: 65e1b275ba4d1239c7e51a5f
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -7367,10 +7367,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267544'
+                    id: '991269906'
                   to:
                     type: user
-                    id: 65e0bb416abd017c52346114
+                    id: 65e1b276ba4d1239c7e51a60
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -7378,10 +7378,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267546'
+                    id: '991269908'
                   to:
                     type: user
-                    id: 65e0bb426abd017c52346115
+                    id: 65e1b277ba4d1239c7e51a61
                   message_type: inapp
                   body:
                   subject: heyy
@@ -7390,7 +7390,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267547'
+                    id: '991269909'
                   to:
                     type: user
                     user_id: '70'
@@ -7401,10 +7401,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267548'
+                    id: '991269910'
                   to:
                     type: user
-                    id: 65e0bb436abd017c52346117
+                    id: 65e1b278ba4d1239c7e51a63
                   message_type: email
                   body:
                   subject: heyy
@@ -7435,12 +7435,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '29'
+                    - id: '86'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991267553
+                      sender_id: 991269917
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7450,15 +7450,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709226821
-                      updated_at: 1709226821
+                      created_at: 1709290106
+                      updated_at: 1709290106
                       newsfeed_assignments: []
-                    - id: '30'
+                    - id: '85'
                       type: news-item
                       workspace_id: this_is_an_id479_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991267555
+                      sender_id: 991269915
                       state: draft
                       labels: []
                       cover_image_url:
@@ -7468,8 +7468,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1709226821
-                      updated_at: 1709226821
+                      created_at: 1709290105
+                      updated_at: 1709290105
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -7482,7 +7482,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5b9c9578-1e54-4e85-9cb7-ebcbf69c7597
+                    request_id: 5f0dcc54-142a-4ee5-bf00-fa98fbd54e69
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7507,12 +7507,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '33'
+                    id: '89'
                     type: news-item
                     workspace_id: this_is_an_id483_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991267562
+                    sender_id: 991269924
                     state: live
                     labels:
                     - New
@@ -7523,10 +7523,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1709226823
-                    updated_at: 1709226823
+                    created_at: 1709290108
+                    updated_at: 1709290108
                     newsfeed_assignments:
-                    - newsfeed_id: 53
+                    - newsfeed_id: 153
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7538,7 +7538,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0112dc89-506a-4352-a54a-6b2cbfd590d4
+                    request_id: f182d773-9363-425c-933f-7934994ec0fc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7559,14 +7559,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991267562
+                  sender_id: 991269924
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 53
+                  - newsfeed_id: 153
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -7595,12 +7595,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '34'
+                    id: '90'
                     type: news-item
                     workspace_id: this_is_an_id487_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991267565
+                    sender_id: 991269927
                     state: live
                     labels: []
                     cover_image_url:
@@ -7610,11 +7610,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1709226824
-                    updated_at: 1709226824
+                    created_at: 1709290109
+                    updated_at: 1709290109
                     newsfeed_assignments:
-                    - newsfeed_id: 55
-                      published_at: 1709226824
+                    - newsfeed_id: 155
+                      published_at: 1709290109
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -7625,7 +7625,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: c12b7db4-d849-4092-9a18-435a24a30904
+                    request_id: 2662cdc1-cb10-4601-b20b-32e04a79bdf8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7639,7 +7639,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1408fb1c-caf3-47b1-8704-cbfe9aeeef01
+                    request_id: db49e34a-bed4-4f36-b20d-f5d97f7e54cf
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7670,12 +7670,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '37'
+                    id: '93'
                     type: news-item
                     workspace_id: this_is_an_id493_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991267573
+                    sender_id: 991269935
                     state: live
                     labels: []
                     cover_image_url:
@@ -7683,8 +7683,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1709226825
-                    updated_at: 1709226826
+                    created_at: 1709290111
+                    updated_at: 1709290112
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -7696,7 +7696,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: b0209861-67d5-442d-a623-62195311b07e
+                    request_id: 0b51323e-1bce-4b7d-be3b-c364cb1d0e91
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7710,7 +7710,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5df59db7-9e0a-4e2c-96ad-f804c1060ca7
+                    request_id: 9608b8a6-2a08-42d5-8a7e-d041abab798e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7727,7 +7727,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991267573
+                  sender_id: 991269935
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7736,7 +7736,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991267576
+                  sender_id: 991269938
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -7766,7 +7766,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '40'
+                    id: '96'
                     object: news-item
                     deleted: true
               schema:
@@ -7779,7 +7779,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 6557d54b-0615-4668-8d2b-5599fd650114
+                    request_id: 4d40e591-b991-46e1-b078-bd0b8f0f1520
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -7793,7 +7793,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a9a3f27a-0ddb-471a-850b-c0ac6a697e98
+                    request_id: 5dad301d-f7aa-4703-9686-2804e4dfff73
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7846,7 +7846,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f8bdb468-2bb0-42f2-aa8d-cc60d23f0b7b
+                    request_id: 2938c8f2-1b69-4108-89ea-92a6d3511ac3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7879,16 +7879,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '68'
+                    - id: '168'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709226831
-                      updated_at: 1709226831
-                    - id: '69'
+                      created_at: 1709290116
+                      updated_at: 1709290116
+                    - id: '169'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1709226831
-                      updated_at: 1709226831
+                      created_at: 1709290116
+                      updated_at: 1709290116
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -7900,7 +7900,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7ea04aec-2f95-46b4-be38-1c7dc07098c4
+                    request_id: 2c2c0545-fd91-46eb-8494-3650feb44294
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7934,11 +7934,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '72'
+                    id: '172'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1709226832
-                    updated_at: 1709226832
+                    created_at: 1709290117
+                    updated_at: 1709290117
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -7949,7 +7949,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4257b130-3e9a-417a-9e45-055739033aaa
+                    request_id: d7535987-0139-4c9f-a0f3-cfb2096c576f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7983,14 +7983,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '37'
-                    created_at: 1708535633
+                    id: '99'
+                    created_at: 1708598917
                     contact:
                       type: contact
-                      id: 65e0bb516abd017c5234611a
+                      id: 65e1b285ba4d1239c7e51a66
                     author:
                       type: admin
-                      id: '991267592'
+                      id: '991269954'
                       name: Ciaran312 Lee
                       email: admin312@email.com
                       away_mode_enabled: false
@@ -8006,7 +8006,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: 98eb1b6b-a6f7-47b9-b466-2fcc319ad75b
+                    request_id: 6dc496f6-5815-408f-b72f-84abf56ea2ce
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8020,7 +8020,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e18a3d71-0415-406b-87be-6b788cb2500d
+                    request_id: f13b4e21-b8a2-478a-84eb-c5349ced8ac4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8056,16 +8056,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 65e0bb526abd017c5234611d
+                      id: 65e1b287ba4d1239c7e51a69
                       name: John segment
-                      created_at: 1709226834
-                      updated_at: 1709226834
+                      created_at: 1709290119
+                      updated_at: 1709290119
                       person_type: user
                     - type: segment
-                      id: 65e0bb526abd017c5234611e
+                      id: 65e1b287ba4d1239c7e51a6a
                       name: Jane segment
-                      created_at: 1709226834
-                      updated_at: 1709226834
+                      created_at: 1709290119
+                      updated_at: 1709290119
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -8077,7 +8077,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4e6cb3e6-9033-4ade-b9e6-02175b36488c
+                    request_id: aa099b23-b1a6-47f7-9671-240bd2a6425a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8111,10 +8111,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 65e0bb536abd017c52346121
+                    id: 65e1b288ba4d1239c7e51a6d
                     name: John segment
-                    created_at: 1709226835
-                    updated_at: 1709226835
+                    created_at: 1709290120
+                    updated_at: 1709290120
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -8126,7 +8126,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: f70b7201-3e11-48f3-8b44-aee9dc290ef6
+                    request_id: 209cc55c-1c32-4e43-9748-1010438f5af6
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8140,7 +8140,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 64811e02-5294-429d-b7bd-2934ef6a7486
+                    request_id: 38d46125-914b-4691-848d-b512f25a9ef7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8170,7 +8170,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '137'
+                      id: '365'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -8193,7 +8193,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6cea578d-4d58-496e-8cb1-a87b93e2ac55
+                    request_id: daafd13b-bc7f-4f0d-9216-829c41f742a4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8223,7 +8223,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/5a2076da-98fb-4564-b666-235eaefb13cc
+                    url: http://via.intercom.io/msgr/7af9f259-2781-48fe-9d0a-b61fa5339d70
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -8256,7 +8256,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 59bf043c-715e-4d9f-b9a3-820d6223bcdd
+                    request_id: 1700b747-33d1-4e7c-b97e-6c8e263a0dc2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8319,7 +8319,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '105'
+                      id: '293'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -8331,7 +8331,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a64767a3-4c98-413a-b133-2c26b156fb8b
+                    request_id: '087e8ce2-44ff-4a23-b7b3-50f4fec0d20d'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8370,7 +8370,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '108'
+                    id: '296'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8382,7 +8382,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: af7e4d4f-1bd7-4c75-88c3-1911001ee775
+                    request_id: d71d98ff-d4a4-4c6f-b5d7-f7faa07fdf4e
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -8396,14 +8396,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: 03b04a49-ea07-48a6-b283-7b2582814a24
+                    request_id: 25f3cc1f-9015-4e8b-a760-30465120a3a8
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: 230779ae-8183-4411-b7be-8eb9f8590054
+                    request_id: 18a4cbe5-5668-49f4-8de8-37a722dff645
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -8417,7 +8417,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b3686524-4185-48cf-9c4f-ea5f043b7216
+                    request_id: b250b183-8cdd-4bdc-a1a4-b9e21c998090
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8483,7 +8483,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '116'
+                    id: '304'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -8495,7 +8495,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 8d4a2db9-42e4-478a-b767-e411bdf6ebd4
+                    request_id: faa21a18-0fbd-4d79-8b99-9ec396fb0193
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8509,7 +8509,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f0702b70-c7ef-4a0d-9857-a5806e2867bd
+                    request_id: 860a3734-d2a5-4724-a6f2-2ea3d31d81b2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8545,7 +8545,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: cd91ab2e-5ddd-4436-ac9d-45b574ae5092
+                    request_id: 3323172f-0136-48db-8d9e-e21d808c19a9
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8559,7 +8559,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: 465678a6-4a23-47e3-9a20-194c7e2d040c
+                    request_id: fab36988-875c-48ee-a5b3-e90717a43b44
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -8574,7 +8574,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 751c4843-b446-43d4-9453-331e41cb0845
+                    request_id: 36b1ae0d-f08e-4d00-88e5-1b5cb3c85b87
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8612,7 +8612,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 13c05757-4879-4107-a16e-aa69a53cb5f8
+                    request_id: 073026ba-5871-4954-a3d5-5832bbcec7a9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8647,7 +8647,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991267630'
+                    id: '991269992'
                     name: team 1
                     admin_ids: []
               schema:
@@ -8660,7 +8660,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: 819e044f-4d1b-44a2-9958-11cc23583dc8
+                    request_id: e03a60f3-abe3-40f4-8ef1-27dc107531b3
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -8674,7 +8674,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a1ac2cd8-4c1c-4150-bdfc-dc0296b76ea2
+                    request_id: 2f4afa3f-6a17-4443-ad1a-52ad1a84a585
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8707,7 +8707,7 @@ paths:
                 Ticket Type Attribute created:
                   value:
                     type: ticket_type_attribute
-                    id: '151'
+                    id: '477'
                     workspace_id: this_is_an_id585_that_should_be_at_least_
                     name: Attribute Title
                     description: Attribute Description
@@ -8720,10 +8720,10 @@ paths:
                     visible_on_create: true
                     visible_to_contacts: true
                     default: false
-                    ticket_type_id: 45
+                    ticket_type_id: 175
                     archived: false
-                    created_at: 1709226854
-                    updated_at: 1709226854
+                    created_at: 1709290138
+                    updated_at: 1709290138
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -8734,7 +8734,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 13c39bcc-2542-47e8-8c1f-3ca7aae82a9f
+                    request_id: '08b79189-0177-4044-9c5b-7dbbd592f27b'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8787,7 +8787,7 @@ paths:
                 Ticket Type Attribute updated:
                   value:
                     type: ticket_type_attribute
-                    id: '156'
+                    id: '482'
                     workspace_id: this_is_an_id589_that_should_be_at_least_
                     name: name
                     description: New Attribute Description
@@ -8798,10 +8798,10 @@ paths:
                     visible_on_create: false
                     visible_to_contacts: false
                     default: false
-                    ticket_type_id: 47
+                    ticket_type_id: 177
                     archived: false
-                    created_at: 1709226854
-                    updated_at: 1709226855
+                    created_at: 1709290139
+                    updated_at: 1709290139
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -8812,7 +8812,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d8c278d9-58c1-4220-bfc7-45ebe4d339cc
+                    request_id: '0863ea6f-fa13-4376-a7a9-06ebee7dc918'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8851,20 +8851,20 @@ paths:
                     type: list
                     data:
                     - type: ticket_type
-                      id: '49'
+                      id: '179'
                       name: Bug Report
                       description: Bug Report Template
                       icon: "\U0001F39F️"
                       workspace_id: this_is_an_id593_that_should_be_at_least_
                       archived: false
-                      created_at: 1709226855
-                      updated_at: 1709226855
+                      created_at: 1709290140
+                      updated_at: 1709290140
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '159'
+                          id: '485'
                           workspace_id: this_is_an_id593_that_should_be_at_least_
                           name: _default_title_
                           description: ''
@@ -8877,12 +8877,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 49
+                          ticket_type_id: 179
                           archived: false
-                          created_at: 1709226855
-                          updated_at: 1709226855
+                          created_at: 1709290140
+                          updated_at: 1709290140
                         - type: ticket_type_attribute
-                          id: '161'
+                          id: '487'
                           workspace_id: this_is_an_id593_that_should_be_at_least_
                           name: name
                           description: description
@@ -8894,12 +8894,12 @@ paths:
                           visible_on_create: false
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 49
+                          ticket_type_id: 179
                           archived: false
-                          created_at: 1709226855
-                          updated_at: 1709226855
+                          created_at: 1709290140
+                          updated_at: 1709290140
                         - type: ticket_type_attribute
-                          id: '160'
+                          id: '486'
                           workspace_id: this_is_an_id593_that_should_be_at_least_
                           name: _default_description_
                           description: ''
@@ -8912,10 +8912,10 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 49
+                          ticket_type_id: 179
                           archived: false
-                          created_at: 1709226855
-                          updated_at: 1709226855
+                          created_at: 1709290140
+                          updated_at: 1709290140
               schema:
                 "$ref": "#/components/schemas/ticket_type_list"
         '401':
@@ -8926,7 +8926,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 769ff726-c0ec-4583-b802-4f4d2b067826
+                    request_id: 053dcd35-3253-4cfc-91b6-bfd33dd7d1ac
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8955,20 +8955,20 @@ paths:
                 Ticket type created:
                   value:
                     type: ticket_type
-                    id: '52'
+                    id: '182'
                     name: Customer Issue
                     description: Customer Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id597_that_should_be_at_least_
                     archived: false
-                    created_at: 1709226857
-                    updated_at: 1709226857
+                    created_at: 1709290141
+                    updated_at: 1709290141
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '168'
+                        id: '494'
                         workspace_id: this_is_an_id597_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -8981,12 +8981,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 52
+                        ticket_type_id: 182
                         archived: false
-                        created_at: 1709226857
-                        updated_at: 1709226857
+                        created_at: 1709290141
+                        updated_at: 1709290141
                       - type: ticket_type_attribute
-                        id: '169'
+                        id: '495'
                         workspace_id: this_is_an_id597_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -8999,10 +8999,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 52
+                        ticket_type_id: 182
                         archived: false
-                        created_at: 1709226857
-                        updated_at: 1709226857
+                        created_at: 1709290141
+                        updated_at: 1709290141
               schema:
                 "$ref": "#/components/schemas/ticket_type"
         '401':
@@ -9013,7 +9013,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2adafcb6-fde0-4129-b70a-84bd490bcf54
+                    request_id: acb2c3e8-30e3-4fa8-a5c8-4b390d6a55a3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9058,20 +9058,20 @@ paths:
                 Ticket type found:
                   value:
                     type: ticket_type
-                    id: '54'
+                    id: '184'
                     name: Bug Report
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id601_that_should_be_at_least_
                     archived: false
-                    created_at: 1709226858
-                    updated_at: 1709226858
+                    created_at: 1709290142
+                    updated_at: 1709290142
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '173'
+                        id: '499'
                         workspace_id: this_is_an_id601_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -9084,12 +9084,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 54
+                        ticket_type_id: 184
                         archived: false
-                        created_at: 1709226858
-                        updated_at: 1709226858
+                        created_at: 1709290142
+                        updated_at: 1709290142
                       - type: ticket_type_attribute
-                        id: '175'
+                        id: '501'
                         workspace_id: this_is_an_id601_that_should_be_at_least_
                         name: name
                         description: description
@@ -9101,12 +9101,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 54
+                        ticket_type_id: 184
                         archived: false
-                        created_at: 1709226858
-                        updated_at: 1709226858
+                        created_at: 1709290142
+                        updated_at: 1709290142
                       - type: ticket_type_attribute
-                        id: '174'
+                        id: '500'
                         workspace_id: this_is_an_id601_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -9119,10 +9119,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 54
+                        ticket_type_id: 184
                         archived: false
-                        created_at: 1709226858
-                        updated_at: 1709226858
+                        created_at: 1709290142
+                        updated_at: 1709290142
               schema:
                 "$ref": "#/components/schemas/ticket_type"
         '401':
@@ -9133,7 +9133,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3f54f1f0-0024-468a-981f-29c09172943a
+                    request_id: aa7a07ef-1d19-4340-b4e8-740f6c746cec
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9166,20 +9166,20 @@ paths:
                 Ticket type updated:
                   value:
                     type: ticket_type
-                    id: '56'
+                    id: '186'
                     name: Bug Report 2
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id605_that_should_be_at_least_
                     archived: false
-                    created_at: 1709226859
-                    updated_at: 1709226859
+                    created_at: 1709290143
+                    updated_at: 1709290143
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '179'
+                        id: '505'
                         workspace_id: this_is_an_id605_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -9192,12 +9192,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 56
+                        ticket_type_id: 186
                         archived: false
-                        created_at: 1709226859
-                        updated_at: 1709226859
+                        created_at: 1709290143
+                        updated_at: 1709290143
                       - type: ticket_type_attribute
-                        id: '181'
+                        id: '507'
                         workspace_id: this_is_an_id605_that_should_be_at_least_
                         name: name
                         description: description
@@ -9209,12 +9209,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 56
+                        ticket_type_id: 186
                         archived: false
-                        created_at: 1709226859
-                        updated_at: 1709226859
+                        created_at: 1709290143
+                        updated_at: 1709290143
                       - type: ticket_type_attribute
-                        id: '180'
+                        id: '506'
                         workspace_id: this_is_an_id605_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -9227,10 +9227,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 56
+                        ticket_type_id: 186
                         archived: false
-                        created_at: 1709226859
-                        updated_at: 1709226859
+                        created_at: 1709290143
+                        updated_at: 1709290143
               schema:
                 "$ref": "#/components/schemas/ticket_type"
         '401':
@@ -9241,7 +9241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d879cda4-57d4-4367-a767-a9e8c263ff88
+                    request_id: e6f217f6-1ac4-4f82-bf3d-64abf7b8dc0b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9286,7 +9286,7 @@ paths:
                 Admin note reply:
                   value:
                     type: ticket_part
-                    id: '80'
+                    id: '241'
                     part_type: note
                     body: |-
                       <h2>An Unordered HTML List</h2>
@@ -9301,10 +9301,10 @@ paths:
                       <li>Tea</li>
                       <li>Milk</li>
                       </ol>
-                    created_at: 1709226862
-                    updated_at: 1709226862
+                    created_at: 1709290148
+                    updated_at: 1709290148
                     author:
-                      id: '991267656'
+                      id: '991270018'
                       type: admin
                       name: Ciaran371 Lee
                       email: admin371@email.com
@@ -9320,7 +9320,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3381897b-e57e-4d3f-b996-b1824ba3272a
+                    request_id: dacc06fa-5a35-470d-9061-c11302918158
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9337,7 +9337,7 @@ paths:
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991267656
+                  admin_id: 991270018
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -9363,27 +9363,27 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '414'
+                    id: '1012'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '63'
+                      id: '193'
                       name: my-ticket-type-6
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id619_that_should_be_at_least_
                       archived: false
-                      created_at: 1709226865
-                      updated_at: 1709226865
+                      created_at: 1709290151
+                      updated_at: 1709290151
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '191'
+                          id: '517'
                           workspace_id: this_is_an_id619_that_should_be_at_least_
                           name: title
                           description: ola
@@ -9395,12 +9395,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 63
+                          ticket_type_id: 193
                           archived: false
-                          created_at: 1709226866
-                          updated_at: 1709226866
+                          created_at: 1709290152
+                          updated_at: 1709290152
                         - type: ticket_type_attribute
-                          id: '192'
+                          id: '518'
                           workspace_id: this_is_an_id619_that_should_be_at_least_
                           name: description
                           description: ola
@@ -9412,31 +9412,31 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 63
+                          ticket_type_id: 193
                           archived: false
-                          created_at: 1709226866
-                          updated_at: 1709226866
+                          created_at: 1709290152
+                          updated_at: 1709290152
                     contacts:
                       type: contact.list
                       contacts:
-                      - id: 65e0bb726abd017c52346144
+                      - id: 65e1b2a8ba4d1239c7e51a90
                         role: user
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709226866
-                    updated_at: 1709226867
+                    created_at: 1709290153
+                    updated_at: 1709290153
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '81'
+                        id: '242'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709226867
-                        updated_at: 1709226867
+                        created_at: 1709290153
+                        updated_at: 1709290153
                         author:
-                          id: '991267676'
+                          id: '991270038'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id619_that_should_be_at_least_@intercom.io
@@ -9453,7 +9453,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1ef64853-c3dc-46e9-8dc2-fcab40489865
+                    request_id: 706a5a08-8857-42eb-9157-b0d3e4ac2552
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9468,9 +9468,9 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  ticket_type_id: 63
+                  ticket_type_id: 193
                   contacts:
-                  - id: 65e0bb726abd017c52346144
+                  - id: 65e1b2a8ba4d1239c7e51a90
                   ticket_attributes:
                     title: example
                     description: there is a problem
@@ -9501,27 +9501,27 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '415'
+                    id: '1013'
                     ticket_attributes:
                       title: example
                       description: there is a problem
                     ticket_state: in_progress
                     ticket_type:
                       type: ticket_type
-                      id: '65'
+                      id: '195'
                       name: my-ticket-type-8
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id623_that_should_be_at_least_
                       archived: false
-                      created_at: 1709226868
-                      updated_at: 1709226868
+                      created_at: 1709290155
+                      updated_at: 1709290155
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '196'
+                          id: '522'
                           workspace_id: this_is_an_id623_that_should_be_at_least_
                           name: title
                           description: ola
@@ -9533,12 +9533,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 65
+                          ticket_type_id: 195
                           archived: false
-                          created_at: 1709226868
-                          updated_at: 1709226868
+                          created_at: 1709290155
+                          updated_at: 1709290155
                         - type: ticket_type_attribute
-                          id: '197'
+                          id: '523'
                           workspace_id: this_is_an_id623_that_should_be_at_least_
                           name: description
                           description: ola
@@ -9550,84 +9550,84 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 65
+                          ticket_type_id: 195
                           archived: false
-                          created_at: 1709226868
-                          updated_at: 1709226868
+                          created_at: 1709290155
+                          updated_at: 1709290155
                     contacts:
                       type: contact.list
                       contacts:
-                      - id: 65e0bb756abd017c52346145
+                      - id: 65e1b2abba4d1239c7e51a91
                         role: lead
-                    admin_assignee_id: '991267690'
+                    admin_assignee_id: '991270052'
                     team_assignee_id: '0'
-                    created_at: 1709226869
-                    updated_at: 1709226871
+                    created_at: 1709290155
+                    updated_at: 1709290158
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '82'
+                        id: '243'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709226869
-                        updated_at: 1709226869
+                        created_at: 1709290156
+                        updated_at: 1709290156
                         author:
-                          id: '991267688'
+                          id: '991270050'
                           type: admin
                           name: Ciaran401 Lee
                           email: admin401@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '83'
+                        id: '244'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709226870
-                        updated_at: 1709226870
+                        created_at: 1709290158
+                        updated_at: 1709290158
                         author:
-                          id: '991267689'
+                          id: '991270051'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id623_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '84'
+                        id: '245'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1709226870
-                        updated_at: 1709226870
+                        created_at: 1709290158
+                        updated_at: 1709290158
                         author:
-                          id: '991267689'
+                          id: '991270051'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id623_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '85'
+                        id: '246'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: in_progress
                         previous_ticket_state: submitted
-                        created_at: 1709226871
-                        updated_at: 1709226871
+                        created_at: 1709290158
+                        updated_at: 1709290158
                         author:
-                          id: '991267689'
+                          id: '991270051'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id623_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '86'
+                        id: '247'
                         part_type: assignment
-                        created_at: 1709226871
-                        updated_at: 1709226871
+                        created_at: 1709290158
+                        updated_at: 1709290158
                         assigned_to:
                           type: admin
-                          id: '991267690'
+                          id: '991270052'
                         author:
-                          id: '991267688'
+                          id: '991270050'
                           type: admin
                           name: Ciaran401 Lee
                           email: admin401@email.com
@@ -9644,14 +9644,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 98fd3baf-0f29-4f0b-92ef-934641fa88cb
+                    request_id: a30f4072-7305-4ddd-93c3-b18264489b6e
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
                 Assignee not found:
                   value:
                     type: error.list
-                    request_id: 8f91e3f3-4f50-4b47-aa64-f4b9112d26d9
+                    request_id: f7f25072-db0f-4708-84f8-f2f7a62cee2d
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
@@ -9663,7 +9663,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: be6a4314-69ed-45de-9fcf-906b7ef3e7d8
+                    request_id: 9028ebe3-37ea-4ae2-8179-d2c4e8757d82
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9683,8 +9683,8 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991267688'
-                    assignee_id: '991267690'
+                    admin_id: '991270050'
+                    assignee_id: '991270052'
                   open: true
                   snoozed_until: 1673609604
               admin_not_found:
@@ -9696,7 +9696,7 @@ paths:
                   state: in_progress
                   assignment:
                     admin_id: '123'
-                    assignee_id: '991267698'
+                    assignee_id: '991270060'
               assignee_not_found:
                 summary: Assignee not found
                 value:
@@ -9705,7 +9705,7 @@ paths:
                     description: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991267704'
+                    admin_id: '991270066'
                     assignee_id: '456'
     get:
       summary: Retrieve a ticket
@@ -9733,27 +9733,27 @@ paths:
                 Ticket found:
                   value:
                     type: ticket
-                    id: '418'
+                    id: '1016'
                     ticket_attributes:
                       title: attribute_value
                       description:
                     ticket_state: submitted
                     ticket_type:
                       type: ticket_type
-                      id: '69'
+                      id: '199'
                       name: my-ticket-type-12
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id631_that_should_be_at_least_
                       archived: false
-                      created_at: 1709226878
-                      updated_at: 1709226878
+                      created_at: 1709290166
+                      updated_at: 1709290166
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '207'
+                          id: '533'
                           workspace_id: this_is_an_id631_that_should_be_at_least_
                           name: title
                           description: ola
@@ -9765,12 +9765,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 69
+                          ticket_type_id: 199
                           archived: false
-                          created_at: 1709226878
-                          updated_at: 1709226878
+                          created_at: 1709290167
+                          updated_at: 1709290167
                         - type: ticket_type_attribute
-                          id: '208'
+                          id: '534'
                           workspace_id: this_is_an_id631_that_should_be_at_least_
                           name: description
                           description: ola
@@ -9782,31 +9782,31 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 69
+                          ticket_type_id: 199
                           archived: false
-                          created_at: 1709226878
-                          updated_at: 1709226878
+                          created_at: 1709290167
+                          updated_at: 1709290167
                     contacts:
                       type: contact.list
                       contacts:
-                      - id: 65e0bb7e6abd017c52346148
+                      - id: 65e1b2b7ba4d1239c7e51a94
                         role: lead
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1709226878
-                    updated_at: 1709226879
+                    created_at: 1709290167
+                    updated_at: 1709290168
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '89'
+                        id: '250'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1709226879
-                        updated_at: 1709226879
+                        created_at: 1709290168
+                        updated_at: 1709290168
                         author:
-                          id: '991267717'
+                          id: '991270079'
                           type: admin
                           name: Ciaran427 Lee
                           email: admin427@email.com
@@ -9823,7 +9823,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 97572bcd-ab4b-430c-981b-c27a09c94707
+                    request_id: 248ef8f9-b5bf-4fdd-b893-095fd1d747ae
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9855,26 +9855,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0bb826abd017c5234614b
+                    id: 65e1b2bcba4d1239c7e51a97
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Turquoise Glasses
+                    pseudonym: Rose Leaf
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/turquoise-glasses.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/rose-leaf.png
                     app_id: this_is_an_id638_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226882
-                    remote_created_at: 1709226882
-                    signed_up_at: 1709226882
-                    updated_at: 1709226883
+                    created_at: 1709290172
+                    remote_created_at: 1709290172
+                    signed_up_at: 1709290172
+                    updated_at: 1709290173
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -9907,7 +9907,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 9b8da192-5537-4f1b-b3fc-5f873d81aec4
+                    request_id: e51421c9-b266-43cc-9de1-85c32906cfa1
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -9921,7 +9921,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5d5ac1ec-10cb-4226-9665-705bfe471628
+                    request_id: 6b676feb-fa1b-4d03-bdcf-e4e3228b6a10
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9936,7 +9936,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 65e0bb826abd017c5234614b
+                  id: 65e1b2bcba4d1239c7e51a97
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -9969,7 +9969,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0bb846abd017c52346151
+                    id: 65e1b2beba4d1239c7e51a9d
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -9985,10 +9985,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226884
-                    remote_created_at: 1709226884
-                    signed_up_at: 1709226884
-                    updated_at: 1709226884
+                    created_at: 1709290174
+                    remote_created_at: 1709290174
+                    signed_up_at: 1709290174
+                    updated_at: 1709290174
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10021,7 +10021,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: b9e5f19b-e423-4308-a02b-0944b3d69c8b
+                    request_id: b79aefe6-2f4a-4531-9794-3bc6c6265e72
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -10035,7 +10035,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1522a80d-fbfc-4236-9862-968f6f1d3f82
+                    request_id: 25d79270-c6a0-4dc4-b4c2-59ec9af208dc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10069,7 +10069,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0bb866abd017c52346157
+                    id: 65e1b2c0ba4d1239c7e51aa3
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -10085,10 +10085,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226886
-                    remote_created_at: 1709226886
-                    signed_up_at: 1709226886
-                    updated_at: 1709226886
+                    created_at: 1709290176
+                    remote_created_at: 1709290176
+                    signed_up_at: 1709290176
+                    updated_at: 1709290176
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10121,7 +10121,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: 0d2fb504-f7c3-453a-949a-db30cb3b1b0d
+                    request_id: f69de64e-b041-4c05-a4a3-ac9cb51d0d87
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -10135,7 +10135,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 58e1bb43-04ec-4acc-b8e6-059eba9a0153
+                    request_id: a7d9d3bf-32a5-42e7-b63f-665a938ced59
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10168,7 +10168,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 65e0bb876abd017c5234615d
+                    id: 65e1b2c1ba4d1239c7e51aa9
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -10184,10 +10184,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1709226887
-                    remote_created_at: 1709226887
-                    signed_up_at: 1709226887
-                    updated_at: 1709226888
+                    created_at: 1709290177
+                    remote_created_at: 1709290177
+                    signed_up_at: 1709290177
+                    updated_at: 1709290178
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -10220,7 +10220,7 @@ paths:
                 Visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 1fb95927-0b4a-4669-ba1d-8e173d6f7c9a
+                    request_id: 15fab4df-9c80-4a1d-a1bd-432c083f0aca
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -10234,7 +10234,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 06fca336-f59b-4b68-b4e1-0a8ce03466c6
+                    request_id: a47b518b-d83b-4fde-a55e-28bee50588c9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10265,7 +10265,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 65e0bb8a6abd017c52346164
+                    id: 65e1b2c3ba4d1239c7e51ab0
                     workspace_id: this_is_an_id662_that_should_be_at_least_
                     external_id:
                     role: user
@@ -10280,9 +10280,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1709226890
-                    updated_at: 1709226890
-                    signed_up_at: 1709226889
+                    created_at: 1709290179
+                    updated_at: 1709290180
+                    signed_up_at: 1709290179
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -10316,31 +10316,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/65e0bb8a6abd017c52346164/tags"
+                      url: "/contacts/65e1b2c3ba4d1239c7e51ab0/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/65e0bb8a6abd017c52346164/notes"
+                      url: "/contacts/65e1b2c3ba4d1239c7e51ab0/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/65e0bb8a6abd017c52346164/companies"
+                      url: "/contacts/65e1b2c3ba4d1239c7e51ab0/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bb8a6abd017c52346164/subscriptions"
+                      url: "/contacts/65e1b2c3ba4d1239c7e51ab0/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/65e0bb8a6abd017c52346164/subscriptions"
+                      url: "/contacts/65e1b2c3ba4d1239c7e51ab0/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -10359,7 +10359,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 49ecae63-47d0-4182-8fa8-143c0fd0392d
+                    request_id: 41b65ea3-baeb-45d1-aa0a-cd4aa91ddf88
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -12569,7 +12569,8 @@ components:
       properties:
         type:
           type: string
-          description: This includes conversation, push, facebook, twitter and email.
+          description: This includes conversation, email, facebook, instagram, phone_call,
+            phone_switch, push, sms, twitter and whatsapp.
           example: conversation
         id:
           type: string


### PR DESCRIPTION
toward [318937](https://github.com/intercom/intercom/issues/318937) & [325446](https://github.com/intercom/intercom/pull/325446)

- Adds `attachment_files` to conversation replies because it is [available in the API](https://github.com/intercom/intercom/blob/master/app/controllers/api/v3/conversations_controller.rb#L821-L837) but missing from the docs
- Fix the broken id option in the path param
- Update some formatting leftover from README
