### PR TITLE
Update Unstable spec with email metadata schemas

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991268907'
+                    id: '991267626'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1717022502
+                      created_at: 1718118338
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991268908'
+                    id: '991267627'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 007776b5-20b1-4bf4-b6f2-ac7b47d414a9
+                    request_id: 9441959b-8a84-499c-8b82-dd322b23bb77
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b9cbd1d4-909c-4e3f-8672-6a64a9146433
+                    request_id: 56643e5a-92db-44a2-bd95-496904512ce2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,10 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: a2b03980-134e-4850-8f86-65dbc9875bc8
+                    - id: 79bae04a-a58b-475d-8429-fd9876fe37e4
                       performed_by:
                         type: admin
-                        id: '991268912'
+                        id: '991267631'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -213,21 +213,21 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1717022508
+                      created_at: 1718118344
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
-                    - id: 0e00fa23-a4d7-41c8-a69b-e1074efca20c
+                    - id: 0ae03979-cb77-4663-a04f-4f23c6d8c358
                       performed_by:
                         type: admin
-                        id: '991268912'
+                        id: '991267631'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
                         before: before
                         after: after
-                      created_at: 1717022508
+                      created_at: 1718118344
                       activity_type: app_name_change
                       activity_description: Ciaran5 Lee changed your app name from
                         before to after.
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 47e3e4cc-cb42-4b69-858a-a27d6addc6b6
+                    request_id: aca11707-a247-4bc8-aa6f-3d20063c53fd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991268914'
+                      id: '991267633'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7a8acc4a-d4fd-493e-9ec1-f684effdfc9d
+                    request_id: 894d290e-daa4-415c-9f37-c02c4d0fe5ce
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991268916'
+                    id: '991267635'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 1f027f9a-001d-4581-8657-83dbc9d8ff95
+                    request_id: d8d2150c-ebc2-4396-bbf0-425a3baed971
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c72c8f9a-6765-4e9f-b185-0d7f354ef1a4
+                    request_id: f617b024-1086-4605-bdca-0a785e8a7d28
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -379,30 +379,30 @@ paths:
                 successful:
                   value:
                     data:
-                    - id: 1
+                    - id: 33
                       type: content_import_source
-                      last_synced_at: 1717022511
+                      last_synced_at: 1718118348
                       status: active
                       url: https://support.example.com/us/1
                       sync_behavior: automatic
-                      created_at: 1717022511
-                      updated_at: 1717022511
-                    - id: 2
+                      created_at: 1718118348
+                      updated_at: 1718118348
+                    - id: 34
                       type: content_import_source
-                      last_synced_at: 1717022511
+                      last_synced_at: 1718118348
                       status: active
                       url: https://support.example.com/us/2
                       sync_behavior: automatic
-                      created_at: 1717022511
-                      updated_at: 1717022511
-                    - id: 3
+                      created_at: 1718118348
+                      updated_at: 1718118348
+                    - id: 35
                       type: content_import_source
-                      last_synced_at: 1717022511
+                      last_synced_at: 1718118348
                       status: active
                       url: https://support.example.com/us/3
                       sync_behavior: automatic
-                      created_at: 1717022511
-                      updated_at: 1717022511
+                      created_at: 1718118348
+                      updated_at: 1718118348
                     pages:
                       type: pages
                       page: 1
@@ -420,7 +420,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a5f3ddd0-f386-4bfb-93a9-d9007c312c9d
+                    request_id: 8f26d04c-b01c-435e-a1d1-a22e7075e511
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -446,14 +446,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 4
+                    id: 36
                     type: content_import_source
-                    last_synced_at: 1717022512
+                    last_synced_at: 1718118350
                     status: active
                     url: https://www.example.com
                     sync_behavior: api
-                    created_at: 1717022512
-                    updated_at: 1717022512
+                    created_at: 1718118350
+                    updated_at: 1718118350
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -464,7 +464,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e54ecd27-f7a6-4d99-8923-22a290b23b32
+                    request_id: da479ec2-c808-4fc8-b8fb-b228d6e3e2ee
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -514,7 +514,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 970ba239-598f-4b90-b449-0a03ab0b2e54
+                    request_id: c6eee5d5-2edd-4152-a6a9-5087c4726154
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -538,14 +538,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 6
+                    id: 38
                     type: content_import_source
-                    last_synced_at: 1717022514
+                    last_synced_at: 1718118351
                     status: active
                     url: https://support.example.com/us/5
                     sync_behavior: api
-                    created_at: 1717022514
-                    updated_at: 1717022514
+                    created_at: 1718118351
+                    updated_at: 1718118351
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -556,7 +556,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b077b402-35f4-48d4-ae9b-a5947bad4693
+                    request_id: 3c640a15-1fc3-4350-ad31-28133fb273cd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -581,14 +581,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 7
+                    id: 39
                     type: content_import_source
-                    last_synced_at: 1717022515
+                    last_synced_at: 1718118353
                     status: active
                     url: https://www.example.com
                     sync_behavior: api
-                    created_at: 1717022515
-                    updated_at: 1717022515
+                    created_at: 1718118353
+                    updated_at: 1718118353
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -599,7 +599,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 62691f8a-bcf1-49ab-8a92-a44675037412
+                    request_id: c88d0692-f5b9-42dd-9c59-19000ca461e1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -637,7 +637,7 @@ paths:
                 successful:
                   value:
                     data:
-                    - id: '3'
+                    - id: '19'
                       type: external_page
                       title: My External Content
                       html: "<h1>Hello world</h1><p>This is external content</p>"
@@ -646,12 +646,12 @@ paths:
                       ai_copilot_availability: true
                       fin_availability: true
                       locale: en
-                      source_id: 10
+                      source_id: 42
                       external_id: '3'
-                      created_at: 1717022517
-                      updated_at: 1717022517
-                      last_ingested_at: 1717022516
-                    - id: '2'
+                      created_at: 1718118354
+                      updated_at: 1718118354
+                      last_ingested_at: 1718118354
+                    - id: '18'
                       type: external_page
                       title: My External Content
                       html: "<h1>Hello world</h1><p>This is external content</p>"
@@ -660,12 +660,12 @@ paths:
                       ai_copilot_availability: true
                       fin_availability: true
                       locale: en
-                      source_id: 9
+                      source_id: 41
                       external_id: '2'
-                      created_at: 1717022516
-                      updated_at: 1717022516
-                      last_ingested_at: 1717022516
-                    - id: '1'
+                      created_at: 1718118354
+                      updated_at: 1718118354
+                      last_ingested_at: 1718118354
+                    - id: '17'
                       type: external_page
                       title: My External Content
                       html: "<h1>Hello world</h1><p>This is external content</p>"
@@ -674,11 +674,11 @@ paths:
                       ai_copilot_availability: true
                       fin_availability: true
                       locale: en
-                      source_id: 8
+                      source_id: 40
                       external_id: '1'
-                      created_at: 1717022516
-                      updated_at: 1717022516
-                      last_ingested_at: 1717022516
+                      created_at: 1718118354
+                      updated_at: 1718118354
+                      last_ingested_at: 1718118354
                     pages:
                       type: pages
                       page: 1
@@ -696,7 +696,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '05985780-6e5c-4b7b-9498-76c0ef85b9e8'
+                    request_id: c39c0c88-fe56-4952-892a-585e3b1e4b81
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -723,7 +723,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '5'
+                    id: '21'
                     type: external_page
                     title: Test
                     html: "<html><body><h1>Test</h1></body></html>"
@@ -732,11 +732,11 @@ paths:
                     ai_copilot_availability: true
                     fin_availability: true
                     locale: en
-                    source_id: 12
+                    source_id: 44
                     external_id: abc1234
-                    created_at: 1717022518
-                    updated_at: 1717022519
-                    last_ingested_at: 1717022519
+                    created_at: 1718118356
+                    updated_at: 1718118356
+                    last_ingested_at: 1718118356
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -747,7 +747,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4ecc5a45-effa-45b4-86ee-d6c8aa640842
+                    request_id: 50b4f941-57f7-442a-9a6d-f5f10f560cb0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -765,7 +765,7 @@ paths:
                   external_id: abc1234
                   html: "<html><body><h1>Test</h1></body></html>"
                   locale: en
-                  source_id: 12
+                  source_id: 44
                   title: Test
                   url: https://www.example.com
   "/ai/external_pages/{id}":
@@ -796,7 +796,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '6'
+                    id: '22'
                     type: external_page
                     title: My External Content
                     html: "<h1>Hello world</h1><p>This is external content</p>"
@@ -805,11 +805,11 @@ paths:
                     ai_copilot_availability: true
                     fin_availability: true
                     locale: en
-                    source_id: 13
+                    source_id: 45
                     external_id: '4'
-                    created_at: 1717022519
-                    updated_at: 1717022519
-                    last_ingested_at: 1717022519
+                    created_at: 1718118357
+                    updated_at: 1718118357
+                    last_ingested_at: 1718118357
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -820,7 +820,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8c7a6d4d-3202-408f-a1bc-e50350c0c2c4
+                    request_id: 99b62135-f4a1-439b-a9f4-c652a5d23fb6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -845,7 +845,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '7'
+                    id: '23'
                     type: external_page
                     title: My External Content
                     html: "<h1>Hello world</h1><p>This is external content</p>"
@@ -854,11 +854,11 @@ paths:
                     ai_copilot_availability: true
                     fin_availability: true
                     locale: en
-                    source_id: 14
+                    source_id: 46
                     external_id: '5'
-                    created_at: 1717022520
-                    updated_at: 1717022520
-                    last_ingested_at: 1717022520
+                    created_at: 1718118358
+                    updated_at: 1718118358
+                    last_ingested_at: 1718118358
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -869,7 +869,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 191fffa8-7553-438c-a0c3-f7b026ff1252
+                    request_id: 11bdc045-5b10-46b8-9e1a-b6b2091eb0be
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -895,7 +895,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '8'
+                    id: '24'
                     type: external_page
                     title: Test
                     html: "<html><body><h1>Test</h1></body></html>"
@@ -904,11 +904,11 @@ paths:
                     ai_copilot_availability: true
                     fin_availability: true
                     locale: en
-                    source_id: 15
+                    source_id: 47
                     external_id: '5678'
-                    created_at: 1717022521
-                    updated_at: 1717022522
-                    last_ingested_at: 1717022522
+                    created_at: 1718118360
+                    updated_at: 1718118360
+                    last_ingested_at: 1718118360
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -919,7 +919,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 37e65448-8fd4-4a1f-bd9b-31d0d3b93b35
+                    request_id: 3c49fe52-d2ce-4323-8e3e-d21207d313bd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -937,7 +937,7 @@ paths:
                   external_id: '5678'
                   html: "<html><body><h1>Test</h1></body></html>"
                   locale: en
-                  source_id: 15
+                  source_id: 47
                   title: Test
                   url: https://www.example.com
   "/articles":
@@ -972,20 +972,20 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '90'
+                    - id: '39'
                       type: article
                       workspace_id: this_is_an_id64_that_should_be_at_least_4
-                      parent_id: 359
+                      parent_id: 143
                       parent_type: collection
                       parent_ids: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991268940
+                      author_id: 991267659
                       state: published
-                      created_at: 1717022522
-                      updated_at: 1717022522
-                      url: http://help-center.test/myapp-64/en/articles/90-this-is-the-article-title
+                      created_at: 1718118361
+                      updated_at: 1718118361
+                      url: http://help-center.test/myapp-64/en/articles/39-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -996,7 +996,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d1b04c55-0e81-4f4d-a0c3-031d8fa29cc0
+                    request_id: abb8b8f0-f717-45a3-857d-482c863b7c7d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1021,10 +1021,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '93'
+                    id: '42'
                     type: article
                     workspace_id: this_is_an_id68_that_should_be_at_least_4
-                    parent_id: 361
+                    parent_id: 145
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1038,11 +1038,11 @@ paths:
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991268945
+                    author_id: 991267664
                     state: published
-                    created_at: 1717022525
-                    updated_at: 1717022525
-                    url: http://help-center.test/myapp-68/en/articles/93-thanks-for-everything
+                    created_at: 1718118363
+                    updated_at: 1718118363
+                    url: http://help-center.test/myapp-68/en/articles/42-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -1053,7 +1053,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: dd209332-b22c-4647-a761-3818b1c3ca9a
+                    request_id: d81af0d8-e2e3-45bd-b199-6e719e52504f
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -1068,7 +1068,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 51a0a314-7879-4a5b-9e2b-a3a10e2b1044
+                    request_id: 49d7856a-318e-44df-b54f-1d526ca8e357
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1086,16 +1086,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991268945
+                  author_id: 991267664
                   state: published
-                  parent_id: 361
+                  parent_id: 145
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991268945
+                      author_id: 991267664
                       state: published
               bad_request:
                 summary: Bad Request
@@ -1132,10 +1132,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '96'
+                    id: '45'
                     type: article
                     workspace_id: this_is_an_id74_that_should_be_at_least_4
-                    parent_id: 364
+                    parent_id: 148
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1149,11 +1149,11 @@ paths:
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991268950
+                    author_id: 991267669
                     state: published
-                    created_at: 1717022527
-                    updated_at: 1717022527
-                    url: http://help-center.test/myapp-74/en/articles/96-this-is-the-article-title
+                    created_at: 1718118366
+                    updated_at: 1718118366
+                    url: http://help-center.test/myapp-74/en/articles/45-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -1164,7 +1164,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: 179aaf56-f291-447d-8e94-3bc040d7a557
+                    request_id: ca6dccef-d906-433d-a873-3b1b6702614f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1178,7 +1178,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8a350777-e8e4-475b-82cd-1465cd331617
+                    request_id: '09168cd0-4bb0-438f-b626-9cff2c7cc96e'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1211,10 +1211,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '99'
+                    id: '48'
                     type: article
                     workspace_id: this_is_an_id80_that_should_be_at_least_4
-                    parent_id: 367
+                    parent_id: 151
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1228,11 +1228,11 @@ paths:
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991268956
+                    author_id: 991267675
                     state: published
-                    created_at: 1717022529
-                    updated_at: 1717022530
-                    url: http://help-center.test/myapp-80/en/articles/99-christmas-is-here
+                    created_at: 1718118368
+                    updated_at: 1718118369
+                    url: http://help-center.test/myapp-80/en/articles/48-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -1243,7 +1243,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 379d7c26-fcb5-4c9e-a595-2e012a6b840e
+                    request_id: 913284f8-0511-4d40-bdcb-46ab4dfa8d08
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1257,7 +1257,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1599af08-be6d-4133-86a5-e000e6421341
+                    request_id: 13a2f555-b638-4b57-866b-9091d2881afb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1305,7 +1305,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '102'
+                    id: '51'
                     object: article
                     deleted: true
               schema:
@@ -1318,7 +1318,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: ecf1e043-444a-4a84-a8ea-ca707b7636eb
+                    request_id: 831ebe4a-ed3f-4818-a6e0-70e96225435b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1332,7 +1332,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d257d910-348d-4175-a672-3825d3738dfe
+                    request_id: b9cd0118-f6c2-4f65-a969-10db043287dc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1392,7 +1392,7 @@ paths:
                     total_count: 1
                     data:
                       articles:
-                      - id: '106'
+                      - id: '55'
                         type: article
                         workspace_id: this_is_an_id92_that_should_be_at_least_4
                         parent_id:
@@ -1401,10 +1401,10 @@ paths:
                         title: Title 1
                         description: ''
                         body: ''
-                        author_id: 991268969
+                        author_id: 991267688
                         state: draft
-                        created_at: 1717022534
-                        updated_at: 1717022534
+                        created_at: 1718118373
+                        updated_at: 1718118373
                         url:
                       highlights: []
                     pages:
@@ -1422,7 +1422,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b51fa501-ab6f-4e92-86b2-24fe552309fa
+                    request_id: ea7781a6-9641-439f-bbfc-360f99aeefb7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1453,27 +1453,27 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '375'
+                    - id: '159'
                       workspace_id: this_is_an_id96_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-96/collection-17
                       order: 17
-                      created_at: 1717022536
-                      updated_at: 1717022536
+                      created_at: 1718118375
+                      updated_at: 1718118375
                       description: english collection description
                       icon: bookmark
                       parent_id:
-                      help_center_id: 187
-                    - id: '376'
+                      help_center_id: 79
+                    - id: '160'
                       workspace_id: this_is_an_id96_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-96/section-1
                       order: 1
-                      created_at: 1717022536
-                      updated_at: 1717022536
+                      created_at: 1718118375
+                      updated_at: 1718118375
                       description:
                       icon: bookmark
-                      parent_id: '375'
+                      parent_id: '159'
                       help_center_id:
                     total_count: 2
                     pages:
@@ -1491,7 +1491,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '0945dbc5-8ab7-42be-a553-24ff87a2be11'
+                    request_id: 04043ff2-f412-408a-88bc-fa9e93014a7e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1516,17 +1516,17 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '381'
+                    id: '165'
                     workspace_id: this_is_an_id100_that_should_be_at_least_
                     name: Thanks for everything
                     url: http://help-center.test/myapp-100/
                     order: 1
-                    created_at: 1717022537
-                    updated_at: 1717022537
+                    created_at: 1718118376
+                    updated_at: 1718118376
                     description: ''
                     icon: book-bookmark
                     parent_id:
-                    help_center_id: 189
+                    help_center_id: 81
               schema:
                 "$ref": "#/components/schemas/collection"
         '400':
@@ -1537,7 +1537,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: d6bf0d22-d2f7-4cf6-a3c2-cd55b33e6c0f
+                    request_id: 7a66c21d-99d9-4184-8aba-3d7511c16a98
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -1551,7 +1551,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f31605cc-102d-4b02-913a-59204e69db65
+                    request_id: e7e7e2e1-c77e-4ebc-aed7-842c24a98d2b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1599,17 +1599,17 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '386'
+                    id: '170'
                     workspace_id: this_is_an_id106_that_should_be_at_least_
                     name: English collection title
                     url: http://help-center.test/myapp-106/collection-22
                     order: 22
-                    created_at: 1717022538
-                    updated_at: 1717022538
+                    created_at: 1718118378
+                    updated_at: 1718118378
                     description: english collection description
                     icon: bookmark
                     parent_id:
-                    help_center_id: 192
+                    help_center_id: 84
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1620,7 +1620,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: bafc5bdf-cf66-43a9-92e9-3ba2348d0159
+                    request_id: 82ac9c0b-579f-4883-a6b4-387ea247137c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1634,7 +1634,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 690bbaf4-9ffb-45e4-b4aa-677232ce5c2f
+                    request_id: b8e41000-ecfa-4bcc-807c-6164eb3cd5b3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1667,17 +1667,17 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '392'
+                    id: '176'
                     workspace_id: this_is_an_id112_that_should_be_at_least_
                     name: Update collection name
                     url: http://help-center.test/myapp-112/collection-25
                     order: 25
-                    created_at: 1717022540
-                    updated_at: 1717022540
+                    created_at: 1718118380
+                    updated_at: 1718118380
                     description: english collection description
                     icon: folder
                     parent_id:
-                    help_center_id: 195
+                    help_center_id: 87
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1688,7 +1688,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: a995dcc1-8c34-4b48-ba19-eca10a31f734
+                    request_id: f7dd16f0-42e3-4403-93cc-1130a6ac5572
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1702,7 +1702,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d1befa4f-ed0a-4ea9-9bea-8ad531a91037
+                    request_id: aebfb639-2e47-43fc-9282-43cbecf42b61
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1749,7 +1749,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '398'
+                    id: '182'
                     object: collection
                     deleted: true
               schema:
@@ -1762,7 +1762,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: 24a1823d-13dd-4832-96a7-5eb8b2c85b11
+                    request_id: d536f2e2-64f3-4fd1-8c08-f280803960bc
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1776,7 +1776,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ceb8027e-6cb7-488a-8470-c2f87e8fb585
+                    request_id: 45f2f5ba-5fb0-43fe-a5ec-5303ca3a5c36
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1810,10 +1810,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '201'
+                    id: '93'
                     workspace_id: this_is_an_id124_that_should_be_at_least_
-                    created_at: 1717022544
-                    updated_at: 1717022544
+                    created_at: 1718118383
+                    updated_at: 1718118383
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1827,7 +1827,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: df11b608-f774-4d9c-a07c-50712ed90825
+                    request_id: 31f84970-d193-4bd3-a18f-755632e68e63
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1841,7 +1841,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4ca4092d-7794-4d85-88f9-e7b6f1452266
+                    request_id: ab46bcba-300d-4703-a657-4f1f141f845f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1879,7 +1879,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e5b8daf1-295b-43aa-9a31-6aa2db647dc6
+                    request_id: 6361e6bc-e198-4850-b2b6-ace3ccfcd8b6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1916,12 +1916,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 6657af566abd0169343f1e01
+                    id: 666867f55cb57e49376d3eca
                     app_id: this_is_an_id147_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1717022550
-                    updated_at: 1717022550
+                    created_at: 1718118389
+                    updated_at: 1718118389
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1958,7 +1958,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fa6ac24d-66a6-46f3-9ca8-6434ff3c2217
+                    request_id: cb91c7e4-4fed-4614-a845-2f8129cc5d0c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2056,12 +2056,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 6657af586abd0169343f1e09
+                      id: 666867f75cb57e49376d3ed2
                       app_id: this_is_an_id153_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1717022552
-                      created_at: 1717022552
-                      updated_at: 1717022552
+                      remote_created_at: 1718118391
+                      created_at: 1718118391
+                      updated_at: 1718118391
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2090,7 +2090,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: af2a5245-6c28-47bc-95e9-27b5dd3ff667
+                    request_id: 06e93b4f-e6f5-4c28-9b34-3f18452ab26b
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2104,7 +2104,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b6eac092-4e8d-4889-b60f-f0d8bff424b1
+                    request_id: 19cca33e-25d5-462d-b286-8e76a648f399
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2139,12 +2139,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 6657af5a6abd0169343f1e14
+                    id: 666867fb5cb57e49376d3edd
                     app_id: this_is_an_id159_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1717022554
-                    created_at: 1717022554
-                    updated_at: 1717022554
+                    remote_created_at: 1718118395
+                    created_at: 1718118395
+                    updated_at: 1718118395
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2166,7 +2166,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 48155285-4cb4-4535-af99-0e28ce9677cb
+                    request_id: 69125236-3de6-47a8-aae3-72316708e775
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2180,7 +2180,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f7352f19-538c-40d3-838b-c4b9ec714b14
+                    request_id: ef805802-07fc-43d9-8f40-094a59e541e4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2219,12 +2219,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 6657af5d6abd0169343f1e1e
+                    id: 666867fd5cb57e49376d3ee7
                     app_id: this_is_an_id165_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1717022557
-                    created_at: 1717022557
-                    updated_at: 1717022557
+                    remote_created_at: 1718118397
+                    created_at: 1718118397
+                    updated_at: 1718118397
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2246,7 +2246,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: b27f5293-7a00-42fa-93b1-0cefbe06343d
+                    request_id: d9bf6a75-167d-4fbf-b1af-44a3e7c54c3f
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2260,7 +2260,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8612e8f5-15c7-4d7a-ad97-e809922c8af2
+                    request_id: 9fc30c87-9066-4142-8c48-d58fa0aef0c1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2292,7 +2292,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 6657af5f6abd0169343f1e28
+                    id: 666868005cb57e49376d3ef1
                     object: company
                     deleted: true
               schema:
@@ -2305,7 +2305,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: edf1ed8b-6a3f-4a16-8188-298f9dad6df0
+                    request_id: cb007a14-29a6-4da5-84e9-4f6db5e73eab
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2319,7 +2319,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fc503eab-1708-44a0-a94e-37bc9c713576
+                    request_id: 00c33183-80b9-45db-944b-30999a0f3ecb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2371,7 +2371,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 6630bad8-85e3-4665-a455-8834efb0c5b7
+                    request_id: bee968a5-bbab-462a-b32d-db711e3d1fa5
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2385,7 +2385,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 936e0efe-d820-4dec-902d-f05dde8e9fc9
+                    request_id: 94d02fe1-4625-4e40-a691-ed5bcb536d99
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2430,7 +2430,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 41c74073-1f81-4f3e-8093-2ddd8639bb5a
+                    request_id: 218ebebf-e004-404b-a2fc-25dfc351f7e1
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2444,7 +2444,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a3acad03-5f03-4c07-b385-a6e898c01fe6
+                    request_id: 8eaea12f-5f66-4c3c-b350-6aaab19aee79
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2505,12 +2505,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 6657af666abd0169343f1e44
+                      id: 666868085cb57e49376d3f0d
                       app_id: this_is_an_id189_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1717022566
-                      created_at: 1717022566
-                      updated_at: 1717022566
+                      remote_created_at: 1718118408
+                      created_at: 1718118408
+                      updated_at: 1718118408
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2539,7 +2539,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 68e6a84d-9f3f-4de6-b7cb-f681ede893d8
+                    request_id: f47e4c49-0d38-46bb-88f4-b9a600d9b2f3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2590,12 +2590,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 6657af686abd0169343f1e4a
+                      id: 6668680a5cb57e49376d3f13
                       app_id: this_is_an_id193_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1717022568
-                      created_at: 1717022568
-                      updated_at: 1717022568
+                      remote_created_at: 1718118410
+                      created_at: 1718118410
+                      updated_at: 1718118410
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2609,7 +2609,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: efbbcc55-abe1-41b2-b1fd-d86ffd95f328
+                    scroll_param: e16ccd5f-653e-47cf-9b0d-c54618fc22f5
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2620,7 +2620,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 64658ac9-ed8e-4329-a18f-1be8fc05eb6b
+                    request_id: adcfd666-3d79-4a35-bc5a-30311089276b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2655,12 +2655,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 6657af6a6abd0169343f1e53
+                    id: 6668680c5cb57e49376d3f1c
                     app_id: this_is_an_id197_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1717022570
-                    created_at: 1717022570
-                    updated_at: 1717022570
+                    remote_created_at: 1718118412
+                    created_at: 1718118412
+                    updated_at: 1718118412
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2682,7 +2682,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 1cdb8ae5-7ccf-438c-aff9-e6f0d2699b8c
+                    request_id: 389fb692-d54b-40d1-b512-c73541d23de1
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2696,7 +2696,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: '07490397-59a4-43ad-8858-365f500f825b'
+                    request_id: aac0867b-9497-4413-8126-9e3cbc766c9d
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2710,7 +2710,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e9b3be2b-65a4-4ca7-ad01-fa3f16481219
+                    request_id: 0f45d27b-49c3-4926-9378-4e7bcd462406
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2733,7 +2733,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 6657af6a6abd0169343f1e53
+                  id: 6668680c5cb57e49376d3f1c
               bad_request:
                 summary: Bad Request
                 value:
@@ -2772,13 +2772,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 6657af716abd0169343f1e74
+                      id: 666868135cb57e49376d3f3d
                       app_id: this_is_an_id213_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1717022577
-                      created_at: 1717022577
-                      updated_at: 1717022577
-                      last_request_at: 1716849777
+                      remote_created_at: 1718118419
+                      created_at: 1718118419
+                      updated_at: 1718118419
+                      last_request_at: 1717945619
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2807,7 +2807,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: e39aeee8-47b0-49bb-9fc2-fb80ce9e9e59
+                    request_id: 9ffc2da6-fbb3-46c5-8718-deaeb72fef85
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2821,7 +2821,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0e1be404-45f3-4b62-bf03-d9d853700ed8
+                    request_id: 29188929-3c85-4728-9e64-89edb9124327
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2864,12 +2864,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 6657af6d6abd0169343f1e63
+                    id: 666868105cb57e49376d3f2c
                     app_id: this_is_an_id205_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1717022573
-                    created_at: 1717022573
-                    updated_at: 1717022574
+                    remote_created_at: 1718118416
+                    created_at: 1718118416
+                    updated_at: 1718118416
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2891,14 +2891,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 362533e5-ec3f-4c23-96cb-12c8d509c063
+                    request_id: ea9521cc-c2a8-4717-9d7f-159720fcc853
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: add5a6ad-a312-4248-8e38-3d528ecb555e
+                    request_id: a8e654c2-c32f-422d-9fd0-4f38b38229c4
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2912,7 +2912,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 21892f79-e649-4157-927b-ba6d83788af0
+                    request_id: 80be4d6f-fd32-4f56-918e-de9499482fe2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2948,42 +2948,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '68'
-                      created_at: 1716417779
+                      id: '29'
+                      created_at: 1717513623
                       contact:
                         type: contact
-                        id: 6657af736abd0169343f1e7f
+                        id: 666868175cb57e49376d3f48
                       author:
                         type: admin
-                        id: '991269029'
+                        id: '991267748'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '67'
-                      created_at: 1716331379
+                      id: '28'
+                      created_at: 1717427223
                       contact:
                         type: contact
-                        id: 6657af736abd0169343f1e7f
+                        id: 666868175cb57e49376d3f48
                       author:
                         type: admin
-                        id: '991269029'
+                        id: '991267748'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '66'
-                      created_at: 1716331379
+                      id: '27'
+                      created_at: 1717427223
                       contact:
                         type: contact
-                        id: 6657af736abd0169343f1e7f
+                        id: 666868175cb57e49376d3f48
                       author:
                         type: admin
-                        id: '991269029'
+                        id: '991267748'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
@@ -3006,7 +3006,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 8a719ddd-3c26-4b49-bdd5-0a8cac2e2d00
+                    request_id: c91b0fe5-d0de-49b4-a069-e71976a97662
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3040,14 +3040,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '73'
-                    created_at: 1717022580
+                    id: '34'
+                    created_at: 1718118424
                     contact:
                       type: contact
-                      id: 6657af746abd0169343f1e81
+                      id: 666868185cb57e49376d3f4a
                     author:
                       type: admin
-                      id: '991269031'
+                      id: '991267750'
                       name: Ciaran124 Lee
                       email: admin124@email.com
                       away_mode_enabled: false
@@ -3063,14 +3063,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 690d9a6f-76f3-4ea9-a43e-9a7adf9391b0
+                    request_id: b66d7c71-2404-4912-8c24-27d6dff118aa
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 7a552478-c7ec-4dd9-b394-83c54dfaf5ad
+                    request_id: 952cccf9-e5b1-499a-96ae-7cb40169e530
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3100,20 +3100,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 6657af746abd0169343f1e81
-                  admin_id: 991269031
+                  contact_id: 666868185cb57e49376d3f4a
+                  admin_id: 991267750
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 6657af756abd0169343f1e82
+                  contact_id: 666868185cb57e49376d3f4b
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991269033
+                  admin_id: 991267752
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -3146,10 +3146,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 6657af766abd0169343f1e84
+                      id: 6668681a5cb57e49376d3f4d
                       name: segment
-                      created_at: 1717022582
-                      updated_at: 1717022582
+                      created_at: 1718118426
+                      updated_at: 1718118426
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -3161,7 +3161,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 3968150b-9d4b-427a-8664-f6258001b6ae
+                    request_id: 6d730d88-1688-4472-94c1-5a3f071a434b
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3175,7 +3175,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0fcb6957-9fe2-4e41-9215-bb78ff306422
+                    request_id: 72660bd1-cd61-4262-a8b2-ebe0dfc3b617
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3219,7 +3219,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '231'
+                      id: '93'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -3233,7 +3233,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '233'
+                      id: '95'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -3256,7 +3256,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 6da0cc3d-1bc4-45f5-bd3b-2b140edfc8d4
+                    request_id: b0fc958a-0729-417f-8932-8458348850bf
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3270,7 +3270,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: af156719-7ae8-461b-acf7-2550d918b7cf
+                    request_id: 863e1f3b-3b10-43b9-9832-60385f983e48
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3311,7 +3311,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '246'
+                    id: '108'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3334,14 +3334,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 1fcae5a4-eff4-483f-b76a-7283d9c31d58
+                    request_id: 22305127-f2b9-47f9-a98f-8b698909d630
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 17efaf4a-653b-4aef-9e6b-2b190d4257a9
+                    request_id: 9c6d14bd-23c2-4f40-ada5-e0ae1c7e98c5
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3355,7 +3355,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a39c9ccc-2fcd-45c8-a692-915e82913928
+                    request_id: b0eddce3-9bb1-40df-b4f6-d156e2b1b88f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3383,12 +3383,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 246
+                  id: 108
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 250
+                  id: 112
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -3434,7 +3434,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '262'
+                    id: '124'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3457,14 +3457,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 439619d0-9c8a-4632-a831-1b0f9770e1dd
+                    request_id: 4a52535d-4f59-46c3-87fd-a8c7fe156d1c
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 498e37ad-a976-4c92-a575-dec9fe63a5fb
+                    request_id: f5b35d36-ec3c-4611-93ba-eade9c1b6ff9
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3478,7 +3478,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7b5c1976-c363-43ab-ba95-577ba59d5e31
+                    request_id: 96f575d8-d457-494e-b78b-89e5cc39e3f6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3516,7 +3516,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '216'
+                      id: '107'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -3528,7 +3528,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 15d55139-5bc4-435f-a4d8-5a80e41f890c
+                    request_id: f9a06b4e-40a2-4730-8ce5-3a049b7dd98b
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3542,7 +3542,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: bc2301f9-68e7-4367-ae30-050d16448837
+                    request_id: 7e280079-e370-4267-965c-c89305753f2b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3577,7 +3577,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '217'
+                    id: '108'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3589,14 +3589,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 3426cac2-f647-469f-9e90-c1e1c78341ab
+                    request_id: 1aec683f-b869-4dd2-b06e-0768fd87eb53
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 61eea1a4-c113-420c-80fe-ee6ce5182c65
+                    request_id: be09c14b-9a1d-494a-b4e8-b1b782286494
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3610,7 +3610,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b47fc1bb-d835-4332-8e15-f4610f2a09ca
+                    request_id: 14f0cc42-a652-4b62-a0c2-c71a5abf1d1f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3633,11 +3633,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 217
+                  id: 108
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 218
+                  id: 109
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3679,7 +3679,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '220'
+                    id: '111'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3691,14 +3691,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: a1f932cd-1580-47be-a9ac-86bcf449e3cf
+                    request_id: a4d450ad-425f-4413-af4a-7b00c0e981af
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: bfd56df5-69a7-4189-b716-8d4d0dc8cfa0
+                    request_id: 5d4f5f78-65ef-46e5-ab68-036a24a3e198
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3712,7 +3712,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8b875fcf-ef85-484d-bdeb-5c4f6f1d70ca
+                    request_id: e410ee26-6685-4fae-9fc3-f0d341fe9dcc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3746,7 +3746,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 6657af856abd0169343f1e9b
+                    id: 6668682a5cb57e49376d3f64
                     workspace_id: this_is_an_id279_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3762,9 +3762,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1717022597
-                    updated_at: 1717022597
-                    signed_up_at: 1717022597
+                    created_at: 1718118442
+                    updated_at: 1718118442
+                    signed_up_at: 1718118442
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3798,31 +3798,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/6657af856abd0169343f1e9b/tags"
+                      url: "/contacts/6668682a5cb57e49376d3f64/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/6657af856abd0169343f1e9b/notes"
+                      url: "/contacts/6668682a5cb57e49376d3f64/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/6657af856abd0169343f1e9b/companies"
+                      url: "/contacts/6668682a5cb57e49376d3f64/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657af856abd0169343f1e9b/subscriptions"
+                      url: "/contacts/6668682a5cb57e49376d3f64/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657af856abd0169343f1e9b/subscriptions"
+                      url: "/contacts/6668682a5cb57e49376d3f64/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3841,7 +3841,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e4eceaf0-b7c2-472f-9a31-9b219599fe83
+                    request_id: 58da5dbb-9fc8-4c51-9a82-4f51a64dcea1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3886,7 +3886,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 6657af876abd0169343f1e9c
+                    id: 6668682c5cb57e49376d3f65
                     workspace_id: this_is_an_id283_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3902,9 +3902,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1717022599
-                    updated_at: 1717022599
-                    signed_up_at: 1717022599
+                    created_at: 1718118444
+                    updated_at: 1718118444
+                    signed_up_at: 1718118444
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3938,31 +3938,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/6657af876abd0169343f1e9c/tags"
+                      url: "/contacts/6668682c5cb57e49376d3f65/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/6657af876abd0169343f1e9c/notes"
+                      url: "/contacts/6668682c5cb57e49376d3f65/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/6657af876abd0169343f1e9c/companies"
+                      url: "/contacts/6668682c5cb57e49376d3f65/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657af876abd0169343f1e9c/subscriptions"
+                      url: "/contacts/6668682c5cb57e49376d3f65/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657af876abd0169343f1e9c/subscriptions"
+                      url: "/contacts/6668682c5cb57e49376d3f65/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3981,7 +3981,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ea05ff6d-5f60-4752-8f71-e6f2bed60426
+                    request_id: 195b290d-2a38-461f-8e4a-ebfea8c61e23
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4012,7 +4012,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 6657af886abd0169343f1e9d
+                    id: 6668682d5cb57e49376d3f66
                     external_id: '70'
                     type: contact
                     deleted: true
@@ -4026,7 +4026,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3f3bef2b-d9bc-4379-b7cd-f31569b79992
+                    request_id: 42c0af11-30e1-45a5-a552-7a94be68be09
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4054,7 +4054,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 6657af896abd0169343f1e9f
+                    id: 6668682f5cb57e49376d3f68
                     workspace_id: this_is_an_id291_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -4070,9 +4070,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1717022601
-                    updated_at: 1717022602
-                    signed_up_at: 1717022601
+                    created_at: 1718118447
+                    updated_at: 1718118447
+                    signed_up_at: 1718118447
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -4106,31 +4106,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/6657af896abd0169343f1e9f/tags"
+                      url: "/contacts/6668682f5cb57e49376d3f68/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/6657af896abd0169343f1e9f/notes"
+                      url: "/contacts/6668682f5cb57e49376d3f68/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/6657af896abd0169343f1e9f/companies"
+                      url: "/contacts/6668682f5cb57e49376d3f68/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657af896abd0169343f1e9f/subscriptions"
+                      url: "/contacts/6668682f5cb57e49376d3f68/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657af896abd0169343f1e9f/subscriptions"
+                      url: "/contacts/6668682f5cb57e49376d3f68/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4149,7 +4149,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6d64f8b4-50d3-4045-a463-f8ed9a4e87cd
+                    request_id: 393e215c-c93f-4f91-9ff9-c70daaf76cc7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4164,8 +4164,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 6657af896abd0169343f1e9e
-                  into: 6657af896abd0169343f1e9f
+                  from: 6668682f5cb57e49376d3f67
+                  into: 6668682f5cb57e49376d3f68
   "/contacts/search":
     post:
       summary: Search contacts
@@ -4304,7 +4304,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 03273127-ad86-4f63-807e-2d13c78c674e
+                    request_id: a3516d34-7d93-4cd0-a82e-2e223894d48d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4370,7 +4370,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 508244d4-b258-45d0-add0-1ed287c8818e
+                    request_id: 6db8f279-f3c0-4b5b-816b-23667393259c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4396,7 +4396,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 6657af8e6abd0169343f1ea2
+                    id: 666868345cb57e49376d3f6b
                     workspace_id: this_is_an_id303_that_should_be_at_least_
                     external_id:
                     role: user
@@ -4412,8 +4412,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1717022606
-                    updated_at: 1717022606
+                    created_at: 1718118452
+                    updated_at: 1718118452
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -4448,31 +4448,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/6657af8e6abd0169343f1ea2/tags"
+                      url: "/contacts/666868345cb57e49376d3f6b/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/6657af8e6abd0169343f1ea2/notes"
+                      url: "/contacts/666868345cb57e49376d3f6b/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/6657af8e6abd0169343f1ea2/companies"
+                      url: "/contacts/666868345cb57e49376d3f6b/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657af8e6abd0169343f1ea2/subscriptions"
+                      url: "/contacts/666868345cb57e49376d3f6b/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657af8e6abd0169343f1ea2/subscriptions"
+                      url: "/contacts/666868345cb57e49376d3f6b/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4491,7 +4491,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 302ef814-1d4b-4951-8563-8c70025a6ef6
+                    request_id: 72281639-1b49-4d32-a688-bf15b1737054
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4537,7 +4537,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 6657af8f6abd0169343f1ea3
+                    id: 666868355cb57e49376d3f6c
                     workspace_id: this_is_an_id307_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -4553,9 +4553,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1717022607
-                    updated_at: 1717022607
-                    signed_up_at: 1717022607
+                    created_at: 1718118453
+                    updated_at: 1718118453
+                    signed_up_at: 1718118453
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -4589,31 +4589,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/6657af8f6abd0169343f1ea3/tags"
+                      url: "/contacts/666868355cb57e49376d3f6c/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/6657af8f6abd0169343f1ea3/notes"
+                      url: "/contacts/666868355cb57e49376d3f6c/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/6657af8f6abd0169343f1ea3/companies"
+                      url: "/contacts/666868355cb57e49376d3f6c/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657af8f6abd0169343f1ea3/subscriptions"
+                      url: "/contacts/666868355cb57e49376d3f6c/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657af8f6abd0169343f1ea3/subscriptions"
+                      url: "/contacts/666868355cb57e49376d3f6c/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4632,7 +4632,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 173c02d3-7e6e-4bd0-8821-dd5412c2e423
+                    request_id: 26cd1ff2-0d55-4b73-b8c6-d9056e85b823
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4665,7 +4665,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 6657af906abd0169343f1ea5
+                    id: 666868375cb57e49376d3f6e
                     external_id: '70'
                     type: contact
                     archived: true
@@ -4698,7 +4698,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 6657af916abd0169343f1ea6
+                    id: 666868385cb57e49376d3f6f
                     external_id: '70'
                     type: contact
                     archived: false
@@ -4734,7 +4734,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '222'
+                    id: '113'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4746,7 +4746,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: cb62c1e0-1ca5-4c71-a1f8-84c55302965f
+                    request_id: 4c9e523a-d9bd-453b-9342-25b0a472cdd1
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4760,7 +4760,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 67abb0db-6479-4728-862c-2b8e88fe0e9f
+                    request_id: 4b80a571-bd04-4b48-a14d-42d7485c0074
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4789,13 +4789,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 222
-                  admin_id: 991269066
+                  id: 113
+                  admin_id: 991267785
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 223
-                  admin_id: 991269068
+                  id: 114
+                  admin_id: 991267787
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4833,7 +4833,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '225'
+                    id: '116'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4845,14 +4845,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 0aa0bf6f-5389-44b4-83b6-fa00324749f5
+                    request_id: ea41de0c-e46d-4302-bf0c-c3ac0f52af31
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: caac0057-6fa0-4f97-a013-04eb18260e1e
+                    request_id: 6e7bc7ca-d5eb-4298-b458-ccbd27cba431
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4866,7 +4866,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 63faf9d0-af22-45b7-bd0e-19deb403f04a
+                    request_id: be8ce718-9c1e-48c5-87ed-eb72983f58f8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4889,15 +4889,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991269070
+                  admin_id: 991267789
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991269072
+                  admin_id: 991267791
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991269073
+                  admin_id: 991267792
   "/conversations":
     get:
       summary: List all conversations
@@ -4948,20 +4948,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '783'
-                      created_at: 1717022618
-                      updated_at: 1717022618
+                      id: '475'
+                      created_at: 1718118465
+                      updated_at: 1718118465
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918484'
+                        id: '403918341'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991269076'
+                          id: '991267795'
                           name: Ciaran166 Lee
                           email: admin166@email.com
                         attachments: []
@@ -4971,7 +4971,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 6657af9a6abd0169343f1eaa
+                          id: 666868415cb57e49376d3f73
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -5008,7 +5008,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a9ed6714-e120-4b26-965d-591a24e12fe6
+                    request_id: 205ae028-dfc0-4689-bcc6-37ab266d485e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5022,7 +5022,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 53da1201-292d-426f-9dc0-a2b09a80739b
+                    request_id: 78dc2abc-f04b-4a2a-8d62-f265c1c23033
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5058,11 +5058,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918494'
-                    created_at: 1717022642
+                    id: '403918351'
+                    created_at: 1718118490
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '811'
+                    conversation_id: '503'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -5073,7 +5073,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: dd598643-7d99-4473-91fe-71295c1fdfcc
+                    request_id: 146218c3-5cc5-4147-81bb-2b37f466a654
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -5087,7 +5087,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3c146517-49bf-42e3-9300-42c7d585a77f
+                    request_id: 8f8fd618-1bb0-4c29-b2c2-3fa298aadb21
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5101,7 +5101,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 22e2ab44-381c-4523-81fc-6f6f0127d4a1
+                    request_id: cc78bc9e-a6e4-4b83-8788-7a9b39963d91
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5118,7 +5118,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 6657afb16abd0169343f1ec2
+                    id: 666868595cb57e49376d3f8b
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -5172,20 +5172,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '815'
-                    created_at: 1717022648
-                    updated_at: 1717022648
+                    id: '507'
+                    created_at: 1718118497
+                    updated_at: 1718118497
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918498'
+                      id: '403918355'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269093'
+                        id: '991267812'
                         name: Ciaran176 Lee
                         email: admin176@email.com
                       attachments: []
@@ -5195,7 +5195,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657afb76abd0169343f1ec6
+                        id: 666868615cb57e49376d3f8f
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5236,7 +5236,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 999a3560-081a-4289-aa12-8022a3952701
+                    request_id: ad1df763-29dc-4070-a51a-bfcfd0cac289
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5250,7 +5250,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 578ae080-2ede-4d41-ab80-6e784e830bc6
+                    request_id: c9a7bec4-0a82-45b4-98c1-2bc005ec32fa
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5264,7 +5264,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: cb3f4fdc-3d4a-430c-afe6-bed30f8c6da9
+                    request_id: 5d6ba466-9216-4cc4-8d63-60cd3cf23d9b
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5311,20 +5311,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '819'
-                    created_at: 1717022654
-                    updated_at: 1717022655
+                    id: '511'
+                    created_at: 1718118504
+                    updated_at: 1718118506
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918502'
+                      id: '403918359'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269101'
+                        id: '991267820'
                         name: Ciaran180 Lee
                         email: admin180@email.com
                       attachments: []
@@ -5334,7 +5334,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657afbe6abd0169343f1eca
+                        id: 666868685cb57e49376d3f93
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5367,15 +5367,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '213'
+                        id: '202'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1717022655
-                        updated_at: 1717022655
-                        notified_at: 1717022655
+                        created_at: 1718118506
+                        updated_at: 1718118506
+                        notified_at: 1718118506
                         assigned_to:
                         author:
-                          id: '991269102'
+                          id: '991267821'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id354_that_should_be_at_least_@intercom.io
@@ -5383,16 +5383,17 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
+                        email_message_metadata:
                       - type: conversation_part
-                        id: '214'
+                        id: '203'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1717022655
-                        updated_at: 1717022655
-                        notified_at: 1717022655
+                        created_at: 1718118506
+                        updated_at: 1718118506
+                        notified_at: 1718118506
                         assigned_to:
                         author:
-                          id: '991269102'
+                          id: '991267821'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id354_that_should_be_at_least_@intercom.io
@@ -5400,6 +5401,7 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
+                        email_message_metadata:
                       total_count: 2
               schema:
                 "$ref": "#/components/schemas/conversation"
@@ -5411,7 +5413,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: f67a8f13-3721-463d-aa31-0493be595652
+                    request_id: 2bb3f528-d8ef-407a-9e75-9dfad92bcc0c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5425,7 +5427,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fcc7d8b8-22fc-4af9-9f34-8acbf1ee7b73
+                    request_id: 1f1f2c03-e903-4ffb-85a4-a22c51073653
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5439,7 +5441,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: b980af41-1d4e-48c8-9f65-5e7a844b57fd
+                    request_id: 03c8ceea-ba8f-471a-b276-c098c3f20d32
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5490,7 +5492,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '823'
+                    id: '515'
                     object: conversation
                     deleted: true
               schema:
@@ -5503,7 +5505,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d0a31941-3f2c-4005-b0e1-ccffdb322a7a
+                    request_id: 16e7010b-d7ac-4e05-b5d7-14dd0ff7324f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5517,7 +5519,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 105cc26a-0710-4480-b1c5-541b702c9a4e
+                    request_id: 755d736a-29e0-489f-91aa-0f10272e8308
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5650,20 +5652,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '826'
-                      created_at: 1717022666
-                      updated_at: 1717022666
+                      id: '518'
+                      created_at: 1718118518
+                      updated_at: 1718118519
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918509'
+                        id: '403918366'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991269131'
+                          id: '991267850'
                           name: Ciaran203 Lee
                           email: admin203@email.com
                         attachments: []
@@ -5673,7 +5675,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 6657afca6abd0169343f1ed1
+                          id: 666868765cb57e49376d3f9a
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -5749,20 +5751,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '835'
-                    created_at: 1717022673
-                    updated_at: 1717022674
-                    waiting_since: 1717022674
+                    id: '527'
+                    created_at: 1718118526
+                    updated_at: 1718118527
+                    waiting_since: 1718118527
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918512'
+                      id: '403918369'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269134'
+                        id: '991267853'
                         name: Ciaran205 Lee
                         email: admin205@email.com
                       attachments: []
@@ -5772,10 +5774,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657afd16abd0169343f1ed9
+                        id: 6668687e5cb57e49376d3fa2
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1717022674
+                      created_at: 1718118527
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5806,15 +5808,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '216'
+                        id: '205'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1717022674
-                        updated_at: 1717022674
-                        notified_at: 1717022674
+                        created_at: 1718118527
+                        updated_at: 1718118527
+                        notified_at: 1718118527
                         assigned_to:
                         author:
-                          id: 6657afd16abd0169343f1ed9
+                          id: 6668687e5cb57e49376d3fa2
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5822,41 +5824,25 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
-                      - type: conversation_part
-                        id: '217'
-                        part_type: language_detection_details
-                        body:
-                        created_at: 1717022674
-                        updated_at: 1717022674
-                        notified_at: 1717022674
-                        assigned_to:
-                        author:
-                          id: '991269135'
-                          type: bot
-                          name: Operator
-                          email: operator+this_is_an_id371_that_should_be_at_least_@intercom.io
-                        attachments: []
-                        external_id:
-                        redacted: false
-                        metadata: {}
-                      total_count: 2
+                        email_message_metadata:
+                      total_count: 1
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '836'
-                    created_at: 1717022676
-                    updated_at: 1717022677
+                    id: '528'
+                    created_at: 1718118529
+                    updated_at: 1718118530
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918513'
+                      id: '403918370'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269136'
+                        id: '991267855'
                         name: Ciaran206 Lee
                         email: admin206@email.com
                       attachments: []
@@ -5866,7 +5852,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657afd36abd0169343f1eda
+                        id: 666868815cb57e49376d3fa3
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5897,7 +5883,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '218'
+                        id: '206'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5912,12 +5898,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1717022677
-                        updated_at: 1717022677
-                        notified_at: 1717022677
+                        created_at: 1718118530
+                        updated_at: 1718118530
+                        notified_at: 1718118530
                         assigned_to:
                         author:
-                          id: '991269136'
+                          id: '991267855'
                           type: admin
                           name: Ciaran206 Lee
                           email: admin206@email.com
@@ -5925,24 +5911,25 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
+                        email_message_metadata:
                       total_count: 1
                 Admin quick_reply reply:
                   value:
                     type: conversation
-                    id: '837'
-                    created_at: 1717022678
-                    updated_at: 1717022678
+                    id: '529'
+                    created_at: 1718118531
+                    updated_at: 1718118532
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918514'
+                      id: '403918371'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269138'
+                        id: '991267857'
                         name: Ciaran207 Lee
                         email: admin207@email.com
                       attachments: []
@@ -5952,7 +5939,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657afd66abd0169343f1edb
+                        id: 666868835cb57e49376d3fa4
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5983,15 +5970,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '219'
+                        id: '207'
                         part_type: quick_reply
                         body:
-                        created_at: 1717022678
-                        updated_at: 1717022678
-                        notified_at: 1717022678
+                        created_at: 1718118532
+                        updated_at: 1718118532
+                        notified_at: 1718118532
                         assigned_to:
                         author:
-                          id: '991269138'
+                          id: '991267857'
                           type: admin
                           name: Ciaran207 Lee
                           email: admin207@email.com
@@ -5999,24 +5986,25 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
+                        email_message_metadata:
                       total_count: 1
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '838'
-                    created_at: 1717022680
-                    updated_at: 1717022681
-                    waiting_since: 1717022680
+                    id: '530'
+                    created_at: 1718118533
+                    updated_at: 1718118534
+                    waiting_since: 1718118534
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918515'
+                      id: '403918372'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269140'
+                        id: '991267859'
                         name: Ciaran208 Lee
                         email: admin208@email.com
                       attachments: []
@@ -6026,10 +6014,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657afd76abd0169343f1edc
+                        id: 666868855cb57e49376d3fa5
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1717022680
+                      created_at: 1718118534
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6060,15 +6048,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '220'
+                        id: '208'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1717022680
-                        updated_at: 1717022680
-                        notified_at: 1717022680
+                        created_at: 1718118534
+                        updated_at: 1718118534
+                        notified_at: 1718118534
                         assigned_to:
                         author:
-                          id: 6657afd76abd0169343f1edc
+                          id: 666868855cb57e49376d3fa5
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6076,24 +6064,8 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
-                      - type: conversation_part
-                        id: '221'
-                        part_type: language_detection_details
-                        body:
-                        created_at: 1717022681
-                        updated_at: 1717022681
-                        notified_at: 1717022681
-                        assigned_to:
-                        author:
-                          id: '991269141'
-                          type: bot
-                          name: Operator
-                          email: operator+this_is_an_id377_that_should_be_at_least_@intercom.io
-                        attachments: []
-                        external_id:
-                        redacted: false
-                        metadata: {}
-                      total_count: 2
+                        email_message_metadata:
+                      total_count: 1
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6104,7 +6076,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 9d11c2df-823a-4031-b828-b98b4d71c17f
+                    request_id: 7f79ca6a-1bfc-42f0-bcb0-bd596e40acc0
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6118,7 +6090,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6a36b1f0-79cb-46cc-b2e7-1b212eacb8ef
+                    request_id: e7b9502b-eb9b-4d4a-8df5-404317af87d1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6132,7 +6104,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 460d9439-79ec-4f86-85ed-0f2d7605f531
+                    request_id: eb4c055a-6c52-463b-9236-5e0c7ecbe380
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6149,14 +6121,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 6657afd16abd0169343f1ed9
+                  intercom_user_id: 6668687e5cb57e49376d3fa2
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991269136
+                  admin_id: 991267855
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -6166,25 +6138,25 @@ paths:
                 value:
                   message_type: quick_reply
                   type: admin
-                  admin_id: 991269138
+                  admin_id: 991267857
                   reply_options:
                   - text: 'Yes'
-                    uuid: 2ec5825c-dc6a-471c-922d-853da622d898
+                    uuid: 1e3ec7a1-4e81-410a-9505-afa8bb678894
                   - text: 'No'
-                    uuid: 67b3f3a5-7837-411c-8d96-2746601c1801
+                    uuid: 18da8770-b2e3-439c-8d4f-0157d33efd06
               user_last_conversation_reply:
                 summary: User last conversation reply
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 6657afd76abd0169343f1edc
+                  intercom_user_id: 666868855cb57e49376d3fa5
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 6657afda6abd0169343f1edd
+                  intercom_user_id: 666868885cb57e49376d3fa6
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -6219,20 +6191,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '842'
-                    created_at: 1717022686
-                    updated_at: 1717022687
+                    id: '534'
+                    created_at: 1718118541
+                    updated_at: 1718118542
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918519'
+                      id: '403918376'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269148'
+                        id: '991267867'
                         name: Ciaran212 Lee
                         email: admin212@email.com
                       attachments: []
@@ -6242,7 +6214,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657afde6abd0169343f1ee0
+                        id: 6668688c5cb57e49376d3fa9
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6273,15 +6245,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '222'
+                        id: '209'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1717022687
-                        updated_at: 1717022687
-                        notified_at: 1717022687
+                        created_at: 1718118542
+                        updated_at: 1718118542
+                        notified_at: 1718118542
                         assigned_to:
                         author:
-                          id: '991269148'
+                          id: '991267867'
                           type: admin
                           name: Ciaran212 Lee
                           email: admin212@email.com
@@ -6289,24 +6261,25 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
+                        email_message_metadata:
                       total_count: 1
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '843'
-                    created_at: 1717022688
-                    updated_at: 1717022689
+                    id: '535'
+                    created_at: 1718118543
+                    updated_at: 1718118544
                     waiting_since:
-                    snoozed_until: 1717026289
+                    snoozed_until: 1718122144
                     source:
                       type: conversation
-                      id: '403918520'
+                      id: '403918377'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269150'
+                        id: '991267869'
                         name: Ciaran213 Lee
                         email: admin213@email.com
                       attachments: []
@@ -6316,7 +6289,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657afe06abd0169343f1ee1
+                        id: 6668688f5cb57e49376d3faa
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6347,15 +6320,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '223'
+                        id: '210'
                         part_type: snoozed
                         body:
-                        created_at: 1717022689
-                        updated_at: 1717022689
-                        notified_at: 1717022689
+                        created_at: 1718118544
+                        updated_at: 1718118544
+                        notified_at: 1718118544
                         assigned_to:
                         author:
-                          id: '991269150'
+                          id: '991267869'
                           type: admin
                           name: Ciaran213 Lee
                           email: admin213@email.com
@@ -6363,24 +6336,25 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
+                        email_message_metadata:
                       total_count: 1
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '848'
-                    created_at: 1717022688
-                    updated_at: 1717022698
+                    id: '540'
+                    created_at: 1718118543
+                    updated_at: 1718118553
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918521'
+                      id: '403918378'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269152'
+                        id: '991267871'
                         name: Ciaran214 Lee
                         email: admin214@email.com
                       attachments: []
@@ -6390,7 +6364,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657afe46abd0169343f1ee6
+                        id: 666868945cb57e49376d3faf
                         external_id: '74'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6421,15 +6395,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '225'
+                        id: '212'
                         part_type: open
                         body:
-                        created_at: 1717022698
-                        updated_at: 1717022698
-                        notified_at: 1717022698
+                        created_at: 1718118553
+                        updated_at: 1718118553
+                        notified_at: 1718118553
                         assigned_to:
                         author:
-                          id: '991269152'
+                          id: '991267871'
                           type: admin
                           name: Ciaran214 Lee
                           email: admin214@email.com
@@ -6437,24 +6411,25 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
+                        email_message_metadata:
                       total_count: 1
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '853'
-                    created_at: 1717022699
-                    updated_at: 1717022699
+                    id: '545'
+                    created_at: 1718118554
+                    updated_at: 1718118555
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918524'
+                      id: '403918381'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269155'
+                        id: '991267874'
                         name: Ciaran216 Lee
                         email: admin216@email.com
                       attachments: []
@@ -6464,10 +6439,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657afea6abd0169343f1eea
+                        id: 6668689a5cb57e49376d3fb3
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991269155
+                    admin_assignee_id: 991267874
                     team_assignee_id:
                     open: true
                     state: open
@@ -6495,17 +6470,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '226'
+                        id: '213'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1717022699
-                        updated_at: 1717022699
-                        notified_at: 1717022699
+                        created_at: 1718118555
+                        updated_at: 1718118555
+                        notified_at: 1718118555
                         assigned_to:
                           type: admin
-                          id: '991269155'
+                          id: '991267874'
                         author:
-                          id: '991269155'
+                          id: '991267874'
                           type: admin
                           name: Ciaran216 Lee
                           email: admin216@email.com
@@ -6513,6 +6488,7 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
+                        email_message_metadata:
                       total_count: 1
               schema:
                 "$ref": "#/components/schemas/conversation"
@@ -6524,7 +6500,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: c0c96e14-6170-4085-9b60-fdc7f8f2b192
+                    request_id: '016579d2-b731-4a91-8bd9-4451a2edbed5'
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6538,7 +6514,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ae0851a1-f9ff-4e97-b874-080cda92c5ad
+                    request_id: d83d8bc0-1ccb-4171-b771-d9d585a097fe
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6552,7 +6528,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 79e0d327-e93e-4194-a77b-06c8080241c1
+                    request_id: 60ab4e0a-170e-4372-9baa-621c241a754e
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6573,32 +6549,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991269148
+                  admin_id: 991267867
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991269150
-                  snoozed_until: 1717026289
+                  admin_id: 991267869
+                  snoozed_until: 1718122144
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991269152
+                  admin_id: 991267871
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991269155
-                  assignee_id: 991269155
+                  admin_id: 991267874
+                  assignee_id: 991267874
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991269157
+                  admin_id: 991267876
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -6632,20 +6608,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '857'
-                    created_at: 1717022705
-                    updated_at: 1717022706
+                    id: '549'
+                    created_at: 1718119014
+                    updated_at: 1718119015
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918528'
+                      id: '403918385'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269163'
+                        id: '991267882'
                         name: Ciaran220 Lee
                         email: admin220@email.com
                       attachments: []
@@ -6655,7 +6631,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657aff06abd0169343f1eee
+                        id: 66686a665cb57e49376d3fb7
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6686,17 +6662,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '227'
+                        id: '214'
                         part_type: default_assignment
                         body:
-                        created_at: 1717022706
-                        updated_at: 1717022706
-                        notified_at: 1717022706
+                        created_at: 1718119015
+                        updated_at: 1718119015
+                        notified_at: 1718119015
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991269164'
+                          id: '991267883'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id400_that_should_be_at_least_@intercom.io
@@ -6704,6 +6680,7 @@ paths:
                         external_id:
                         redacted: false
                         metadata: {}
+                        email_message_metadata:
                       total_count: 1
               schema:
                 "$ref": "#/components/schemas/conversation"
@@ -6715,7 +6692,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: b5b900bb-7ded-48ed-ae7c-8a1c750cb47a
+                    request_id: e22adc0f-a0fa-4839-b123-1e1072ccb70a
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6729,7 +6706,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3eba3d4e-ee4e-482a-98b5-a7853737ed56
+                    request_id: be03a1ce-882c-4a27-a9a0-929a40bac809
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6743,7 +6720,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 2048bde5-26c5-4573-bd17-71d62733e635
+                    request_id: 348ba6f2-4248-4906-8b3e-fdc089a706ac
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6784,7 +6761,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 6657aff76abd0169343f1ef2
+                      id: 66686a6d5cb57e49376d3fbb
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6795,7 +6772,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 9ecb8a1f-325d-4510-a968-03c25533a9fb
+                    request_id: 1f00772b-9066-4774-b9f9-d65bf1bfa71c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6809,7 +6786,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c3570617-466e-44e0-a5c2-deeba5260cb3
+                    request_id: a477fc67-9c5e-4c36-85a5-590e92579596
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6823,7 +6800,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 87169ba6-be0f-4af1-8c89-c7afb3041fee
+                    request_id: d6957894-449f-4e7c-9ecf-5883d1c0507c
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6838,15 +6815,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991269171
+                  admin_id: 991267890
                   customer:
-                    intercom_user_id: 6657aff76abd0169343f1ef2
+                    intercom_user_id: 66686a6d5cb57e49376d3fbb
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991269173
+                  admin_id: 991267892
                   customer:
-                    intercom_user_id: 6657aff96abd0169343f1ef3
+                    intercom_user_id: 66686a6f5cb57e49376d3fbc
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -6889,7 +6866,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 6657b0046abd0169343f1efe
+                      id: 66686a7b5cb57e49376d3fc7
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6900,14 +6877,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: d32d1a13-745e-4f09-b959-3600fce85af1
+                    request_id: 88ba159f-3ecb-451e-b0bb-f94e8c12cf8e
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 2ecd4e89-039a-467e-9bd5-64fceda5f49f
+                    request_id: 1047694d-9bbd-44f9-b0be-714d63a9798e
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -6921,7 +6898,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: 935ad8fe-40e7-45ea-b90f-d0917fa0fd22
+                    request_id: 464a0494-2dd6-4399-875b-cb1ccdaf1ad3
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -6935,7 +6912,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c09f856a-2bee-4925-b235-9277459cc985
+                    request_id: e0a89bc2-0e97-43ce-b9c7-49a04e02b211
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6949,7 +6926,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 713ca642-2480-4d5e-8a76-b1685cfa2e73
+                    request_id: 7bb4f71c-e7ca-48e4-a0c2-4d759883ca37
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6964,27 +6941,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991269179
+                  admin_id: 991267898
                   customer:
-                    intercom_user_id: 6657affe6abd0169343f1ef6
+                    intercom_user_id: 66686a745cb57e49376d3fbf
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991269182
+                  admin_id: 991267901
                   customer:
-                    intercom_user_id: 6657b0066abd0169343f1eff
+                    intercom_user_id: 66686a7c5cb57e49376d3fc8
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991269185
+                  admin_id: 991267904
                   customer:
-                    intercom_user_id: 6657b00d6abd0169343f1f07
+                    intercom_user_id: 66686a845cb57e49376d3fd0
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991269188
+                  admin_id: 991267907
                   customer:
-                    intercom_user_id: 6657b0156abd0169343f1f0f
+                    intercom_user_id: 66686a8c5cb57e49376d3fd8
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -7012,20 +6989,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '919'
-                    created_at: 1717022764
-                    updated_at: 1717022767
-                    waiting_since: 1717022765
+                    id: '611'
+                    created_at: 1718120060
+                    updated_at: 1718120061
+                    waiting_since: 1718120060
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918554'
+                      id: '403918411'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991269197'
+                        id: '991267916'
                         name: Ciaran240 Lee
                         email: admin240@email.com
                       attachments: []
@@ -7035,10 +7012,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657b02c6abd0169343f1f27
+                        id: 66686e7b5cb57e49376d3ff0
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1717022765
+                      created_at: 1718120060
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -7069,15 +7046,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '235'
+                        id: '222'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1717022765
-                        updated_at: 1717022767
-                        notified_at: 1717022765
+                        created_at: 1718120060
+                        updated_at: 1718120061
+                        notified_at: 1718120060
                         assigned_to:
                         author:
-                          id: 6657b02c6abd0169343f1f27
+                          id: 66686e7b5cb57e49376d3ff0
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -7085,24 +7062,8 @@ paths:
                         external_id:
                         redacted: true
                         metadata: {}
-                      - type: conversation_part
-                        id: '236'
-                        part_type: language_detection_details
-                        body:
-                        created_at: 1717022766
-                        updated_at: 1717022766
-                        notified_at: 1717022766
-                        assigned_to:
-                        author:
-                          id: '991269198'
-                          type: bot
-                          name: Operator
-                          email: operator+this_is_an_id434_that_should_be_at_least_@intercom.io
-                        attachments: []
-                        external_id:
-                        redacted: false
-                        metadata: {}
-                      total_count: 2
+                        email_message_metadata:
+                      total_count: 1
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -7113,7 +7074,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 77253cf9-5798-4829-830f-908c337f3ea1
+                    request_id: 2a5e8b7a-5c88-49be-904e-4521af2c4b86
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -7127,7 +7088,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ed5c2c65-b1e5-4c9c-b6a5-2ad3726ae691
+                    request_id: f714a5ff-1e9a-4234-9680-515f971ba896
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7143,8 +7104,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 919
-                  conversation_part_id: 235
+                  conversation_id: 611
+                  conversation_part_id: 222
               not_found:
                 summary: Not found
                 value:
@@ -7179,22 +7140,22 @@ paths:
                 successful:
                   value:
                     type: ticket
-                    id: '922'
-                    ticket_id: '41'
+                    id: '614'
+                    ticket_id: '37'
                     ticket_attributes: {}
                     ticket_state: submitted
                     ticket_state_internal_label: Submitted
                     ticket_state_external_label: Submitted
                     ticket_type:
                       type: ticket_type
-                      id: '159'
+                      id: '79'
                       name: my-ticket-type-1
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id440_that_should_be_at_least_
                       archived: false
-                      created_at: 1717022774
-                      updated_at: 1717022774
+                      created_at: 1718120069
+                      updated_at: 1718120069
                       is_internal: false
                       ticket_type_attributes:
                         type: list
@@ -7204,55 +7165,43 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657b0346abd0169343f1f2a
+                        id: 66686e825cb57e49376d3ff3
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1717022772
-                    updated_at: 1717022775
+                    created_at: 1718120066
+                    updated_at: 1718120069
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '239'
+                        id: '224'
                         part_type: comment
                         body: "<p>Comment for message</p>"
-                        created_at: 1717022772
-                        updated_at: 1717022772
+                        created_at: 1718120066
+                        updated_at: 1718120066
                         author:
-                          id: 6657b0346abd0169343f1f2a
+                          id: 66686e825cb57e49376d3ff3
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '240'
-                        part_type: language_detection_details
-                        created_at: 1717022772
-                        updated_at: 1717022772
-                        author:
-                          id: '991269207'
-                          type: bot
-                          name: Operator
-                          email: operator+this_is_an_id440_that_should_be_at_least_@intercom.io
-                        attachments: []
-                        redacted: false
-                      - type: ticket_part
-                        id: '241'
+                        id: '225'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1717022775
-                        updated_at: 1717022775
+                        created_at: 1718120069
+                        updated_at: 1718120069
                         author:
-                          id: '991269207'
+                          id: '991267926'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id440_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
-                      total_count: 3
+                      total_count: 2
                     open: true
                     linked_objects:
                       type: list
@@ -7271,7 +7220,7 @@ paths:
                 Bad request:
                   value:
                     type: error.list
-                    request_id: 798864e2-3006-4bb4-b1ff-533c3bbeab4a
+                    request_id: 4d8555ff-3af1-4527-a3dc-cb4d765a5dbf
                     errors:
                     - code: parameter_invalid
                       message: Ticket type is not a customer ticket type
@@ -7286,11 +7235,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  ticket_type_id: '159'
+                  ticket_type_id: '79'
               bad_request:
                 summary: Bad request
                 value:
-                  ticket_type_id: '160'
+                  ticket_type_id: '80'
   "/custom_object_instances/{custom_object_type_identifier}":
     parameters:
     - name: custom_object_type_identifier
@@ -7319,14 +7268,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '1'
+                    id: '11'
                     type: object_type_identifier_1
                     custom_attributes: {}
                     external_id: '123'
                     external_created_at: 1392036272
                     external_updated_at: 1392036272
-                    created_at: 1717022779
-                    updated_at: 1717022779
+                    created_at: 1718120074
+                    updated_at: 1718120074
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7337,7 +7286,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b0018270-2bb0-4d68-b127-d8918ccfbb54
+                    request_id: 4abb3631-9a58-436c-b41e-0ca059fd4d68
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7397,14 +7346,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '3'
+                    id: '13'
                     type: object_type_identifier_4
                     custom_attributes: {}
                     external_id: '123'
                     external_created_at:
                     external_updated_at:
-                    created_at: 1717022781
-                    updated_at: 1717022781
+                    created_at: 1718120075
+                    updated_at: 1718120075
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7415,7 +7364,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8d400e4d-4add-41da-b6bb-c283b7ec0a8a
+                    request_id: d44ec6de-b0c2-40b5-9ebd-593d17eadc2b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7455,14 +7404,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '4'
+                    id: '14'
                     type: object_type_identifier_6
                     custom_attributes: {}
                     external_id: '123'
                     external_created_at:
                     external_updated_at:
-                    created_at: 1717022782
-                    updated_at: 1717022782
+                    created_at: 1718120076
+                    updated_at: 1718120076
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7473,7 +7422,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: eac5ec38-d4d8-4f75-a9d6-a9e86e3f8995
+                    request_id: 353d7756-5181-4c50-ac6c-7bc82260a8ce
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7504,7 +7453,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '5'
+                    id: '15'
                     object: object_type_identifier_8
                     deleted: true
               schema:
@@ -7517,7 +7466,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c74aa6ed-993a-42bf-9653-6db65c168984
+                    request_id: 7d019b5d-1781-4427-b543-216f85227b51
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7703,7 +7652,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 82
+                    - id: 34
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -7716,9 +7665,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991269224'
-                      created_at: 1717022783
-                      updated_at: 1717022783
+                      admin_id: '991267943'
+                      created_at: 1718120079
+                      updated_at: 1718120079
                       model: company
                     - type: data_attribute
                       name: id
@@ -7790,7 +7739,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 73e78c89-e1a4-4636-98a8-fbdd04016d30
+                    request_id: 35d94089-b762-4aa5-abe8-de930181d63e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7815,7 +7764,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 85
+                    id: 37
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -7826,9 +7775,9 @@ paths:
                     messenger_writable: false
                     custom: true
                     archived: false
-                    admin_id: '991269226'
-                    created_at: 1717022785
-                    updated_at: 1717022785
+                    admin_id: '991267945'
+                    created_at: 1718120080
+                    updated_at: 1718120080
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -7840,7 +7789,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: 43ae31d6-dc65-4d2f-8169-0c31819227b5
+                    request_id: 977c95e9-e76e-4881-ac34-23a6e0975cde
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -7848,7 +7797,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: 22848dda-eae0-49c2-8213-a25600825798
+                    request_id: eee7c946-882c-4f99-815a-5e8942ec0240
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -7856,7 +7805,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: 6459b448-ca02-4d98-8256-2df027306e33
+                    request_id: 97ed6d68-2f41-4746-8b77-c456a31c5929
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -7864,14 +7813,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: 3bb6cbf9-3560-43d1-866d-bbfe617a181e
+                    request_id: b0e114ad-7288-4770-ab6a-301a2d23cabc
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: 2dd08d25-f837-49c0-b8ba-2675f4155003
+                    request_id: 5243551b-d846-4761-8bc0-a85db42fd166
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -7886,7 +7835,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a7174243-606c-4fe2-b702-b597c0290baf
+                    request_id: 7d3d1a52-922d-4659-beee-b826b6476088
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7965,7 +7914,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 92
+                    id: 44
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -7980,9 +7929,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991269233'
-                    created_at: 1717022788
-                    updated_at: 1717022788
+                    admin_id: '991267952'
+                    created_at: 1718120084
+                    updated_at: 1718120084
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -7994,7 +7943,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: 68699d81-1d7d-4f65-989e-e381fb6bf66d
+                    request_id: bfa0f946-ed93-4671-bee3-222b4f5646e8
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -8008,7 +7957,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: dcab6caf-70ab-411a-9dae-fd8cbb3fe502
+                    request_id: cfbd45b0-c2ea-4791-afe4-bb8804a81618
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -8022,7 +7971,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: bf11cfa0-40f9-4e0f-807b-de91cfe8c3e7
+                    request_id: 2beec9bb-dd08-48f9-9352-660a67ce930d
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -8037,7 +7986,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 537371db-5b53-4381-8544-93d719eb00fe
+                    request_id: 46eb48c6-2628-4444-a96d-83951a94d868
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8142,7 +8091,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6a2f5e54-e5f8-43a9-844e-3443f6fc5c03
+                    request_id: 821e132b-945c-441d-90fa-b243c0d04600
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8229,7 +8178,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 6657b0496abd0169343f1f30
+                    intercom_user_id: 66686e995cb57e49376d3ff9
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -8241,7 +8190,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f14446ee-ba0c-46bb-8981-a74e85656ef6
+                    request_id: 0bec7a01-2c45-4b0b-be62-7e4d2a8410e2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8272,7 +8221,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 39ee1e92-9b60-4d55-879d-1b167bffbb4a
+                    request_id: bfab8093-330f-4a0c-9f09-adbc4f1cf45b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8316,7 +8265,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: pgrepn0ioiwd2rzr
+                    job_identifier: qfxii6h2bz5hnk8p
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -8331,8 +8280,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1717004796
-                  created_at_before: 1717022796
+                  created_at_after: 1718102091
+                  created_at_before: 1718120091
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -8366,7 +8315,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: j5pyejc5g3rjk3c0
+                    job_identifier: 3r8gan9jv20ewvwh
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -8398,7 +8347,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: yfa54r5i32ywqvra
+                    job_identifier: oa4mv2v2pta5bjkk
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -8459,30 +8408,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918559'
-                    created_at: 1717022798
+                    id: '403918416'
+                    created_at: 1718120094
                     body: heyy
                     message_type: inapp
-                    conversation_id: '924'
+                    conversation_id: '616'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918560'
-                    created_at: 1717022800
+                    id: '403918417'
+                    created_at: 1718120095
                     body: heyy
                     message_type: inapp
-                    conversation_id: '925'
+                    conversation_id: '617'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '30'
-                    created_at: 1717022801
+                    id: '15'
+                    created_at: 1718120097
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991269256'
+                      id: '991267975'
                       name: Ciaran292 Lee
                       email: admin292@email.com
                       away_mode_enabled: false
@@ -8497,14 +8446,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: b64e903d-85ca-4b2e-80ee-dfe3af66edc0
+                    request_id: cdeef2d2-77f0-4304-bd90-edff002eccd3
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: f56cde8c-5ed9-4487-97e4-ea7552c4fa78
+                    request_id: 1a538c71-64ac-488d-9d3c-f622d608e0bc
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -8518,7 +8467,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: cc559af2-e7c0-4d56-bce7-59983e7cadf4
+                    request_id: be822e16-a7c8-4420-96ce-88124f210ad3
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -8532,7 +8481,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c7ce7ac6-811b-45cf-97b9-6fcd75312946
+                    request_id: dd7aba6a-add2-4379-b810-f2424a0efda6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8546,7 +8495,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 4f4ef55d-b6ff-45b4-8e81-295bc2b21d06
+                    request_id: 61bd6cde-9bca-4f6f-9b72-a89b0f228284
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -8563,7 +8512,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 6657b04e6abd0169343f1f35
+                    id: 66686e9e5cb57e49376d3ffe
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -8571,7 +8520,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 6657b04f6abd0169343f1f36
+                    id: 66686e9f5cb57e49376d3fff
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -8579,10 +8528,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991269256'
+                    id: '991267975'
                   to:
                     type: user
-                    id: 6657b0516abd0169343f1f37
+                    id: 66686ea05cb57e49376d4000
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -8590,10 +8539,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991269258'
+                    id: '991267977'
                   to:
                     type: user
-                    id: 6657b0516abd0169343f1f38
+                    id: 66686ea15cb57e49376d4001
                   message_type: inapp
                   body:
                   subject: heyy
@@ -8602,7 +8551,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991269259'
+                    id: '991267978'
                   to:
                     type: user
                     user_id: '70'
@@ -8613,10 +8562,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991269260'
+                    id: '991267979'
                   to:
                     type: user
-                    id: 6657b0536abd0169343f1f3a
+                    id: 66686ea35cb57e49376d4003
                   message_type: email
                   body:
                   subject: heyy
@@ -8647,12 +8596,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '71'
+                    - id: '30'
                       type: news-item
                       workspace_id: this_is_an_id530_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991269265
+                      sender_id: 991267986
                       state: draft
                       labels: []
                       cover_image_url:
@@ -8662,15 +8611,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1717022805
-                      updated_at: 1717022805
+                      created_at: 1718120101
+                      updated_at: 1718120101
                       newsfeed_assignments: []
-                    - id: '72'
+                    - id: '29'
                       type: news-item
                       workspace_id: this_is_an_id530_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991269267
+                      sender_id: 991267984
                       state: draft
                       labels: []
                       cover_image_url:
@@ -8680,8 +8629,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1717022805
-                      updated_at: 1717022805
+                      created_at: 1718120100
+                      updated_at: 1718120100
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -8694,7 +8643,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cc00ec94-3ba8-462e-9b57-974edbba21a5
+                    request_id: cc0c9dca-78e8-45c5-bdc3-2321ff495330
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8719,12 +8668,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '75'
+                    id: '33'
                     type: news-item
                     workspace_id: this_is_an_id534_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991269274
+                    sender_id: 991267993
                     state: live
                     labels:
                     - New
@@ -8735,10 +8684,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1717022807
-                    updated_at: 1717022807
+                    created_at: 1718120103
+                    updated_at: 1718120103
                     newsfeed_assignments:
-                    - newsfeed_id: 128
+                    - newsfeed_id: 53
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -8750,7 +8699,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 820f41e6-4382-44e1-8ce1-3d7ce6d7b32b
+                    request_id: 623af24e-a435-4372-89b3-50285e8ed7cf
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8771,14 +8720,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991269274
+                  sender_id: 991267993
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 128
+                  - newsfeed_id: 53
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -8807,12 +8756,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '76'
+                    id: '34'
                     type: news-item
                     workspace_id: this_is_an_id538_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991269277
+                    sender_id: 991267996
                     state: live
                     labels: []
                     cover_image_url:
@@ -8822,11 +8771,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1717022808
-                    updated_at: 1717022808
+                    created_at: 1718120104
+                    updated_at: 1718120104
                     newsfeed_assignments:
-                    - newsfeed_id: 130
-                      published_at: 1717022808
+                    - newsfeed_id: 55
+                      published_at: 1718120104
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -8837,7 +8786,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 235cc3b0-2915-4f37-9c7b-4f8153645e7b
+                    request_id: 8033ed6f-6c8f-4dec-8d38-bc3baacdf2e1
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8851,7 +8800,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3766c8bf-c6f2-4086-bcbc-28e4248de4a9
+                    request_id: 24c62ebc-7445-42e8-8cae-335f3ae7fdb1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8882,12 +8831,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '79'
+                    id: '37'
                     type: news-item
                     workspace_id: this_is_an_id544_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991269285
+                    sender_id: 991268004
                     state: live
                     labels: []
                     cover_image_url:
@@ -8895,8 +8844,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1717022810
-                    updated_at: 1717022811
+                    created_at: 1718120106
+                    updated_at: 1718120107
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -8908,7 +8857,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 7ed8ea99-288a-4f27-aff6-158342239a5c
+                    request_id: 55acac50-0ae2-41dd-a0a1-5497888f643f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8922,7 +8871,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: eb2c434b-4c64-4a94-b3ff-7d6556a03138
+                    request_id: 0cf24971-3374-41a1-8078-8d073b57ddd2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8939,7 +8888,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991269285
+                  sender_id: 991268004
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -8948,7 +8897,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991269288
+                  sender_id: 991268007
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -8978,7 +8927,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '82'
+                    id: '40'
                     object: news-item
                     deleted: true
               schema:
@@ -8991,7 +8940,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 3df8602e-8d1e-4b81-bf70-c1105b7fc87f
+                    request_id: a85a17f2-301a-45ab-8f13-0d3b37f5a1df
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9005,7 +8954,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3bdfb774-591c-4034-a1cb-d92a0f18a147
+                    request_id: ad3b0967-dba7-4a9f-acd6-4acf7942ed2e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9058,7 +9007,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a86e8e81-2641-4748-a8f7-d413839354bf
+                    request_id: 402d2a3d-8a06-4c3f-8ce3-c99d63674064
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9091,16 +9040,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '143'
+                    - id: '68'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1717022816
-                      updated_at: 1717022816
-                    - id: '144'
+                      created_at: 1718120112
+                      updated_at: 1718120112
+                    - id: '69'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1717022816
-                      updated_at: 1717022816
+                      created_at: 1718120112
+                      updated_at: 1718120112
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -9112,7 +9061,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3bd990d3-fc7c-42a6-833b-5445a77468d2
+                    request_id: '081e0e29-24b5-494a-a944-d34e1785620a'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9146,11 +9095,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '147'
+                    id: '72'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1717022817
-                    updated_at: 1717022817
+                    created_at: 1718120113
+                    updated_at: 1718120113
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -9161,7 +9110,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4e630be1-73ac-42ad-b338-2a917c2b39c8
+                    request_id: a33e5d36-4e48-4b02-84fe-f96bf9f63595
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9195,14 +9144,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '76'
-                    created_at: 1716331618
+                    id: '37'
+                    created_at: 1717428914
                     contact:
                       type: contact
-                      id: 6657b0626abd0169343f1f3d
+                      id: 66686eb25cb57e49376d4006
                     author:
                       type: admin
-                      id: '991269304'
+                      id: '991268023'
                       name: Ciaran339 Lee
                       email: admin339@email.com
                       away_mode_enabled: false
@@ -9218,7 +9167,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: 19ec1828-28a2-4e06-84c8-f744c57fb925
+                    request_id: f40f0271-b494-444b-89d1-4392b2d9b0e3
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9232,7 +9181,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fcfb2bad-835d-4fdb-a74b-f8bcfa37df6b
+                    request_id: c7152d9b-c085-4c18-9062-df22b39decd0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9268,16 +9217,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 6657b0646abd0169343f1f40
+                      id: 66686eb45cb57e49376d4009
                       name: John segment
-                      created_at: 1717022820
-                      updated_at: 1717022820
+                      created_at: 1718120116
+                      updated_at: 1718120116
                       person_type: user
                     - type: segment
-                      id: 6657b0646abd0169343f1f41
+                      id: 66686eb45cb57e49376d400a
                       name: Jane segment
-                      created_at: 1717022820
-                      updated_at: 1717022820
+                      created_at: 1718120116
+                      updated_at: 1718120116
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -9289,7 +9238,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6ba3afbc-492a-4bee-94c2-6a967adca8df
+                    request_id: f71d0e1a-5458-462c-879c-929801559770
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9323,10 +9272,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 6657b0656abd0169343f1f44
+                    id: 66686eb55cb57e49376d400d
                     name: John segment
-                    created_at: 1717022821
-                    updated_at: 1717022821
+                    created_at: 1718120117
+                    updated_at: 1718120117
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -9338,7 +9287,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: 44f14d65-13ad-44fd-a296-b0873e808fcd
+                    request_id: 49f27682-e1b2-4f0e-aedf-ce29bae6483b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9352,7 +9301,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5683f5e3-814e-4ade-b636-348310f1e4f1
+                    request_id: 5b38f9bc-21eb-433e-83d1-b924f24534e0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9382,7 +9331,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '275'
+                      id: '137'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -9405,7 +9354,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d301a167-9797-4124-a987-58d5c0ccec50
+                    request_id: ed380075-09b8-478d-9dca-cdb49b0d8f0e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9435,7 +9384,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/776e550a-d9c1-4683-8d5d-20902661e5c6
+                    url: http://via.intercom.io/msgr/b4f590b4-6108-47bd-adca-4854765fc6dd
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -9468,7 +9417,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1ccd2615-30fc-487f-835d-6413c90bf235
+                    request_id: 87839a64-89b7-4942-8c9d-a89cba41959c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9531,7 +9480,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '238'
+                      id: '129'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -9543,7 +9492,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c614bfb6-0583-41f6-95a2-858a92651af8
+                    request_id: 551fccf8-ffa5-43aa-a42a-75d18e5db4f7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9582,7 +9531,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '241'
+                    id: '132'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9594,7 +9543,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: 5da22fc7-7965-4603-ba0a-6747102011e6
+                    request_id: 7eaf37cd-cc64-4d01-a11c-dadc1c0e50b4
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -9608,14 +9557,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: bb2b9d71-fee0-4fd3-afac-5c16aa0e720f
+                    request_id: 3df043f8-1aaa-433b-b818-e312e5742279
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: 5d7fb70f-1a65-42ff-9526-bc4ca3101d2e
+                    request_id: 0a8e43d4-3a88-49d2-90f5-7e5e47ad9a8f
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -9629,7 +9578,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f8fa27f3-3c62-4a07-95ef-6f4ac421a4a0
+                    request_id: 4d839ee6-756b-468b-9af1-0f6608d98b98
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9695,7 +9644,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '249'
+                    id: '140'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9707,7 +9656,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 2216fc3d-5a73-4111-b012-3c775aa0294f
+                    request_id: 639a65e0-6483-4be9-bcbf-5a54ae00e427
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9721,7 +9670,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ca2014fd-f421-45b2-81b3-8f1b00e0731c
+                    request_id: 5ae858d3-8422-4cc7-9ba6-94ecafe90c07
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9757,7 +9706,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: de5291f9-4a6c-4210-84ad-f07a9a2eb64a
+                    request_id: 596ad3c2-e777-43b8-b3d5-fb3abaa906ee
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9771,7 +9720,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: 7c6763fc-826d-4ee2-91cf-e272411960a3
+                    request_id: b9e07b4b-a704-445d-afb3-3fad7fdea117
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -9786,7 +9735,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fa2a89f8-60bf-49e8-9c6c-835b41a25dee
+                    request_id: f7595537-0c86-4b94-9615-bf6b51959ac9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9824,7 +9773,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 30a27f94-69a9-4a8f-85de-2d52a76e6dbf
+                    request_id: fe77c371-1d27-46c6-9acb-a0519fd50c61
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9859,7 +9808,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991269342'
+                    id: '991268061'
                     name: team 1
                     admin_ids: []
               schema:
@@ -9872,7 +9821,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: 4d127401-d40c-4391-b087-de93cda6e9a5
+                    request_id: 116f6a7e-98af-41f9-8ca7-e3a1ec4e6aef
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -9886,7 +9835,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3d6243d3-de07-41ec-9512-7e898ba84bb0
+                    request_id: fbf1c8f7-cf6c-43e2-b1e0-4da2f71f7fab
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9919,7 +9868,7 @@ paths:
                 Ticket Type Attribute created:
                   value:
                     type: ticket_type_attribute
-                    id: '439'
+                    id: '240'
                     workspace_id: this_is_an_id636_that_should_be_at_least_
                     name: Attribute Title
                     description: Attribute Description
@@ -9932,10 +9881,10 @@ paths:
                     visible_on_create: true
                     visible_to_contacts: true
                     default: false
-                    ticket_type_id: 161
+                    ticket_type_id: 81
                     archived: false
-                    created_at: 1717022841
-                    updated_at: 1717022841
+                    created_at: 1718120138
+                    updated_at: 1718120138
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -9946,7 +9895,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: cd7fea85-d5a2-4949-8c67-950f35d3b2f5
+                    request_id: eab6d6c9-9229-4de1-add9-22a893b4df74
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9999,7 +9948,7 @@ paths:
                 Ticket Type Attribute updated:
                   value:
                     type: ticket_type_attribute
-                    id: '444'
+                    id: '245'
                     workspace_id: this_is_an_id640_that_should_be_at_least_
                     name: name
                     description: New Attribute Description
@@ -10010,10 +9959,10 @@ paths:
                     visible_on_create: false
                     visible_to_contacts: false
                     default: false
-                    ticket_type_id: 163
+                    ticket_type_id: 83
                     archived: false
-                    created_at: 1717022842
-                    updated_at: 1717022843
+                    created_at: 1718120139
+                    updated_at: 1718120140
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -10024,7 +9973,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d838c3c4-69bc-43d0-b40e-92c6aaa5d264
+                    request_id: f10af1f4-4f11-4ba7-be69-a2284f57c331
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10063,20 +10012,20 @@ paths:
                     type: list
                     data:
                     - type: ticket_type
-                      id: '165'
+                      id: '85'
                       name: Bug Report
                       description: Bug Report Template
                       icon: "\U0001F39F️"
                       workspace_id: this_is_an_id644_that_should_be_at_least_
                       archived: false
-                      created_at: 1717022843
-                      updated_at: 1717022843
+                      created_at: 1718120140
+                      updated_at: 1718120140
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '447'
+                          id: '248'
                           workspace_id: this_is_an_id644_that_should_be_at_least_
                           name: _default_title_
                           description: ''
@@ -10089,12 +10038,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 165
+                          ticket_type_id: 85
                           archived: false
-                          created_at: 1717022843
-                          updated_at: 1717022843
+                          created_at: 1718120141
+                          updated_at: 1718120141
                         - type: ticket_type_attribute
-                          id: '449'
+                          id: '250'
                           workspace_id: this_is_an_id644_that_should_be_at_least_
                           name: name
                           description: description
@@ -10106,12 +10055,12 @@ paths:
                           visible_on_create: false
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 165
+                          ticket_type_id: 85
                           archived: false
-                          created_at: 1717022843
-                          updated_at: 1717022843
+                          created_at: 1718120141
+                          updated_at: 1718120141
                         - type: ticket_type_attribute
-                          id: '448'
+                          id: '249'
                           workspace_id: this_is_an_id644_that_should_be_at_least_
                           name: _default_description_
                           description: ''
@@ -10124,10 +10073,10 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 165
+                          ticket_type_id: 85
                           archived: false
-                          created_at: 1717022843
-                          updated_at: 1717022843
+                          created_at: 1718120141
+                          updated_at: 1718120141
                       category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type_list"
@@ -10139,7 +10088,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5d41bd8b-49e5-4c69-b94a-14f8d5028934
+                    request_id: 5d380039-ed80-44fd-be65-97c178acf343
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10168,20 +10117,20 @@ paths:
                 Ticket type created:
                   value:
                     type: ticket_type
-                    id: '168'
+                    id: '88'
                     name: Customer Issue
                     description: Customer Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id648_that_should_be_at_least_
                     archived: false
-                    created_at: 1717022845
-                    updated_at: 1717022845
+                    created_at: 1718120142
+                    updated_at: 1718120142
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '456'
+                        id: '257'
                         workspace_id: this_is_an_id648_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -10194,12 +10143,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 168
+                        ticket_type_id: 88
                         archived: false
-                        created_at: 1717022845
-                        updated_at: 1717022845
+                        created_at: 1718120142
+                        updated_at: 1718120142
                       - type: ticket_type_attribute
-                        id: '457'
+                        id: '258'
                         workspace_id: this_is_an_id648_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -10212,10 +10161,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 168
+                        ticket_type_id: 88
                         archived: false
-                        created_at: 1717022845
-                        updated_at: 1717022845
+                        created_at: 1718120142
+                        updated_at: 1718120142
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -10227,7 +10176,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7628e9d9-6582-4dfd-ae25-f5397edb1f6e
+                    request_id: 1f5c787b-b7d5-42b4-850a-5add72761f02
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10273,20 +10222,20 @@ paths:
                 Ticket type found:
                   value:
                     type: ticket_type
-                    id: '170'
+                    id: '90'
                     name: Bug Report
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id652_that_should_be_at_least_
                     archived: false
-                    created_at: 1717022846
-                    updated_at: 1717022846
+                    created_at: 1718120143
+                    updated_at: 1718120143
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '461'
+                        id: '262'
                         workspace_id: this_is_an_id652_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -10299,12 +10248,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 170
+                        ticket_type_id: 90
                         archived: false
-                        created_at: 1717022846
-                        updated_at: 1717022846
+                        created_at: 1718120143
+                        updated_at: 1718120143
                       - type: ticket_type_attribute
-                        id: '463'
+                        id: '264'
                         workspace_id: this_is_an_id652_that_should_be_at_least_
                         name: name
                         description: description
@@ -10316,12 +10265,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 170
+                        ticket_type_id: 90
                         archived: false
-                        created_at: 1717022846
-                        updated_at: 1717022846
+                        created_at: 1718120143
+                        updated_at: 1718120143
                       - type: ticket_type_attribute
-                        id: '462'
+                        id: '263'
                         workspace_id: this_is_an_id652_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -10334,10 +10283,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 170
+                        ticket_type_id: 90
                         archived: false
-                        created_at: 1717022846
-                        updated_at: 1717022846
+                        created_at: 1718120143
+                        updated_at: 1718120143
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -10349,7 +10298,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c788a72b-b3b7-49d1-849a-6c7aef4a3aa7
+                    request_id: 8af5f19f-4ba0-4be6-b2af-e11e0fe58e68
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10382,20 +10331,20 @@ paths:
                 Ticket type updated:
                   value:
                     type: ticket_type
-                    id: '172'
+                    id: '92'
                     name: Bug Report 2
                     description: Bug Report Template
                     icon: "\U0001F39F️"
                     workspace_id: this_is_an_id656_that_should_be_at_least_
                     archived: false
-                    created_at: 1717022847
-                    updated_at: 1717022847
+                    created_at: 1718120144
+                    updated_at: 1718120145
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '467'
+                        id: '268'
                         workspace_id: this_is_an_id656_that_should_be_at_least_
                         name: _default_title_
                         description: ''
@@ -10408,12 +10357,12 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 172
+                        ticket_type_id: 92
                         archived: false
-                        created_at: 1717022847
-                        updated_at: 1717022847
+                        created_at: 1718120144
+                        updated_at: 1718120144
                       - type: ticket_type_attribute
-                        id: '469'
+                        id: '270'
                         workspace_id: this_is_an_id656_that_should_be_at_least_
                         name: name
                         description: description
@@ -10425,12 +10374,12 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 172
+                        ticket_type_id: 92
                         archived: false
-                        created_at: 1717022847
-                        updated_at: 1717022847
+                        created_at: 1718120145
+                        updated_at: 1718120145
                       - type: ticket_type_attribute
-                        id: '468'
+                        id: '269'
                         workspace_id: this_is_an_id656_that_should_be_at_least_
                         name: _default_description_
                         description: ''
@@ -10443,10 +10392,10 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 172
+                        ticket_type_id: 92
                         archived: false
-                        created_at: 1717022847
-                        updated_at: 1717022847
+                        created_at: 1718120144
+                        updated_at: 1718120144
                     category: Customer
               schema:
                 "$ref": "#/components/schemas/ticket_type"
@@ -10458,7 +10407,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e70596cf-f73c-4a5d-a793-f3b13235ef08
+                    request_id: 829bd2f2-1478-4074-9097-0456d6a08eaa
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10504,13 +10453,13 @@ paths:
                 User reply:
                   value:
                     type: ticket_part
-                    id: '245'
+                    id: '228'
                     part_type: comment
                     body: "<p>Thanks again :)</p>"
-                    created_at: 1717022850
-                    updated_at: 1717022850
+                    created_at: 1718120148
+                    updated_at: 1718120148
                     author:
-                      id: 6657b0826abd0169343f1f67
+                      id: 66686ed35cb57e49376d4030
                       type: user
                       name:
                       email: user30@email.com
@@ -10519,7 +10468,7 @@ paths:
                 Admin note reply:
                   value:
                     type: ticket_part
-                    id: '248'
+                    id: '230'
                     part_type: note
                     body: |-
                       <h2>An Unordered HTML List</h2>
@@ -10534,10 +10483,10 @@ paths:
                       <li>Tea</li>
                       <li>Milk</li>
                       </ol>
-                    created_at: 1717022853
-                    updated_at: 1717022853
+                    created_at: 1718120788
+                    updated_at: 1718120788
                     author:
-                      id: '991269369'
+                      id: '991268088'
                       type: admin
                       name: Ciaran398 Lee
                       email: admin398@email.com
@@ -10546,12 +10495,12 @@ paths:
                 Admin quick_reply reply:
                   value:
                     type: ticket_part
-                    id: '250'
+                    id: '232'
                     part_type: quick_reply
-                    created_at: 1717022857
-                    updated_at: 1717022857
+                    created_at: 1718120792
+                    updated_at: 1718120792
                     author:
-                      id: '991269374'
+                      id: '991268093'
                       type: admin
                       name: Ciaran402 Lee
                       email: admin402@email.com
@@ -10567,7 +10516,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 50ec9656-e998-4abb-8372-c1bb56c1b397
+                    request_id: 74816012-9f33-4380-84c5-4b9e3c425621
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -10581,7 +10530,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4f3fc677-08a7-433a-919d-f27ebef663aa
+                    request_id: df67a965-32f9-4df1-a3ac-3b85b9f37cf2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10606,14 +10555,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 6657b0826abd0169343f1f67
+                  intercom_user_id: 66686ed35cb57e49376d4030
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991269369
+                  admin_id: 991268088
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -10623,18 +10572,18 @@ paths:
                 value:
                   message_type: quick_reply
                   type: admin
-                  admin_id: 991269374
+                  admin_id: 991268093
                   reply_options:
                   - text: 'Yes'
-                    uuid: 5652715c-1ac0-4914-8dba-3a5e4a178799
+                    uuid: '087a44af-27b6-4de5-8206-7dc7e72c3e2d'
                   - text: 'No'
-                    uuid: 11ef7639-44d9-4125-9ce6-ab0bb4512ecc
+                    uuid: 8c9454ac-1d28-4a91-9c62-460bd708e533
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 6657b08a6abd0169343f1f6a
+                  intercom_user_id: 666871595cb57e49376d4033
                   body: Thanks again :)
   "/tickets/{ticket_id}/tags":
     post:
@@ -10666,7 +10615,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '257'
+                    id: '148'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -10678,7 +10627,7 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: b2c4bbbe-d1cc-4380-8672-9c98788c0b1a
+                    request_id: 203ab175-3d78-44c7-80cb-fcc4d5fa4f81
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
@@ -10692,7 +10641,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0fc2c07b-f023-4541-a5f5-3ff1b5b5a735
+                    request_id: '0993bd5c-68ae-40a8-86a0-3838680304df'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10721,13 +10670,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 257
-                  admin_id: 991269384
+                  id: 148
+                  admin_id: 991268103
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  id: 258
-                  admin_id: 991269387
+                  id: 149
+                  admin_id: 991268106
   "/tickets/{ticket_id}/tags/{id}":
     delete:
       summary: Remove tag from a ticket
@@ -10765,7 +10714,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '260'
+                    id: '151'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -10777,14 +10726,14 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: 386a6648-fb82-4b32-92fc-04b3a3662d93
+                    request_id: 054d13b8-6efd-4ea5-9b62-2f80b484d00c
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 2e3349d8-096b-416d-840b-e5c97827a9e5
+                    request_id: 7b4c01ec-f869-452c-941f-ea2eb882b915
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -10798,7 +10747,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 3fb969f8-fcb4-4994-aa01-c79bd1f1be9d
+                    request_id: bd2406c6-d514-48ce-9377-a217edb8d37b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10821,15 +10770,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991269393
+                  admin_id: 991268112
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  admin_id: 991269396
+                  admin_id: 991268115
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991269399
+                  admin_id: 991268118
   "/tickets":
     post:
       summary: Create a ticket
@@ -10851,8 +10800,8 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '937'
-                    ticket_id: '52'
+                    id: '629'
+                    ticket_id: '48'
                     ticket_attributes:
                       _default_title_: example
                       _default_description_: there is a problem
@@ -10861,20 +10810,20 @@ paths:
                     ticket_state_external_label: Submitted
                     ticket_type:
                       type: ticket_type
-                      id: '186'
+                      id: '106'
                       name: my-ticket-type-15
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id684_that_should_be_at_least_
                       archived: false
-                      created_at: 1717022874
-                      updated_at: 1717022874
+                      created_at: 1718120811
+                      updated_at: 1718120811
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '481'
+                          id: '282'
                           workspace_id: this_is_an_id684_that_should_be_at_least_
                           name: _default_title_
                           description: ola
@@ -10886,12 +10835,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 186
+                          ticket_type_id: 106
                           archived: false
-                          created_at: 1717022874
-                          updated_at: 1717022874
+                          created_at: 1718120811
+                          updated_at: 1718120811
                         - type: ticket_type_attribute
-                          id: '482'
+                          id: '283'
                           workspace_id: this_is_an_id684_that_should_be_at_least_
                           name: _default_description_
                           description: ola
@@ -10903,33 +10852,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 186
+                          ticket_type_id: 106
                           archived: false
-                          created_at: 1717022875
-                          updated_at: 1717022875
+                          created_at: 1718120812
+                          updated_at: 1718120812
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657b09b6abd0169343f1f72
+                        id: 6668716c5cb57e49376d403b
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1717022875
-                    updated_at: 1717022876
+                    created_at: 1718120812
+                    updated_at: 1718120813
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '251'
+                        id: '233'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1717022876
-                        updated_at: 1717022876
+                        created_at: 1718120813
+                        updated_at: 1718120813
                         author:
-                          id: '991269411'
+                          id: '991268130'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id684_that_should_be_at_least_@intercom.io
@@ -10954,7 +10903,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b7ba2cb4-e75b-4d1f-ac25-db800272b973
+                    request_id: f332c4af-089f-4d80-84e0-01aef24079b2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10975,9 +10924,9 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  ticket_type_id: 186
+                  ticket_type_id: 106
                   contacts:
-                  - id: 6657b09b6abd0169343f1f72
+                  - id: 6668716c5cb57e49376d403b
                   ticket_attributes:
                     _default_title_: example
                     _default_description_: there is a problem
@@ -11008,8 +10957,8 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '938'
-                    ticket_id: '53'
+                    id: '630'
+                    ticket_id: '49'
                     ticket_attributes:
                       _default_title_: example
                       _default_description_: there is a problem
@@ -11018,20 +10967,20 @@ paths:
                     ticket_state_external_label: In progress
                     ticket_type:
                       type: ticket_type
-                      id: '188'
+                      id: '108'
                       name: my-ticket-type-17
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id688_that_should_be_at_least_
                       archived: false
-                      created_at: 1717022877
-                      updated_at: 1717022877
+                      created_at: 1718120814
+                      updated_at: 1718120814
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '486'
+                          id: '287'
                           workspace_id: this_is_an_id688_that_should_be_at_least_
                           name: _default_title_
                           description: ola
@@ -11043,12 +10992,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 188
+                          ticket_type_id: 108
                           archived: false
-                          created_at: 1717022877
-                          updated_at: 1717022877
+                          created_at: 1718120814
+                          updated_at: 1718120814
                         - type: ticket_type_attribute
-                          id: '487'
+                          id: '288'
                           workspace_id: this_is_an_id688_that_should_be_at_least_
                           name: _default_description_
                           description: ola
@@ -11060,98 +11009,98 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 188
+                          ticket_type_id: 108
                           archived: false
-                          created_at: 1717022877
-                          updated_at: 1717022877
+                          created_at: 1718120815
+                          updated_at: 1718120815
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657b09e6abd0169343f1f73
-                        external_id: 64e1c4fe-97d2-4d46-b5c2-fb1cc7e9ca90
-                    admin_assignee_id: '991269425'
+                        id: 6668716f5cb57e49376d403c
+                        external_id: 60fc2fc6-bb8e-411b-8baa-72a4f079cc00
+                    admin_assignee_id: '991268144'
                     team_assignee_id: '0'
-                    created_at: 1717022878
-                    updated_at: 1717022881
+                    created_at: 1718120815
+                    updated_at: 1718120818
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '252'
+                        id: '234'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1717022878
-                        updated_at: 1717022878
+                        created_at: 1718120815
+                        updated_at: 1718120815
                         author:
-                          id: '991269423'
+                          id: '991268142'
                           type: admin
                           name: Ciaran442 Lee
                           email: admin442@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '253'
+                        id: '235'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1717022879
-                        updated_at: 1717022879
+                        created_at: 1718120817
+                        updated_at: 1718120817
                         author:
-                          id: '991269424'
+                          id: '991268143'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id688_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '254'
+                        id: '236'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1717022880
-                        updated_at: 1717022880
+                        created_at: 1718120817
+                        updated_at: 1718120817
                         author:
-                          id: '991269424'
+                          id: '991268143'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id688_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '255'
+                        id: '237'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: in_progress
                         previous_ticket_state: submitted
-                        created_at: 1717022880
-                        updated_at: 1717022880
+                        created_at: 1718120817
+                        updated_at: 1718120817
                         author:
-                          id: '991269424'
+                          id: '991268143'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id688_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '256'
+                        id: '238'
                         part_type: assignment
-                        created_at: 1717022880
-                        updated_at: 1717022880
+                        created_at: 1718120818
+                        updated_at: 1718120818
                         assigned_to:
                           type: admin
-                          id: '991269425'
+                          id: '991268144'
                         author:
-                          id: '991269423'
+                          id: '991268142'
                           type: admin
                           name: Ciaran442 Lee
                           email: admin442@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '257'
+                        id: '239'
                         part_type: snoozed
-                        created_at: 1717022881
-                        updated_at: 1717022881
+                        created_at: 1718120818
+                        updated_at: 1718120818
                         author:
-                          id: '991269424'
+                          id: '991268143'
                           type: bot
                           name: Operator
                           email: operator+this_is_an_id688_that_should_be_at_least_@intercom.io
@@ -11159,7 +11108,7 @@ paths:
                         redacted: false
                       total_count: 6
                     open: true
-                    snoozed_until: 1717084800
+                    snoozed_until: 1718208000
                     linked_objects:
                       type: list
                       data: []
@@ -11177,14 +11126,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: eccb46bc-5d8b-4ad7-8d00-f814c35af421
+                    request_id: efa44aa2-335d-4f89-ab3c-3c0c2b94527f
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
                 Assignee not found:
                   value:
                     type: error.list
-                    request_id: 5f6e6273-571c-4437-880f-823bce61b8ed
+                    request_id: 8289fe77-db6a-4d41-89da-79f6318a3f75
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
@@ -11196,7 +11145,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 581662e2-4ebd-4358-b9d9-a5086ad66202
+                    request_id: 7a9ddffa-b6f3-4632-a58d-49b49812a914
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11216,8 +11165,8 @@ paths:
                     _default_description_: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991269423'
-                    assignee_id: '991269425'
+                    admin_id: '991268142'
+                    assignee_id: '991268144'
                   open: true
                   snoozed_until: 1673609604
               admin_not_found:
@@ -11229,7 +11178,7 @@ paths:
                   state: in_progress
                   assignment:
                     admin_id: '123'
-                    assignee_id: '991269433'
+                    assignee_id: '991268152'
               assignee_not_found:
                 summary: Assignee not found
                 value:
@@ -11238,7 +11187,7 @@ paths:
                     _default_description_: there is a problem
                   state: in_progress
                   assignment:
-                    admin_id: '991269439'
+                    admin_id: '991268158'
                     assignee_id: '456'
     get:
       summary: Retrieve a ticket
@@ -11266,8 +11215,8 @@ paths:
                 Ticket found:
                   value:
                     type: ticket
-                    id: '941'
-                    ticket_id: '56'
+                    id: '633'
+                    ticket_id: '52'
                     ticket_attributes:
                       _default_title_: attribute_value
                       _default_description_:
@@ -11276,20 +11225,20 @@ paths:
                     ticket_state_external_label: Submitted
                     ticket_type:
                       type: ticket_type
-                      id: '192'
+                      id: '112'
                       name: my-ticket-type-21
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id696_that_should_be_at_least_
                       archived: false
-                      created_at: 1717022887
-                      updated_at: 1717022887
+                      created_at: 1718120826
+                      updated_at: 1718120826
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '497'
+                          id: '298'
                           workspace_id: this_is_an_id696_that_should_be_at_least_
                           name: _default_title_
                           description: ola
@@ -11301,12 +11250,12 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 192
+                          ticket_type_id: 112
                           archived: false
-                          created_at: 1717022887
-                          updated_at: 1717022887
+                          created_at: 1718120827
+                          updated_at: 1718120827
                         - type: ticket_type_attribute
-                          id: '498'
+                          id: '299'
                           workspace_id: this_is_an_id696_that_should_be_at_least_
                           name: _default_description_
                           description: ola
@@ -11318,33 +11267,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 192
+                          ticket_type_id: 112
                           archived: false
-                          created_at: 1717022887
-                          updated_at: 1717022887
+                          created_at: 1718120827
+                          updated_at: 1718120827
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 6657b0a76abd0169343f1f76
-                        external_id: 45564dcc-95f2-4ed4-93da-7a1c0bc61c9c
+                        id: 6668717b5cb57e49376d403f
+                        external_id: e1f88e2f-5288-4b0b-8d64-7783b0d57c2d
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1717022887
-                    updated_at: 1717022888
+                    created_at: 1718120827
+                    updated_at: 1718120828
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '260'
+                        id: '242'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1717022888
-                        updated_at: 1717022888
+                        created_at: 1718120828
+                        updated_at: 1718120828
                         author:
-                          id: '991269452'
+                          id: '991268171'
                           type: admin
                           name: Ciaran468 Lee
                           email: admin468@email.com
@@ -11369,7 +11318,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 49a10bc7-939f-47bf-990c-be3ad14939a2
+                    request_id: 1708a3d8-c5b9-406c-838a-5edca0fbded9
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11400,7 +11349,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '942'
+                    id: '634'
                     object: ticket
                     deleted: true
               schema:
@@ -11430,7 +11379,7 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: c43cbbf1-b73d-4c04-84d8-4243f725147c
+                    request_id: 9a50a9b6-8e6f-4c51-8abe-b13bc20ca9ed
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
@@ -11475,7 +11424,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fabb1036-06d2-4813-aeb7-e2c97490badd
+                    request_id: 5515b5de-5e76-47c8-b2de-ac48f27f6870
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11571,8 +11520,8 @@ paths:
                     total_count: 1
                     tickets:
                     - type: ticket
-                      id: '943'
-                      ticket_id: '58'
+                      id: '635'
+                      ticket_id: '54'
                       ticket_attributes:
                         _default_title_: attribute_value
                         _default_description_:
@@ -11581,20 +11530,20 @@ paths:
                       ticket_state_external_label: Submitted
                       ticket_type:
                         type: ticket_type
-                        id: '197'
+                        id: '117'
                         name: my-ticket-type-26
                         description: my ticket type description is awesome.
                         icon: "\U0001F981"
                         workspace_id: this_is_an_id706_that_should_be_at_least_
                         archived: false
-                        created_at: 1717022894
-                        updated_at: 1717022894
+                        created_at: 1718120835
+                        updated_at: 1718120835
                         is_internal: false
                         ticket_type_attributes:
                           type: list
                           data:
                           - type: ticket_type_attribute
-                            id: '509'
+                            id: '310'
                             workspace_id: this_is_an_id706_that_should_be_at_least_
                             name: _default_title_
                             description: ola
@@ -11606,12 +11555,12 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 197
+                            ticket_type_id: 117
                             archived: false
-                            created_at: 1717022895
-                            updated_at: 1717022895
+                            created_at: 1718120835
+                            updated_at: 1718120835
                           - type: ticket_type_attribute
-                            id: '510'
+                            id: '311'
                             workspace_id: this_is_an_id706_that_should_be_at_least_
                             name: _default_description_
                             description: ola
@@ -11623,33 +11572,33 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 197
+                            ticket_type_id: 117
                             archived: false
-                            created_at: 1717022895
-                            updated_at: 1717022895
+                            created_at: 1718120836
+                            updated_at: 1718120836
                         category: Back-office
                       contacts:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 6657b0af6abd0169343f1f78
-                          external_id: 33e950ad-b63e-44d0-9b62-6320840659c8
+                          id: 666871845cb57e49376d4041
+                          external_id: 754d9847-b4db-4fd8-805e-e4b5fc239776
                       admin_assignee_id: '0'
                       team_assignee_id: '0'
-                      created_at: 1717022895
-                      updated_at: 1717022896
+                      created_at: 1718120836
+                      updated_at: 1718120837
                       ticket_parts:
                         type: ticket_part.list
                         ticket_parts:
                         - type: ticket_part
-                          id: '263'
+                          id: '245'
                           part_type: ticket_state_updated_by_admin
                           ticket_state: submitted
                           previous_ticket_state: submitted
-                          created_at: 1717022896
-                          updated_at: 1717022896
+                          created_at: 1718120837
+                          updated_at: 1718120837
                           author:
-                            id: '991269484'
+                            id: '991268203'
                             type: admin
                             name: Ciaran498 Lee
                             email: admin498@email.com
@@ -11709,26 +11658,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 6657b0b26abd0169343f1f7b
+                    id: 666871885cb57e49376d4044
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Indigo Paw
+                    pseudonym: Cyan Turtle
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/indigo-paw.png
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/cyan-turtle.png
                     app_id: this_is_an_id710_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1717022899
-                    remote_created_at: 1717022898
-                    signed_up_at: 1717022898
-                    updated_at: 1717022899
+                    created_at: 1718120840
+                    remote_created_at: 1718120840
+                    signed_up_at: 1718120840
+                    updated_at: 1718120840
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -11761,7 +11710,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: a3771f7e-40b8-491f-ab67-388017529231
+                    request_id: 2e93c4d4-618e-40c3-b097-c2d4c6238421
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -11775,7 +11724,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a0d18d0d-45c1-41c1-8cbc-71af883fdfe9
+                    request_id: 1e8eb0a8-d346-41f4-a166-42fa28f919e4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11790,7 +11739,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 6657b0b26abd0169343f1f7b
+                  id: 666871885cb57e49376d4044
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -11823,7 +11772,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 6657b0b46abd0169343f1f81
+                    id: 6668718a5cb57e49376d404a
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -11839,10 +11788,10 @@ paths:
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1717022900
-                    remote_created_at: 1717022900
-                    signed_up_at: 1717022900
-                    updated_at: 1717022900
+                    created_at: 1718120842
+                    remote_created_at: 1718120842
+                    signed_up_at: 1718120842
+                    updated_at: 1718120842
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -11875,7 +11824,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: d8b69467-f9aa-4a01-a3fe-9730d6965727
+                    request_id: 2407371c-a4cf-4166-b4ad-c0353c276016
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -11889,7 +11838,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d415b8ec-16d0-478c-9a55-8f5f29464ad7
+                    request_id: eaf34dad-9582-4b0e-9e2b-21115720e30d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11920,7 +11869,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 6657b0b66abd0169343f1f88
+                    id: 6668718c5cb57e49376d4051
                     workspace_id: this_is_an_id722_that_should_be_at_least_
                     external_id:
                     role: user
@@ -11936,9 +11885,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1717022902
-                    updated_at: 1717022903
-                    signed_up_at: 1717022902
+                    created_at: 1718120844
+                    updated_at: 1718120844
+                    signed_up_at: 1718120844
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -11972,31 +11921,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/6657b0b66abd0169343f1f88/tags"
+                      url: "/contacts/6668718c5cb57e49376d4051/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/6657b0b66abd0169343f1f88/notes"
+                      url: "/contacts/6668718c5cb57e49376d4051/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/6657b0b66abd0169343f1f88/companies"
+                      url: "/contacts/6668718c5cb57e49376d4051/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657b0b66abd0169343f1f88/subscriptions"
+                      url: "/contacts/6668718c5cb57e49376d4051/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/6657b0b66abd0169343f1f88/subscriptions"
+                      url: "/contacts/6668718c5cb57e49376d4051/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -12015,7 +11964,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1c0c5f3a-8384-4d44-b997-7538073187c8
+                    request_id: 216f3389-7a9b-4ff9-b562-2d253ee9d69f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -14583,6 +14532,9 @@ components:
           type: boolean
           description: Whether or not the conversation part has been redacted.
           example: false
+        email_message_metadata:
+          "$ref": "#/components/schemas/email_message_metadata"
+          nullable: true
     conversation_part_author:
       title: Conversation part author
       type: object
@@ -16269,6 +16221,40 @@ components:
           example: '5017690'
       required:
       - admin_id
+    email_address_header:
+      title: Email Address Header
+      type: object
+      description: Contains data for an email address header for a conversation part
+        that was sent as an email.
+      properties:
+        type:
+          type: string
+          description: The type of email address header
+          example: from
+        email_address:
+          type: string
+          description: The email address
+          example: wash@serenity.io
+        name:
+          type: string
+          nullable: true
+          description: The name associated with the email address
+          example: Hoban Washburne
+    email_message_metadata:
+      title: Email Message Metadata
+      type: object
+      description: Contains metadata if the message was sent as an email
+      properties:
+        subject:
+          type: string
+          description: The subject of the email
+          example: Question about my order
+        email_address_headers:
+          title: Email Address Headers
+          type: array
+          description: A list of an email address headers.
+          items:
+            "$ref": "#/components/schemas/email_address_header"
     error:
       type: object
       title: Error


### PR DESCRIPTION
Adding schemas to Unstable
- email message metadata
- email address header

Updated conversation part schema to include email message metadata

```
    email_address_header:
      title: Email Address Header
      type: object
      description: Contains data for an email address header for a conversation part
        that was sent as an email.
      properties:
        type:
          type: string
          description: The type of email address header
          example: from
        email_address:
          type: string
          description: The email address
          example: wash@serenity.io
        name:
          type: string
          nullable: true
          description: The name associated with the email address
          example: Hoban Washburne
    email_message_metadata:
      title: Email Message Metadata
      type: object
      description: Contains metadata if the message was sent as an email
      properties:
        subject:
          type: string
          description: The subject of the email
          example: Question about my order
        email_address_headers:
          title: Email Address Headers
          type: array
          description: A list of an email address headers.
          items:
            "$ref": "#/components/schemas/email_address_header"
```