### PR TITLE
Update documentation for AI Content API Unstable

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -37,7 +37,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991266830'
+                    id: '991267460'
                     email: admin1@email.com
                     name: Ciaran1 Lee
                     email_verified: true
@@ -45,7 +45,7 @@ paths:
                       type: app
                       id_code: this_is_an_id1_that_should_be_at_least_40
                       name: MyApp 1
-                      created_at: 1727856792
+                      created_at: 1733320889
                       secure: false
                       identity_verification: false
                       timezone: America/Los_Angeles
@@ -83,7 +83,7 @@ paths:
                 Successful response:
                   value:
                     type: admin
-                    id: '991266831'
+                    id: '991267461'
                     name: Ciaran2 Lee
                     email: admin2@email.com
                     away_mode_enabled: true
@@ -100,7 +100,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: cc85f377-00d3-4294-ae76-fd7b5a580e37
+                    request_id: de2dec9c-1fbb-4169-ab49-d0f4283c0cb4
                     errors:
                     - code: admin_not_found
                       message: Admin for admin_id not found
@@ -114,7 +114,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f82a1d2b-fec2-4546-8768-2cc339a119ab
+                    request_id: '050209e4-52f8-439b-9a09-fe718fbb90dc'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -201,23 +201,10 @@ paths:
                       per_page: 20
                       total_pages: 1
                     activity_logs:
-                    - id: 51388355-4556-4f75-98f2-2f713d781377
+                    - id: 1c3b4614-eca5-461a-ba4f-e7141d7419c3
                       performed_by:
                         type: admin
-                        id: '991266835'
-                        email: admin5@email.com
-                        ip: 127.0.0.1
-                      metadata:
-                        before: before
-                        after: after
-                      created_at: 1727856800
-                      activity_type: app_name_change
-                      activity_description: Ciaran5 Lee changed your app name from
-                        before to after.
-                    - id: 5eba91c1-5cf7-476f-ae35-7f34a0ea8e3e
-                      performed_by:
-                        type: admin
-                        id: '991266835'
+                        id: '991267465'
                         email: admin5@email.com
                         ip: 127.0.0.1
                       metadata:
@@ -226,11 +213,24 @@ paths:
                           title: Initial message title
                         before: Initial message title
                         after: Eventual message title
-                      created_at: 1727856800
+                      created_at: 1733320898
                       activity_type: message_state_change
                       activity_description: Ciaran5 Lee changed your Initial message
                         title message from Initial message title to Eventual message
                         title.
+                    - id: 07de2b0f-17d5-443f-903b-41025085b568
+                      performed_by:
+                        type: admin
+                        id: '991267465'
+                        email: admin5@email.com
+                        ip: 127.0.0.1
+                      metadata:
+                        before: before
+                        after: after
+                      created_at: 1733320897
+                      activity_type: app_name_change
+                      activity_description: Ciaran5 Lee changed your app name from
+                        before to after.
               schema:
                 "$ref": "#/components/schemas/activity_log_list"
         '401':
@@ -241,7 +241,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b1508a10-0195-43d7-aeb2-4eaa1b72132d
+                    request_id: 870d9428-821a-441c-90ea-9a6177848abb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -271,7 +271,7 @@ paths:
                     admins:
                     - type: admin
                       email: admin7@email.com
-                      id: '991266837'
+                      id: '991267467'
                       name: Ciaran7 Lee
                       away_mode_enabled: false
                       away_mode_reassign: false
@@ -287,7 +287,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8f6afb01-98ec-4ccd-8a7d-6069a78ec697
+                    request_id: 44aa4ee9-bfc4-4e06-b4c3-9bf6e25b1223
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -321,7 +321,7 @@ paths:
                 Admin found:
                   value:
                     type: admin
-                    id: '991266839'
+                    id: '991267469'
                     name: Ciaran9 Lee
                     email: admin9@email.com
                     away_mode_enabled: false
@@ -338,7 +338,7 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: 2d72b5aa-926f-45e9-9f0c-ed05a6a9296a
+                    request_id: d949efe3-2772-48fe-b82d-c90ffa122e70
                     errors:
                     - code: admin_not_found
                       message: Admin not found
@@ -352,7 +352,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7170420b-64c8-4ce6-905c-10deba56cce3
+                    request_id: c3cad7cc-a8a1-4886-acea-65255c829017
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -379,30 +379,30 @@ paths:
                 successful:
                   value:
                     data:
-                    - id: 17
+                    - id: 33
                       type: content_import_source
-                      last_synced_at: 1727856804
+                      last_synced_at: 1733320903
                       status: active
                       url: https://support.example.com/us/1
                       sync_behavior: automatic
-                      created_at: 1727856804
-                      updated_at: 1727856804
-                    - id: 18
+                      created_at: 1733320903
+                      updated_at: 1733320903
+                    - id: 34
                       type: content_import_source
-                      last_synced_at: 1727856804
+                      last_synced_at: 1733320903
                       status: active
                       url: https://support.example.com/us/2
                       sync_behavior: automatic
-                      created_at: 1727856804
-                      updated_at: 1727856804
-                    - id: 19
+                      created_at: 1733320903
+                      updated_at: 1733320903
+                    - id: 35
                       type: content_import_source
-                      last_synced_at: 1727856804
+                      last_synced_at: 1733320903
                       status: active
                       url: https://support.example.com/us/3
                       sync_behavior: automatic
-                      created_at: 1727856804
-                      updated_at: 1727856804
+                      created_at: 1733320903
+                      updated_at: 1733320903
                     pages:
                       type: pages
                       page: 1
@@ -420,7 +420,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1de1fb14-56dd-43da-9e33-ca6a288cd1e8
+                    request_id: 2bc8df6a-f516-477a-a301-2840604b3eb3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -446,14 +446,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 20
+                    id: 36
                     type: content_import_source
-                    last_synced_at: 1727856806
+                    last_synced_at: 1733320905
                     status: active
                     url: https://www.example.com
                     sync_behavior: api
-                    created_at: 1727856806
-                    updated_at: 1727856806
+                    created_at: 1733320905
+                    updated_at: 1733320905
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -464,7 +464,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d190a53b-d380-44e8-945d-65b6f3518cf5
+                    request_id: 346d2d97-b1c0-4df0-8d46-dc2d5fe6b323
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -514,7 +514,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 285a794e-efb4-4d71-9eae-5f274c67b711
+                    request_id: 3888806c-45c3-4588-8d1e-ca417ba7bf01
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -538,14 +538,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 22
+                    id: 38
                     type: content_import_source
-                    last_synced_at: 1727856808
+                    last_synced_at: 1733320909
                     status: active
                     url: https://support.example.com/us/5
                     sync_behavior: api
-                    created_at: 1727856808
-                    updated_at: 1727856808
+                    created_at: 1733320909
+                    updated_at: 1733320909
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -556,7 +556,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c279123e-3692-4d46-976e-901932435a66
+                    request_id: 2882118c-c544-4fc6-8c20-09b0f1f67d14
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -581,14 +581,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 23
+                    id: 39
                     type: content_import_source
-                    last_synced_at: 1727856809
+                    last_synced_at: 1733320910
                     status: active
                     url: https://www.example.com
                     sync_behavior: api
-                    created_at: 1727856809
-                    updated_at: 1727856810
+                    created_at: 1733320910
+                    updated_at: 1733320910
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -599,7 +599,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 858a0910-c9b2-4302-8537-130b68bd020d
+                    request_id: 3333d5c0-4867-4304-a37b-b657b558b329
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -637,7 +637,7 @@ paths:
                 successful:
                   value:
                     data:
-                    - id: '11'
+                    - id: '19'
                       type: external_page
                       title: My External Content
                       html: "<h1>Hello world</h1><p>This is external content</p>"
@@ -646,12 +646,12 @@ paths:
                       ai_copilot_availability: true
                       fin_availability: true
                       locale: en
-                      source_id: 26
+                      source_id: 42
                       external_id: '3'
-                      created_at: 1727856811
-                      updated_at: 1727856811
-                      last_ingested_at: 1727856811
-                    - id: '10'
+                      created_at: 1733320912
+                      updated_at: 1733320912
+                      last_ingested_at: 1733320912
+                    - id: '18'
                       type: external_page
                       title: My External Content
                       html: "<h1>Hello world</h1><p>This is external content</p>"
@@ -660,12 +660,12 @@ paths:
                       ai_copilot_availability: true
                       fin_availability: true
                       locale: en
-                      source_id: 25
+                      source_id: 41
                       external_id: '2'
-                      created_at: 1727856811
-                      updated_at: 1727856811
-                      last_ingested_at: 1727856811
-                    - id: '9'
+                      created_at: 1733320912
+                      updated_at: 1733320912
+                      last_ingested_at: 1733320912
+                    - id: '17'
                       type: external_page
                       title: My External Content
                       html: "<h1>Hello world</h1><p>This is external content</p>"
@@ -674,11 +674,11 @@ paths:
                       ai_copilot_availability: true
                       fin_availability: true
                       locale: en
-                      source_id: 24
+                      source_id: 40
                       external_id: '1'
-                      created_at: 1727856811
-                      updated_at: 1727856811
-                      last_ingested_at: 1727856811
+                      created_at: 1733320912
+                      updated_at: 1733320912
+                      last_ingested_at: 1733320912
                     pages:
                       type: pages
                       page: 1
@@ -696,7 +696,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: db45aca5-7713-46a3-941e-75901ca936bf
+                    request_id: 8625f5d1-cbd3-4395-98e6-3796cb93c9c6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -723,7 +723,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '13'
+                    id: '21'
                     type: external_page
                     title: Test
                     html: "<html><body><h1>Test</h1></body></html>"
@@ -732,11 +732,11 @@ paths:
                     ai_copilot_availability: true
                     fin_availability: true
                     locale: en
-                    source_id: 28
+                    source_id: 44
                     external_id: abc1234
-                    created_at: 1727856814
-                    updated_at: 1727856814
-                    last_ingested_at: 1727856814
+                    created_at: 1733320915
+                    updated_at: 1733320915
+                    last_ingested_at: 1733320915
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -747,7 +747,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 387b0e3f-0105-41f3-afed-bc906ee12a5c
+                    request_id: 03c6062a-d178-4f5e-88a9-f81c7ad46531
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -765,7 +765,7 @@ paths:
                   external_id: abc1234
                   html: "<html><body><h1>Test</h1></body></html>"
                   locale: en
-                  source_id: 28
+                  source_id: 44
                   title: Test
                   url: https://www.example.com
   "/ai/external_pages/{id}":
@@ -796,7 +796,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '14'
+                    id: '22'
                     type: external_page
                     title: My External Content
                     html: ''
@@ -805,11 +805,11 @@ paths:
                     ai_copilot_availability: true
                     fin_availability: true
                     locale: en
-                    source_id: 29
+                    source_id: 45
                     external_id: '4'
-                    created_at: 1727856815
-                    updated_at: 1727856815
-                    last_ingested_at: 1727856815
+                    created_at: 1733320917
+                    updated_at: 1733320917
+                    last_ingested_at: 1733320917
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -820,7 +820,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: be39c0f6-55e8-44ff-8327-b70bc9e55aec
+                    request_id: ef436d4b-11d8-41fc-a9dc-4cbe540d34b5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -845,7 +845,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '15'
+                    id: '23'
                     type: external_page
                     title: My External Content
                     html: "<h1>Hello world</h1><p>This is external content</p>"
@@ -854,11 +854,11 @@ paths:
                     ai_copilot_availability: true
                     fin_availability: true
                     locale: en
-                    source_id: 30
+                    source_id: 46
                     external_id: '5'
-                    created_at: 1727856817
-                    updated_at: 1727856817
-                    last_ingested_at: 1727856817
+                    created_at: 1733320918
+                    updated_at: 1733320918
+                    last_ingested_at: 1733320918
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -869,7 +869,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e10b7ffb-2964-4b3c-bc0b-b172a1b92ead
+                    request_id: b1728b57-7aa3-4875-90c7-a9c761df2c34
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -895,7 +895,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '16'
+                    id: '24'
                     type: external_page
                     title: Test
                     html: "<html><body><h1>Test</h1></body></html>"
@@ -904,11 +904,11 @@ paths:
                     ai_copilot_availability: true
                     fin_availability: true
                     locale: en
-                    source_id: 31
+                    source_id: 47
                     external_id: '5678'
-                    created_at: 1727856818
-                    updated_at: 1727856818
-                    last_ingested_at: 1727856818
+                    created_at: 1733320920
+                    updated_at: 1733320920
+                    last_ingested_at: 1733320920
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -919,7 +919,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c71ccf6b-6333-4d5c-bf47-7604266d0eea
+                    request_id: 5eb20d9a-ad0e-4b88-9b27-5c6147a87ec4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -937,7 +937,7 @@ paths:
                   external_id: '5678'
                   html: "<html><body><h1>Test</h1></body></html>"
                   locale: en
-                  source_id: 31
+                  source_id: 47
                   title: Test
                   url: https://www.example.com
   "/articles":
@@ -972,20 +972,23 @@ paths:
                       total_pages: 1
                     total_count: 1
                     data:
-                    - id: '20'
+                    - id: '39'
                       type: article
                       workspace_id: this_is_an_id64_that_should_be_at_least_4
-                      parent_id: 72
+                      parent_id: 143
                       parent_type: collection
                       parent_ids: []
+                      tags:
+                        type: tag.list
+                        tags: []
                       title: This is the article title
                       description: ''
                       body: ''
-                      author_id: 991266863
+                      author_id: 991267493
                       state: published
-                      created_at: 1727856820
-                      updated_at: 1727856820
-                      url: http://help-center.test/myapp-64/en/articles/20-this-is-the-article-title
+                      created_at: 1733320922
+                      updated_at: 1733320922
+                      url: http://help-center.test/myapp-64/en/articles/39-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article_list"
         '401':
@@ -996,7 +999,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e550e46b-1974-4312-9983-25378549254c
+                    request_id: b7b68b0e-9bf6-4c1c-b19d-eae34027010c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1021,10 +1024,10 @@ paths:
               examples:
                 article created:
                   value:
-                    id: '23'
+                    id: '42'
                     type: article
                     workspace_id: this_is_an_id68_that_should_be_at_least_4
-                    parent_id: 74
+                    parent_id: 145
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1035,14 +1038,17 @@ paths:
                       happy_reaction_percentage: 0
                       neutral_reaction_percentage: 0
                       sad_reaction_percentage: 0
+                    tags:
+                      type: tag.list
+                      tags: []
                     title: Thanks for everything
                     description: Description of the Article
                     body: <p class="no-margin">Body of the Article</p>
-                    author_id: 991266868
+                    author_id: 991267498
                     state: published
-                    created_at: 1727856823
-                    updated_at: 1727856823
-                    url: http://help-center.test/myapp-68/en/articles/23-thanks-for-everything
+                    created_at: 1733320925
+                    updated_at: 1733320925
+                    url: http://help-center.test/myapp-68/en/articles/42-thanks-for-everything
               schema:
                 "$ref": "#/components/schemas/article"
         '400':
@@ -1053,7 +1059,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 4516b3bb-3057-4dfd-9d50-072ec16c007f
+                    request_id: d07bfae6-3fe8-417a-b6e7-d0e94555eb34
                     errors:
                     - code: parameter_not_found
                       message: author_id must be in the main body or default locale
@@ -1068,7 +1074,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: abf685e8-18c0-4ae9-aa24-ed5b070d6249
+                    request_id: f79368c0-113d-4cd8-abe4-730bb0b94a7b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1086,16 +1092,16 @@ paths:
                   title: Thanks for everything
                   description: Description of the Article
                   body: Body of the Article
-                  author_id: 991266868
+                  author_id: 991267498
                   state: published
-                  parent_id: 74
+                  parent_id: 145
                   parent_type: collection
                   translated_content:
                     fr:
                       title: Merci pour tout
                       description: Description de l'article
                       body: Corps de l'article
-                      author_id: 991266868
+                      author_id: 991267498
                       state: published
               bad_request:
                 summary: Bad Request
@@ -1132,10 +1138,10 @@ paths:
               examples:
                 Article found:
                   value:
-                    id: '26'
+                    id: '45'
                     type: article
                     workspace_id: this_is_an_id74_that_should_be_at_least_4
-                    parent_id: 77
+                    parent_id: 148
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1146,14 +1152,17 @@ paths:
                       happy_reaction_percentage: 0
                       neutral_reaction_percentage: 0
                       sad_reaction_percentage: 0
+                    tags:
+                      type: tag.list
+                      tags: []
                     title: This is the article title
                     description: ''
                     body: ''
-                    author_id: 991266873
+                    author_id: 991267503
                     state: published
-                    created_at: 1727856826
-                    updated_at: 1727856826
-                    url: http://help-center.test/myapp-74/en/articles/26-this-is-the-article-title
+                    created_at: 1733320928
+                    updated_at: 1733320929
+                    url: http://help-center.test/myapp-74/en/articles/45-this-is-the-article-title
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -1164,7 +1173,7 @@ paths:
                 Article not found:
                   value:
                     type: error.list
-                    request_id: 94144152-d550-4319-8e87-6ec6d48a9395
+                    request_id: e85e51c2-a074-49d1-b303-5ba528822ed4
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1178,7 +1187,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5c8cb9f3-8e0b-4070-a980-01ef9e3e3ee9
+                    request_id: 18fc8dba-0dfa-417d-982e-cf429e5a05da
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1211,10 +1220,10 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '29'
+                    id: '48'
                     type: article
                     workspace_id: this_is_an_id80_that_should_be_at_least_4
-                    parent_id: 80
+                    parent_id: 151
                     parent_type: collection
                     parent_ids: []
                     statistics:
@@ -1225,14 +1234,17 @@ paths:
                       happy_reaction_percentage: 0
                       neutral_reaction_percentage: 0
                       sad_reaction_percentage: 0
+                    tags:
+                      type: tag.list
+                      tags: []
                     title: Christmas is here!
                     description: ''
                     body: <p class="no-margin">New gifts in store for the jolly season</p>
-                    author_id: 991266879
+                    author_id: 991267509
                     state: published
-                    created_at: 1727856829
-                    updated_at: 1727856830
-                    url: http://help-center.test/myapp-80/en/articles/29-christmas-is-here
+                    created_at: 1733320932
+                    updated_at: 1733320933
+                    url: http://help-center.test/myapp-80/en/articles/48-christmas-is-here
               schema:
                 "$ref": "#/components/schemas/article"
         '404':
@@ -1243,7 +1255,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: 869da353-32dd-415d-94d2-092a0b57273e
+                    request_id: d6a3d78e-3a4d-44bc-8c48-d7b8ef44a7a4
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1257,7 +1269,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ca9b4122-c978-4d54-a06d-9514267890fc
+                    request_id: e443983a-cc5d-400d-b394-378419882522
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1305,7 +1317,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '32'
+                    id: '51'
                     object: article
                     deleted: true
               schema:
@@ -1318,7 +1330,7 @@ paths:
                 Article Not Found:
                   value:
                     type: error.list
-                    request_id: a9b48eb2-39d4-4bc3-8603-e6e353cdc0c9
+                    request_id: 737cc5f9-b03b-4ad3-b28e-9f189720730e
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1332,7 +1344,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '096d5175-52c8-4ebe-a766-f0033e39cc5e'
+                    request_id: e9398e07-6478-4ce6-8528-50eaa6e7b0e4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1392,19 +1404,22 @@ paths:
                     total_count: 1
                     data:
                       articles:
-                      - id: '36'
+                      - id: '55'
                         type: article
                         workspace_id: this_is_an_id92_that_should_be_at_least_4
                         parent_id:
                         parent_type:
                         parent_ids: []
+                        tags:
+                          type: tag.list
+                          tags: []
                         title: Title 1
                         description: ''
                         body: ''
-                        author_id: 991266892
+                        author_id: 991267522
                         state: draft
-                        created_at: 1727856837
-                        updated_at: 1727856837
+                        created_at: 1733320940
+                        updated_at: 1733320940
                         url:
                       highlights: []
                     pages:
@@ -1422,7 +1437,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 84a092d5-9c1c-4017-abdc-afb03b128af5
+                    request_id: d1427292-4171-47f4-b516-732c3dabd0d7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1453,27 +1468,27 @@ paths:
                   value:
                     type: list
                     data:
-                    - id: '88'
+                    - id: '159'
                       workspace_id: this_is_an_id96_that_should_be_at_least_4
                       name: English collection title
                       url: http://help-center.test/myapp-96/collection-17
                       order: 17
-                      created_at: 1727856839
-                      updated_at: 1727856839
+                      created_at: 1733320942
+                      updated_at: 1733320942
                       description: english collection description
                       icon: bookmark
                       parent_id:
-                      help_center_id: 48
-                    - id: '89'
+                      help_center_id: 79
+                    - id: '160'
                       workspace_id: this_is_an_id96_that_should_be_at_least_4
                       name: English section title
                       url: http://help-center.test/myapp-96/section-1
                       order: 1
-                      created_at: 1727856839
-                      updated_at: 1727856839
+                      created_at: 1733320942
+                      updated_at: 1733320942
                       description:
                       icon: bookmark
-                      parent_id: '88'
+                      parent_id: '159'
                       help_center_id:
                     total_count: 2
                     pages:
@@ -1491,7 +1506,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 30051b93-dbf3-4b17-bc3d-df93fe4b1146
+                    request_id: 3b3bd3ce-5311-4e4a-9784-60b45123dfab
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1516,17 +1531,17 @@ paths:
               examples:
                 collection created:
                   value:
-                    id: '94'
+                    id: '165'
                     workspace_id: this_is_an_id100_that_should_be_at_least_
                     name: Thanks for everything
                     url: http://help-center.test/myapp-100/
                     order: 1
-                    created_at: 1727856841
-                    updated_at: 1727856841
+                    created_at: 1733320945
+                    updated_at: 1733320945
                     description: ''
                     icon: book-bookmark
                     parent_id:
-                    help_center_id: 50
+                    help_center_id: 81
               schema:
                 "$ref": "#/components/schemas/collection"
         '400':
@@ -1537,7 +1552,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 2976e109-3e90-433a-9a58-c795739fd750
+                    request_id: da0c95a7-3bc1-4282-adf7-fbfe8acd9e19
                     errors:
                     - code: parameter_not_found
                       message: Name is a required parameter.
@@ -1551,7 +1566,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6d2f1b0f-7d09-4cff-afd6-06ecdfa23419
+                    request_id: 2ece8754-6edb-4153-9248-9df4668ddae6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1599,17 +1614,17 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '99'
+                    id: '170'
                     workspace_id: this_is_an_id106_that_should_be_at_least_
                     name: English collection title
                     url: http://help-center.test/myapp-106/collection-22
                     order: 22
-                    created_at: 1727856842
-                    updated_at: 1727856842
+                    created_at: 1733320947
+                    updated_at: 1733320947
                     description: english collection description
                     icon: bookmark
                     parent_id:
-                    help_center_id: 53
+                    help_center_id: 84
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1620,7 +1635,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: 9d6ea1af-30cc-4c70-b692-e74b798a50c6
+                    request_id: 96f2b087-0e68-4df4-b23d-640285d28497
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1634,7 +1649,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4859234a-b4e2-438c-ad8c-b30ed41ab313
+                    request_id: 84b880c3-7325-4458-9597-e49677195459
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1667,17 +1682,17 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '105'
+                    id: '176'
                     workspace_id: this_is_an_id112_that_should_be_at_least_
                     name: Update collection name
                     url: http://help-center.test/myapp-112/collection-25
                     order: 25
-                    created_at: 1727856845
-                    updated_at: 1727856845
+                    created_at: 1733320949
+                    updated_at: 1733320950
                     description: english collection description
                     icon: folder
                     parent_id:
-                    help_center_id: 56
+                    help_center_id: 87
               schema:
                 "$ref": "#/components/schemas/collection"
         '404':
@@ -1688,7 +1703,7 @@ paths:
                 Collection Not Found:
                   value:
                     type: error.list
-                    request_id: 836ac598-181e-457f-bea8-b5dbdf8f73ae
+                    request_id: ed4f179e-22b1-4b13-a9af-1edc368bd0aa
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1702,7 +1717,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dbfcbdd3-1761-482d-82c5-0eb285cb9a79
+                    request_id: 425a93a8-3779-4de1-bcab-ac55c48e9a4d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1749,7 +1764,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '111'
+                    id: '182'
                     object: collection
                     deleted: true
               schema:
@@ -1762,7 +1777,7 @@ paths:
                 collection Not Found:
                   value:
                     type: error.list
-                    request_id: cb237461-fdba-4b97-adf7-9692c92acfe7
+                    request_id: '0518695c-7c36-4b1a-9c0c-165efe85f958'
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1776,7 +1791,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5b39cbad-b15f-409e-9428-b57eb94c8b3d
+                    request_id: e3436d4e-76d2-46d4-8213-3ed95ab18c52
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1810,10 +1825,10 @@ paths:
               examples:
                 Collection found:
                   value:
-                    id: '62'
+                    id: '93'
                     workspace_id: this_is_an_id124_that_should_be_at_least_
-                    created_at: 1727856849
-                    updated_at: 1727856849
+                    created_at: 1733320956
+                    updated_at: 1733320956
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
@@ -1827,7 +1842,7 @@ paths:
                 Collection not found:
                   value:
                     type: error.list
-                    request_id: df02015a-7c46-4eee-8f35-0ae268eb75c3
+                    request_id: aa8929f1-657b-4518-b80b-9939a7749e0e
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -1841,7 +1856,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2f844ec3-e4cd-43e9-bf0b-d1064c0ed7cd
+                    request_id: 057f8d34-e924-4a00-a68b-37859f662415
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1879,7 +1894,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5c488c7a-b061-4880-8da5-ad93865dc8f0
+                    request_id: 310cd516-4eea-459d-b142-e53ceed29df3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -1916,12 +1931,12 @@ paths:
                   value:
                     type: company
                     company_id: company_remote_id
-                    id: 66fd00da9ffbe52cc8b3a9c4
+                    id: 67506105d5eefd6f04e7d00e
                     app_id: this_is_an_id147_that_should_be_at_least_
                     name: my company
                     remote_created_at: 1374138000
-                    created_at: 1727856858
-                    updated_at: 1727856858
+                    created_at: 1733320965
+                    updated_at: 1733320965
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -1958,7 +1973,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 53f950ad-1395-4b39-a6aa-d4323b8dfd10
+                    request_id: bb5d3569-fc96-435d-8e69-5c0b11c39aad
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2056,12 +2071,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 66fd00dd9ffbe52cc8b3a9cc
+                      id: 67506108d5eefd6f04e7d016
                       app_id: this_is_an_id153_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1727856861
-                      created_at: 1727856861
-                      updated_at: 1727856861
+                      remote_created_at: 1733320968
+                      created_at: 1733320968
+                      updated_at: 1733320968
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2090,7 +2105,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: df490fa4-28c8-4c09-8e13-87be99912f4d
+                    request_id: a2439155-3f85-4609-a401-96bbcb8df6d1
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2104,7 +2119,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 141f46bf-fa8c-4b64-90ff-db6e23599d75
+                    request_id: dccf8e8c-939f-47e3-823a-598775e6d018
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2139,12 +2154,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 66fd00e09ffbe52cc8b3a9d7
+                    id: 6750610cd5eefd6f04e7d021
                     app_id: this_is_an_id159_that_should_be_at_least_
                     name: company1
-                    remote_created_at: 1727856864
-                    created_at: 1727856864
-                    updated_at: 1727856864
+                    remote_created_at: 1733320972
+                    created_at: 1733320972
+                    updated_at: 1733320972
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2166,7 +2181,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 56c7582d-9ae7-4f22-af29-3570044a0ea5
+                    request_id: ce290548-2e17-466b-934c-04ea58e06720
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2180,7 +2195,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7ce5547a-717d-4441-b968-cbda363ec7fb
+                    request_id: 7e00deb7-bed9-4f78-8b68-9e7549d4218f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2219,12 +2234,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 66fd00e39ffbe52cc8b3a9e1
+                    id: 6750610fd5eefd6f04e7d02b
                     app_id: this_is_an_id165_that_should_be_at_least_
                     name: company2
-                    remote_created_at: 1727856867
-                    created_at: 1727856867
-                    updated_at: 1727856867
+                    remote_created_at: 1733320975
+                    created_at: 1733320975
+                    updated_at: 1733320975
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2246,7 +2261,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 5e589fe7-2913-47d2-b711-61129cf91c51
+                    request_id: 48083e30-f44c-4ec3-9ce0-7102e7c8395f
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2260,7 +2275,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 23d7c88a-c971-401b-9085-a0191cf7ac6a
+                    request_id: 9b9da142-bf37-49b3-b4d9-8ed96143e33f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2292,7 +2307,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 66fd00e79ffbe52cc8b3a9eb
+                    id: 67506112d5eefd6f04e7d035
                     object: company
                     deleted: true
               schema:
@@ -2305,7 +2320,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 9d76873f-1164-4838-bc98-710a51a8f765
+                    request_id: d1cba0d0-08b6-40af-a190-c07ea2ea1348
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2319,7 +2334,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 69c21889-2980-4a4a-a028-ca47480205f0
+                    request_id: 5d991d83-5165-42a8-9e20-bf57edbad157
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2371,7 +2386,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: d1064107-cae5-4747-befc-b320a73f9a93
+                    request_id: dfc3679d-6b1b-4e39-ad26-d1be0365f23f
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2385,7 +2400,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f8b7b87c-0fcd-4e76-bbfa-2df4cee2dfd2
+                    request_id: 17ab4bc8-c8f2-47f3-aaad-be335ca93c12
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2430,7 +2445,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: a37aefd0-2de3-4eb2-b2cf-9d28fcc59c89
+                    request_id: 84ce8890-f200-47a8-91ce-ace484ca48d7
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2444,7 +2459,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fc4f6acb-0315-42e6-9adc-d5d5939fea8c
+                    request_id: d6157c0c-4601-4497-be36-5d02e710604b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2505,12 +2520,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 66fd00f19ffbe52cc8b3aa07
+                      id: 6750611cd5eefd6f04e7d051
                       app_id: this_is_an_id189_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1727856881
-                      created_at: 1727856881
-                      updated_at: 1727856881
+                      remote_created_at: 1733320988
+                      created_at: 1733320988
+                      updated_at: 1733320988
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2539,7 +2554,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 12c3a436-fdaf-445e-9dd1-1346ecb33c45
+                    request_id: b5daab81-946b-469c-9579-77dc10676651
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2590,12 +2605,12 @@ paths:
                     data:
                     - type: company
                       company_id: remote_companies_scroll_2
-                      id: 66fd00f39ffbe52cc8b3aa0d
+                      id: 6750611ed5eefd6f04e7d057
                       app_id: this_is_an_id193_that_should_be_at_least_
                       name: IntercomQATest1
-                      remote_created_at: 1727856883
-                      created_at: 1727856883
-                      updated_at: 1727856883
+                      remote_created_at: 1733320990
+                      created_at: 1733320990
+                      updated_at: 1733320990
                       monthly_spend: 0
                       session_count: 0
                       user_count: 4
@@ -2609,7 +2624,7 @@ paths:
                       custom_attributes: {}
                     pages:
                     total_count:
-                    scroll_param: 6f0c010d-8de4-411d-8cf2-6fb728d4941a
+                    scroll_param: 7c2bc6a8-7312-4f0e-89ab-e1ef761ececd
               schema:
                 "$ref": "#/components/schemas/company_scroll"
         '401':
@@ -2620,7 +2635,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: a0506b9b-d0d5-46b7-bb6c-392f2e82c226
+                    request_id: bc708887-1197-4265-8d80-0456f71ec3d3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2655,12 +2670,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 66fd00f69ffbe52cc8b3aa16
+                    id: 67506121d5eefd6f04e7d060
                     app_id: this_is_an_id197_that_should_be_at_least_
                     name: company6
-                    remote_created_at: 1727856886
-                    created_at: 1727856886
-                    updated_at: 1727856886
+                    remote_created_at: 1733320993
+                    created_at: 1733320993
+                    updated_at: 1733320993
                     monthly_spend: 0
                     session_count: 0
                     user_count: 1
@@ -2682,7 +2697,7 @@ paths:
                 Bad Request:
                   value:
                     type: error.list
-                    request_id: 6c18323d-7c0c-430a-8315-62c7688d9221
+                    request_id: 812d9df8-0bd3-430b-beeb-4ece72659ea1
                     errors:
                     - code: parameter_not_found
                       message: company not specified
@@ -2696,7 +2711,7 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 0dbe8e3d-efe4-49b7-a4e6-84b477ccff9e
+                    request_id: 1e0f3dfe-ff1c-4f23-b875-d61a488b3735
                     errors:
                     - code: company_not_found
                       message: Company Not Found
@@ -2710,7 +2725,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 46cd55fe-5c27-4ec8-98e0-bfd9c1d2a490
+                    request_id: 6c46667e-9539-4ff8-a843-28d55079a0c1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2733,7 +2748,7 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 66fd00f69ffbe52cc8b3aa16
+                  id: 67506121d5eefd6f04e7d060
               bad_request:
                 summary: Bad Request
                 value:
@@ -2772,13 +2787,13 @@ paths:
                     data:
                     - type: company
                       company_id: '1'
-                      id: 66fd01009ffbe52cc8b3aa37
+                      id: 6750612bd5eefd6f04e7d081
                       app_id: this_is_an_id213_that_should_be_at_least_
                       name: company12
-                      remote_created_at: 1727856896
-                      created_at: 1727856896
-                      updated_at: 1727856896
-                      last_request_at: 1727684096
+                      remote_created_at: 1733321003
+                      created_at: 1733321003
+                      updated_at: 1733321003
+                      last_request_at: 1733148203
                       monthly_spend: 0
                       session_count: 0
                       user_count: 1
@@ -2807,7 +2822,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: df816646-79c4-4d81-92fd-3f2710c3e72d
+                    request_id: 8edf724d-0f7d-4e17-ba0e-09a7ecfe4c74
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2821,7 +2836,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9b1176e4-c54b-4931-b8c5-401de4ca35e3
+                    request_id: 1a80c886-b8ae-45fc-8495-3645ffcd69e4
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2864,12 +2879,12 @@ paths:
                   value:
                     type: company
                     company_id: '1'
-                    id: 66fd00fb9ffbe52cc8b3aa26
+                    id: 67506126d5eefd6f04e7d070
                     app_id: this_is_an_id205_that_should_be_at_least_
                     name: company8
-                    remote_created_at: 1727856891
-                    created_at: 1727856891
-                    updated_at: 1727856892
+                    remote_created_at: 1733320998
+                    created_at: 1733320998
+                    updated_at: 1733320998
                     monthly_spend: 0
                     session_count: 0
                     user_count: 0
@@ -2891,14 +2906,14 @@ paths:
                 Company Not Found:
                   value:
                     type: error.list
-                    request_id: 14121a1a-a146-4035-8073-5e63897bffec
+                    request_id: ab3f8c1a-dd0d-43a2-8ea3-5e09ba715dd6
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 714bd18d-28aa-46e0-bea2-1fd0881185a4
+                    request_id: 724c5da4-72b1-480f-a1bc-219e4a8242b7
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -2912,7 +2927,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 891db4db-706e-4d1a-a0c2-6d0bd8a2c0bc
+                    request_id: f6e9e963-805f-464a-9362-67b76c9d8c2c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -2948,42 +2963,42 @@ paths:
                     type: list
                     data:
                     - type: note
-                      id: '16'
-                      created_at: 1727252100
+                      id: '29'
+                      created_at: 1732716208
                       contact:
                         type: contact
-                        id: 66fd01049ffbe52cc8b3aa42
+                        id: 67506130d5eefd6f04e7d08c
                       author:
                         type: admin
-                        id: '991266952'
+                        id: '991267582'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '15'
-                      created_at: 1727165700
+                      id: '28'
+                      created_at: 1732629808
                       contact:
                         type: contact
-                        id: 66fd01049ffbe52cc8b3aa42
+                        id: 67506130d5eefd6f04e7d08c
                       author:
                         type: admin
-                        id: '991266952'
+                        id: '991267582'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
                         away_mode_reassign: false
                       body: "<p>This is a note.</p>"
                     - type: note
-                      id: '14'
-                      created_at: 1727165700
+                      id: '27'
+                      created_at: 1732629808
                       contact:
                         type: contact
-                        id: 66fd01049ffbe52cc8b3aa42
+                        id: 67506130d5eefd6f04e7d08c
                       author:
                         type: admin
-                        id: '991266952'
+                        id: '991267582'
                         name: Ciaran122 Lee
                         email: admin122@email.com
                         away_mode_enabled: false
@@ -3006,7 +3021,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 69dae9ea-0711-4dd9-af8b-aedc7c1e34c3
+                    request_id: 0355b1eb-e7f3-48b6-8dce-485925d48680
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3040,14 +3055,14 @@ paths:
                 Successful response:
                   value:
                     type: note
-                    id: '21'
-                    created_at: 1727856903
+                    id: '34'
+                    created_at: 1733321010
                     contact:
                       type: contact
-                      id: 66fd01069ffbe52cc8b3aa44
+                      id: 67506132d5eefd6f04e7d08e
                     author:
                       type: admin
-                      id: '991266954'
+                      id: '991267584'
                       name: Ciaran124 Lee
                       email: admin124@email.com
                       away_mode_enabled: false
@@ -3063,14 +3078,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: d6a77f1d-7eb7-4af9-9807-13c9b2058ceb
+                    request_id: c4fd9803-70b9-4c86-9a5e-57e6ac8b33d2
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: bdac6716-6720-4990-bc1f-a283574ceaee
+                    request_id: c5d3d5e8-db14-4d9d-a89e-79fba5eb4188
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3100,20 +3115,20 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  contact_id: 66fd01069ffbe52cc8b3aa44
-                  admin_id: 991266954
+                  contact_id: 67506132d5eefd6f04e7d08e
+                  admin_id: 991267584
                   body: Hello
               admin_not_found:
                 summary: Admin not found
                 value:
-                  contact_id: 66fd01079ffbe52cc8b3aa45
+                  contact_id: 67506133d5eefd6f04e7d08f
                   admin_id: 123
                   body: Hello
               contact_not_found:
                 summary: Contact not found
                 value:
                   contact_id: 123
-                  admin_id: 991266956
+                  admin_id: 991267586
                   body: Hello
   "/contacts/{contact_id}/segments":
     get:
@@ -3146,10 +3161,10 @@ paths:
                     type: list
                     data:
                     - type: segment
-                      id: 66fd010a9ffbe52cc8b3aa47
+                      id: 67506135d5eefd6f04e7d091
                       name: segment
-                      created_at: 1727856906
-                      updated_at: 1727856906
+                      created_at: 1733321013
+                      updated_at: 1733321013
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/contact_segments"
@@ -3161,7 +3176,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: f5eaedc9-9c7e-467c-83cf-2bb27a1ab70e
+                    request_id: 6be3548c-e948-4e1a-bb56-d135d0ec0127
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3175,7 +3190,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0d5bd439-7eb7-4c83-861b-804a3c666c5d
+                    request_id: '08446ae5-b3a3-4081-be42-19d7b897104d'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3219,7 +3234,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '47'
+                      id: '93'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -3233,7 +3248,7 @@ paths:
                       content_types:
                       - email
                     - type: subscription
-                      id: '49'
+                      id: '95'
                       state: live
                       consent_type: opt_in
                       default_translation:
@@ -3256,7 +3271,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: a3b635b2-18b4-4050-bb95-eb7d350d645e
+                    request_id: f36145eb-c56f-49fe-95f3-78cd7fbe9ed4
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3270,7 +3285,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 16e6d3d1-3105-42c3-8612-077ce9b5c871
+                    request_id: 13f85025-4372-4b28-8236-e132450bf3cd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3311,7 +3326,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '62'
+                    id: '108'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3334,14 +3349,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: fd87c3e0-af0e-4144-8cd9-13734a4dc1e0
+                    request_id: 5984eb52-c1ca-408c-b71a-af242fb9f206
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 6a8feb4c-981d-453e-ade0-5725de361dad
+                    request_id: f5119662-8183-46ed-b6c4-b67667600d31
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3355,7 +3370,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 03cf16eb-c261-4c29-9d7b-471822531291
+                    request_id: 0e3583aa-1d41-4042-8b36-898aadda62d7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3383,12 +3398,12 @@ paths:
               successful:
                 summary: Successful
                 value:
-                  id: 62
+                  id: 108
                   consent_type: opt_in
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 66
+                  id: 112
                   consent_type: opt_in
               resource_not_found:
                 summary: Resource not found
@@ -3434,7 +3449,7 @@ paths:
                 Successful:
                   value:
                     type: subscription
-                    id: '78'
+                    id: '124'
                     state: live
                     consent_type: opt_in
                     default_translation:
@@ -3457,14 +3472,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 12fb835c-7ed9-496c-b2aa-ccb8de94e670
+                    request_id: 5c3437a7-6a2e-4542-b9b6-f2b120597766
                     errors:
                     - code: not_found
                       message: User Not Found
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: d9f37d47-4ae5-4219-a915-4e4eab5d73ec
+                    request_id: fe2d2850-95b0-4284-a1be-cd798083ac86
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3478,7 +3493,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ea6d6c78-cfb3-47c4-b49b-182214870200
+                    request_id: c0e10dff-b620-426c-a99b-5170b37ff0bc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3516,7 +3531,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '47'
+                      id: '93'
                       name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -3528,7 +3543,7 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 677e9745-29e7-4651-86bf-c33caa803fdb
+                    request_id: 2cba220e-5281-4aad-8e6f-d8d07c98db49
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -3542,7 +3557,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c97b42ad-c524-438e-ba9f-b34a50b5a458
+                    request_id: 5f931143-1552-4a6a-b190-ab05ad109dca
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3577,7 +3592,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '48'
+                    id: '94'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3589,14 +3604,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 836128ff-c99d-4fe8-86e0-c49fe95f0b4b
+                    request_id: 178fec1c-3369-4748-842c-e26a2b1dc15f
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: b3036f7a-1747-46ae-a936-6eecdaf00035
+                    request_id: 88371359-a04d-416c-8ba1-1c486aed1b42
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3610,7 +3625,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 362b4ff1-e885-46a2-9eed-28467e242aad
+                    request_id: cd0c707a-c6d5-4044-8614-aa9407a2500a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3633,11 +3648,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 48
+                  id: 94
               contact_not_found:
                 summary: Contact not found
                 value:
-                  id: 49
+                  id: 95
               tag_not_found:
                 summary: Tag not found
                 value:
@@ -3679,7 +3694,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '51'
+                    id: '97'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -3691,14 +3706,14 @@ paths:
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: 5192f776-12c4-4e22-b056-328dd42381ad
+                    request_id: c7eaf0cc-2fcd-46d4-90d8-87b92b2766be
                     errors:
                     - code: not_found
                       message: User Not Found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 689e4255-3285-4b93-96c1-1a1042cb7c4a
+                    request_id: 251e06bb-ea79-43d9-a098-6214f03a83e7
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -3712,7 +3727,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '097cc71a-add9-489a-a1e5-6eed83b99d51'
+                    request_id: 208cf564-94f6-4158-9055-d2ef21254682
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3746,7 +3761,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 66fd01239ffbe52cc8b3aa5e
+                    id: 6750614ed5eefd6f04e7d0a8
                     workspace_id: this_is_an_id279_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3762,9 +3777,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1727856931
-                    updated_at: 1727856931
-                    signed_up_at: 1727856931
+                    created_at: 1733321038
+                    updated_at: 1733321039
+                    signed_up_at: 1733321038
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3798,31 +3813,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/66fd01239ffbe52cc8b3aa5e/tags"
+                      url: "/contacts/6750614ed5eefd6f04e7d0a8/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/66fd01239ffbe52cc8b3aa5e/notes"
+                      url: "/contacts/6750614ed5eefd6f04e7d0a8/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/66fd01239ffbe52cc8b3aa5e/companies"
+                      url: "/contacts/6750614ed5eefd6f04e7d0a8/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd01239ffbe52cc8b3aa5e/subscriptions"
+                      url: "/contacts/6750614ed5eefd6f04e7d0a8/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd01239ffbe52cc8b3aa5e/subscriptions"
+                      url: "/contacts/6750614ed5eefd6f04e7d0a8/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3831,8 +3846,16 @@ paths:
                     utm_source:
                     utm_term:
                     referrer:
+                    enabled_push_messaging:
               schema:
-                "$ref": "#/components/schemas/contact"
+                allOf:
+                - "$ref": "#/components/schemas/contact"
+                properties:
+                  enabled_push_messaging:
+                    type: boolean
+                    nullable: true
+                    description: If the user has enabled push messaging.
+                    example: true
         '401':
           description: Unauthorized
           content:
@@ -3841,7 +3864,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b2f4b92f-9a9b-4888-b9ca-95aae731dc48
+                    request_id: c660576b-6a5c-416a-8dae-041423709361
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -3886,7 +3909,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 66fd01259ffbe52cc8b3aa5f
+                    id: 67506150d5eefd6f04e7d0a9
                     workspace_id: this_is_an_id283_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -3902,9 +3925,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1727856933
-                    updated_at: 1727856933
-                    signed_up_at: 1727856933
+                    created_at: 1733321041
+                    updated_at: 1733321040
+                    signed_up_at: 1733321040
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -3938,31 +3961,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/66fd01259ffbe52cc8b3aa5f/tags"
+                      url: "/contacts/67506150d5eefd6f04e7d0a9/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/66fd01259ffbe52cc8b3aa5f/notes"
+                      url: "/contacts/67506150d5eefd6f04e7d0a9/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/66fd01259ffbe52cc8b3aa5f/companies"
+                      url: "/contacts/67506150d5eefd6f04e7d0a9/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd01259ffbe52cc8b3aa5f/subscriptions"
+                      url: "/contacts/67506150d5eefd6f04e7d0a9/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd01259ffbe52cc8b3aa5f/subscriptions"
+                      url: "/contacts/67506150d5eefd6f04e7d0a9/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -3971,8 +3994,16 @@ paths:
                     utm_source:
                     utm_term:
                     referrer:
+                    enabled_push_messaging:
               schema:
-                "$ref": "#/components/schemas/contact"
+                allOf:
+                - "$ref": "#/components/schemas/contact"
+                properties:
+                  enabled_push_messaging:
+                    type: boolean
+                    nullable: true
+                    description: If the user has enabled push messaging.
+                    example: true
         '401':
           description: Unauthorized
           content:
@@ -3981,7 +4012,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0e8e7323-189a-4257-9e71-2cbdb93b56c2
+                    request_id: febe8ef6-f98a-4e91-8d34-4d65c7bdd722
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4012,7 +4043,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 66fd01279ffbe52cc8b3aa60
+                    id: 67506153d5eefd6f04e7d0aa
                     external_id: '70'
                     type: contact
                     deleted: true
@@ -4026,7 +4057,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fe391f69-e134-49dd-ba65-5bb49fe412e0
+                    request_id: 4ef9c8ab-ec11-4e38-90f8-b4b8af1030ef
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4054,7 +4085,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 66fd01299ffbe52cc8b3aa62
+                    id: 67506155d5eefd6f04e7d0ac
                     workspace_id: this_is_an_id291_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -4070,9 +4101,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1727856937
-                    updated_at: 1727856938
-                    signed_up_at: 1727856937
+                    created_at: 1733321045
+                    updated_at: 1733321046
+                    signed_up_at: 1733321045
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -4106,31 +4137,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/66fd01299ffbe52cc8b3aa62/tags"
+                      url: "/contacts/67506155d5eefd6f04e7d0ac/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/66fd01299ffbe52cc8b3aa62/notes"
+                      url: "/contacts/67506155d5eefd6f04e7d0ac/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/66fd01299ffbe52cc8b3aa62/companies"
+                      url: "/contacts/67506155d5eefd6f04e7d0ac/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd01299ffbe52cc8b3aa62/subscriptions"
+                      url: "/contacts/67506155d5eefd6f04e7d0ac/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd01299ffbe52cc8b3aa62/subscriptions"
+                      url: "/contacts/67506155d5eefd6f04e7d0ac/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4139,8 +4170,16 @@ paths:
                     utm_source:
                     utm_term:
                     referrer:
+                    enabled_push_messaging:
               schema:
-                "$ref": "#/components/schemas/contact"
+                allOf:
+                - "$ref": "#/components/schemas/contact"
+                properties:
+                  enabled_push_messaging:
+                    type: boolean
+                    nullable: true
+                    description: If the user has enabled push messaging.
+                    example: true
         '401':
           description: Unauthorized
           content:
@@ -4149,7 +4188,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7bb0d16d-62f8-4e6f-aed8-fd7ee19bb4eb
+                    request_id: dfb74c74-b5e0-4584-9067-b4e857cfb6f6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4164,8 +4203,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  from: 66fd01299ffbe52cc8b3aa61
-                  into: 66fd01299ffbe52cc8b3aa62
+                  from: 67506155d5eefd6f04e7d0ab
+                  into: 67506155d5eefd6f04e7d0ac
   "/contacts/search":
     post:
       summary: Search contacts
@@ -4304,7 +4343,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c055b158-ec01-49c5-b16a-8eb13db90c0d
+                    request_id: a6f4b281-f71d-4342-a327-4866d52be68b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4370,7 +4409,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 9592a707-0231-4d17-bc4a-afd5d2f95440
+                    request_id: dbb860eb-52b8-4617-bf3d-8e746ee52635
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4396,7 +4435,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 66fd01309ffbe52cc8b3aa65
+                    id: 6750615cd5eefd6f04e7d0af
                     workspace_id: this_is_an_id303_that_should_be_at_least_
                     external_id:
                     role: user
@@ -4412,8 +4451,8 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1727856944
-                    updated_at: 1727856944
+                    created_at: 1733321052
+                    updated_at: 1733321052
                     signed_up_at:
                     last_seen_at:
                     last_replied_at:
@@ -4448,31 +4487,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/66fd01309ffbe52cc8b3aa65/tags"
+                      url: "/contacts/6750615cd5eefd6f04e7d0af/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/66fd01309ffbe52cc8b3aa65/notes"
+                      url: "/contacts/6750615cd5eefd6f04e7d0af/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/66fd01309ffbe52cc8b3aa65/companies"
+                      url: "/contacts/6750615cd5eefd6f04e7d0af/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd01309ffbe52cc8b3aa65/subscriptions"
+                      url: "/contacts/6750615cd5eefd6f04e7d0af/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd01309ffbe52cc8b3aa65/subscriptions"
+                      url: "/contacts/6750615cd5eefd6f04e7d0af/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4481,8 +4520,16 @@ paths:
                     utm_source:
                     utm_term:
                     referrer:
+                    enabled_push_messaging:
               schema:
-                "$ref": "#/components/schemas/contact"
+                allOf:
+                - "$ref": "#/components/schemas/contact"
+                properties:
+                  enabled_push_messaging:
+                    type: boolean
+                    nullable: true
+                    description: If the user has enabled push messaging.
+                    example: true
         '401':
           description: Unauthorized
           content:
@@ -4491,7 +4538,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ebe26426-9c95-455c-ad5d-dd6f8366b20e
+                    request_id: 3551552e-e23b-4f7d-86a9-0567349aeb68
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4537,7 +4584,7 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 66fd01329ffbe52cc8b3aa66
+                    id: 6750615ed5eefd6f04e7d0b0
                     workspace_id: this_is_an_id307_that_should_be_at_least_
                     external_id: '70'
                     role: user
@@ -4553,9 +4600,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1727856946
-                    updated_at: 1727856946
-                    signed_up_at: 1727856946
+                    created_at: 1733321054
+                    updated_at: 1733321054
+                    signed_up_at: 1733321054
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -4589,31 +4636,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/66fd01329ffbe52cc8b3aa66/tags"
+                      url: "/contacts/6750615ed5eefd6f04e7d0b0/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/66fd01329ffbe52cc8b3aa66/notes"
+                      url: "/contacts/6750615ed5eefd6f04e7d0b0/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/66fd01329ffbe52cc8b3aa66/companies"
+                      url: "/contacts/6750615ed5eefd6f04e7d0b0/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd01329ffbe52cc8b3aa66/subscriptions"
+                      url: "/contacts/6750615ed5eefd6f04e7d0b0/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd01329ffbe52cc8b3aa66/subscriptions"
+                      url: "/contacts/6750615ed5eefd6f04e7d0b0/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -4622,8 +4669,16 @@ paths:
                     utm_source:
                     utm_term:
                     referrer:
+                    enabled_push_messaging:
               schema:
-                "$ref": "#/components/schemas/contact"
+                allOf:
+                - "$ref": "#/components/schemas/contact"
+                properties:
+                  enabled_push_messaging:
+                    type: boolean
+                    nullable: true
+                    description: If the user has enabled push messaging.
+                    example: true
         '401':
           description: Unauthorized
           content:
@@ -4632,7 +4687,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2093ae35-8bf9-49d4-8c11-57771e4b3c06
+                    request_id: 6f2a2183-40fa-4794-8f5f-35632df917a1
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4665,7 +4720,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 66fd01349ffbe52cc8b3aa68
+                    id: 67506160d5eefd6f04e7d0b2
                     external_id: '70'
                     type: contact
                     archived: true
@@ -4698,7 +4753,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: 66fd01369ffbe52cc8b3aa69
+                    id: 67506161d5eefd6f04e7d0b3
                     external_id: '70'
                     type: contact
                     archived: false
@@ -4734,7 +4789,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '53'
+                    id: '99'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4746,7 +4801,7 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 7cb55eca-e989-410d-b223-4f947a6ecf5f
+                    request_id: 4a2c8ea9-2bbb-4bfe-9fff-e47e38de22f8
                     errors:
                     - code: not_found
                       message: Conversation not found
@@ -4760,7 +4815,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 64d7a15e-4438-47b0-bbf8-8559a8e892d2
+                    request_id: fec2f112-902b-4c1b-800c-942ad3431d0e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4789,13 +4844,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 53
-                  admin_id: 991266989
+                  id: 99
+                  admin_id: 991267619
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  id: 54
-                  admin_id: 991266991
+                  id: 100
+                  admin_id: 991267621
   "/conversations/{conversation_id}/tags/{id}":
     delete:
       summary: Remove tag from a conversation
@@ -4833,7 +4888,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '56'
+                    id: '102'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -4845,14 +4900,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: 38ff13a7-7283-423c-93b8-14c242662487
+                    request_id: 9f48c3c7-b155-4c18-a3ba-6a4e4b7028f0
                     errors:
                     - code: not_found
                       message: Conversation not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: 34ef3b73-b554-46f3-98c9-8d5910e4cd83
+                    request_id: 2b70d833-80ff-4450-98c0-bf9b4948a335
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -4866,7 +4921,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 736f0c2b-fc56-4b1d-bbf4-85a3918334d9
+                    request_id: fa2c1440-4397-4ef9-958d-f2e192dfb1dc
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -4889,15 +4944,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991266993
+                  admin_id: 991267623
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991266995
+                  admin_id: 991267625
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991266996
+                  admin_id: 991267626
   "/conversations":
     get:
       summary: List all conversations
@@ -4948,20 +5003,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '171'
-                      created_at: 1727856965
-                      updated_at: 1727856965
+                      id: '337'
+                      created_at: 1733321072
+                      updated_at: 1733321072
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918153'
+                        id: '403918241'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991266999'
+                          id: '991267629'
                           name: Ciaran166 Lee
                           email: admin166@email.com
                         attachments: []
@@ -4971,7 +5026,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 66fd01449ffbe52cc8b3aa6d
+                          id: 67506170d5eefd6f04e7d0b7
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -5008,7 +5063,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 24b961f0-5ae0-4476-bc2d-6340b7c58ebe
+                    request_id: 5fa5e89b-fc97-461b-b660-130ad1a45c58
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5022,7 +5077,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 6a3e8010-1fe0-439e-986a-01486f641bfc
+                    request_id: 39d59862-440d-4e53-b281-91448ca78268
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5058,11 +5113,11 @@ paths:
                 conversation created:
                   value:
                     type: user_message
-                    id: '403918163'
-                    created_at: 1727857007
+                    id: '403918251'
+                    created_at: 1733321110
                     body: Hello there
                     message_type: inapp
-                    conversation_id: '199'
+                    conversation_id: '365'
               schema:
                 "$ref": "#/components/schemas/message"
         '404':
@@ -5073,7 +5128,7 @@ paths:
                 Contact Not Found:
                   value:
                     type: error.list
-                    request_id: 1430dc67-fe2c-43e8-9f1f-ce82c871b7ca
+                    request_id: 81c815b9-1cce-4a23-ba9c-1edd4eae238c
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -5087,7 +5142,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e1fbce52-d712-45a4-a677-96ec34208546
+                    request_id: de237675-d169-4901-b7de-6217e51fcc72
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5101,7 +5156,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 7be7ca5f-b5b3-4360-a12b-8367451ed02c
+                    request_id: 4ca4a407-3f34-4e9d-8a95-6c654c7410ac
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5118,7 +5173,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 66fd016d9ffbe52cc8b3aa85
+                    id: 67506194d5eefd6f04e7d0cf
                   body: Hello there
               contact_not_found:
                 summary: Contact Not Found
@@ -5172,20 +5227,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '203'
-                    created_at: 1727857016
-                    updated_at: 1727857016
+                    id: '369'
+                    created_at: 1733321118
+                    updated_at: 1733321118
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918167'
+                      id: '403918255'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267016'
+                        id: '991267646'
                         name: Ciaran176 Lee
                         email: admin176@email.com
                       attachments: []
@@ -5195,7 +5250,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01789ffbe52cc8b3aa89
+                        id: 6750619ed5eefd6f04e7d0d3
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5236,7 +5291,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 43c9b3eb-75fb-4d81-a582-0288cfd111d7
+                    request_id: 9434a262-e420-4677-8d31-a889a105ae3a
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5250,7 +5305,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 77136027-72ca-4792-8eef-406104220952
+                    request_id: 8e8a1f78-1802-461d-80fa-4b556b5abe3b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5264,7 +5319,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: e458da79-ae4c-4b9a-b3b3-a6398b2fe94d
+                    request_id: d1013c19-7d19-4aa9-9213-9beb16c08390
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5311,20 +5366,20 @@ paths:
                 conversation found:
                   value:
                     type: conversation
-                    id: '207'
-                    created_at: 1727857025
-                    updated_at: 1727857027
+                    id: '373'
+                    created_at: 1733321128
+                    updated_at: 1733321130
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918171'
+                      id: '403918259'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267024'
+                        id: '991267654'
                         name: Ciaran180 Lee
                         email: admin180@email.com
                       attachments: []
@@ -5334,7 +5389,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01819ffbe52cc8b3aa8d
+                        id: 675061a8d5eefd6f04e7d0d7
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5367,17 +5422,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '65'
+                        id: '136'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1727857027
-                        updated_at: 1727857027
-                        notified_at: 1727857027
+                        created_at: 1733321130
+                        updated_at: 1733321130
+                        notified_at: 1733321130
                         assigned_to:
                         author:
-                          id: '991267025'
+                          id: '991267655'
                           type: bot
-                          name: Operator
+                          name: Fin
                           email: operator+this_is_an_id354_that_should_be_at_least_@intercom.io
                         attachments: []
                         external_id:
@@ -5385,17 +5440,17 @@ paths:
                         metadata: {}
                         email_message_metadata:
                       - type: conversation_part
-                        id: '66'
+                        id: '137'
                         part_type: conversation_attribute_updated_by_admin
                         body:
-                        created_at: 1727857027
-                        updated_at: 1727857027
-                        notified_at: 1727857027
+                        created_at: 1733321130
+                        updated_at: 1733321130
+                        notified_at: 1733321130
                         assigned_to:
                         author:
-                          id: '991267025'
+                          id: '991267655'
                           type: bot
-                          name: Operator
+                          name: Fin
                           email: operator+this_is_an_id354_that_should_be_at_least_@intercom.io
                         attachments: []
                         external_id:
@@ -5413,7 +5468,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: da3b8d2a-b8d2-4338-86bb-2c7c2a2991f3
+                    request_id: 1acafb00-4f20-4fa0-8456-149d87467e35
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -5427,7 +5482,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ca1d4caa-d9db-4eb6-becf-b0cf1a1ce61e
+                    request_id: e3fdedec-f165-4faa-af7d-d313e9eea6c7
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5441,7 +5496,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: ee098ddb-32be-4351-8a24-e850878cfcac
+                    request_id: 5f50b24c-5430-4e55-911f-72cb2e55d231
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5492,7 +5547,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '211'
+                    id: '377'
                     object: conversation
                     deleted: true
               schema:
@@ -5505,7 +5560,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1855affc-fbdf-428e-a267-48a6343f571d
+                    request_id: 442a6006-d37f-412d-b1e9-196c4d081c2f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -5519,7 +5574,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 7ce56f06-d349-4ff1-9f24-b9bd7e3b8a6c
+                    request_id: 433d7ad0-1705-458f-b0a6-694cbdb2eae7
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -5652,20 +5707,20 @@ paths:
                     total_count: 1
                     conversations:
                     - type: conversation
-                      id: '214'
-                      created_at: 1727857044
-                      updated_at: 1727857044
+                      id: '380'
+                      created_at: 1733321148
+                      updated_at: 1733321148
                       waiting_since:
                       snoozed_until:
                       source:
                         type: conversation
-                        id: '403918178'
+                        id: '403918266'
                         delivered_as: admin_initiated
                         subject: ''
                         body: "<p>this is the message body</p>"
                         author:
                           type: admin
-                          id: '991267054'
+                          id: '991267684'
                           name: Ciaran203 Lee
                           email: admin203@email.com
                         attachments: []
@@ -5675,7 +5730,7 @@ paths:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 66fd01939ffbe52cc8b3aa94
+                          id: 675061bcd5eefd6f04e7d0de
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id:
@@ -5751,20 +5806,20 @@ paths:
                 User reply:
                   value:
                     type: conversation
-                    id: '223'
-                    created_at: 1727857056
-                    updated_at: 1727857057
-                    waiting_since: 1727857057
+                    id: '389'
+                    created_at: 1733321161
+                    updated_at: 1733321162
+                    waiting_since: 1733321162
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918181'
+                      id: '403918269'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267057'
+                        id: '991267687'
                         name: Ciaran205 Lee
                         email: admin205@email.com
                       attachments: []
@@ -5774,10 +5829,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01a09ffbe52cc8b3aa9c
+                        id: 675061c8d5eefd6f04e7d0e6
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1727857057
+                      created_at: 1733321162
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -5808,15 +5863,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '68'
+                        id: '139'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1727857057
-                        updated_at: 1727857057
-                        notified_at: 1727857057
+                        created_at: 1733321162
+                        updated_at: 1733321162
+                        notified_at: 1733321162
                         assigned_to:
                         author:
-                          id: 66fd01a09ffbe52cc8b3aa9c
+                          id: 675061c8d5eefd6f04e7d0e6
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -5829,20 +5884,20 @@ paths:
                 Admin note reply:
                   value:
                     type: conversation
-                    id: '224'
-                    created_at: 1727857059
-                    updated_at: 1727857061
+                    id: '390'
+                    created_at: 1733321164
+                    updated_at: 1733321166
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918182'
+                      id: '403918270'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267059'
+                        id: '991267689'
                         name: Ciaran206 Lee
                         email: admin206@email.com
                       attachments: []
@@ -5852,7 +5907,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01a29ffbe52cc8b3aa9d
+                        id: 675061ccd5eefd6f04e7d0e7
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5883,7 +5938,7 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '69'
+                        id: '140'
                         part_type: note
                         body: |-
                           <h2>An Unordered HTML List</h2>
@@ -5898,12 +5953,12 @@ paths:
                           <li>Tea</li>
                           <li>Milk</li>
                           </ol>
-                        created_at: 1727857061
-                        updated_at: 1727857061
-                        notified_at: 1727857061
+                        created_at: 1733321166
+                        updated_at: 1733321166
+                        notified_at: 1733321166
                         assigned_to:
                         author:
-                          id: '991267059'
+                          id: '991267689'
                           type: admin
                           name: Ciaran206 Lee
                           email: admin206@email.com
@@ -5916,20 +5971,20 @@ paths:
                 Admin quick_reply reply:
                   value:
                     type: conversation
-                    id: '225'
-                    created_at: 1727857062
-                    updated_at: 1727857064
+                    id: '391'
+                    created_at: 1733321167
+                    updated_at: 1733321169
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918183'
+                      id: '403918271'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267061'
+                        id: '991267691'
                         name: Ciaran207 Lee
                         email: admin207@email.com
                       attachments: []
@@ -5939,7 +5994,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01a69ffbe52cc8b3aa9e
+                        id: 675061cfd5eefd6f04e7d0e8
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -5970,15 +6025,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '70'
+                        id: '141'
                         part_type: quick_reply
                         body:
-                        created_at: 1727857064
-                        updated_at: 1727857064
-                        notified_at: 1727857064
+                        created_at: 1733321169
+                        updated_at: 1733321169
+                        notified_at: 1733321169
                         assigned_to:
                         author:
-                          id: '991267061'
+                          id: '991267691'
                           type: admin
                           name: Ciaran207 Lee
                           email: admin207@email.com
@@ -5991,20 +6046,20 @@ paths:
                 User last conversation reply:
                   value:
                     type: conversation
-                    id: '226'
-                    created_at: 1727857066
-                    updated_at: 1727857067
-                    waiting_since: 1727857067
+                    id: '392'
+                    created_at: 1733321171
+                    updated_at: 1733321172
+                    waiting_since: 1733321172
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918184'
+                      id: '403918272'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267063'
+                        id: '991267693'
                         name: Ciaran208 Lee
                         email: admin208@email.com
                       attachments: []
@@ -6014,10 +6069,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01a99ffbe52cc8b3aa9f
+                        id: 675061d2d5eefd6f04e7d0e9
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1727857067
+                      created_at: 1733321172
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -6048,15 +6103,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '71'
+                        id: '142'
                         part_type: open
                         body: "<p>Thanks again :)</p>"
-                        created_at: 1727857067
-                        updated_at: 1727857067
-                        notified_at: 1727857067
+                        created_at: 1733321172
+                        updated_at: 1733321172
+                        notified_at: 1733321172
                         assigned_to:
                         author:
-                          id: 66fd01a99ffbe52cc8b3aa9f
+                          id: 675061d2d5eefd6f04e7d0e9
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -6076,7 +6131,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 4154228e-b2c3-4899-90fc-72185bc1233e
+                    request_id: d73c0a7c-422c-4616-aa30-4a0366e48b2f
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6090,7 +6145,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7ad53952-7179-4d7b-8b07-e41da78983ac
+                    request_id: 211971f0-10e7-41d7-bbc7-b6632841098e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6104,7 +6159,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 5fae2837-22f7-4670-bd8e-1b71de0bfb2d
+                    request_id: a1d5a35e-ef52-4d97-8a16-025da2308976
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6121,14 +6176,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 66fd01a09ffbe52cc8b3aa9c
+                  intercom_user_id: 675061c8d5eefd6f04e7d0e6
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991267059
+                  admin_id: 991267689
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -6138,25 +6193,25 @@ paths:
                 value:
                   message_type: quick_reply
                   type: admin
-                  admin_id: 991267061
+                  admin_id: 991267691
                   reply_options:
                   - text: 'Yes'
-                    uuid: 52337e6c-5eba-48a3-aa23-c66b234985d6
+                    uuid: 5e48fd0b-d71a-40f8-8a8b-8607a5b2d620
                   - text: 'No'
-                    uuid: 49b7650d-ffca-4116-b3b1-dcee4680704a
+                    uuid: 73251be4-a9b9-456b-b0be-73d3d784e36c
               user_last_conversation_reply:
                 summary: User last conversation reply
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 66fd01a99ffbe52cc8b3aa9f
+                  intercom_user_id: 675061d2d5eefd6f04e7d0e9
                   body: Thanks again :)
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 66fd01ac9ffbe52cc8b3aaa0
+                  intercom_user_id: 675061d6d5eefd6f04e7d0ea
                   body: Thanks again :)
   "/conversations/{id}/parts":
     post:
@@ -6191,20 +6246,20 @@ paths:
                 Close a conversation:
                   value:
                     type: conversation
-                    id: '230'
-                    created_at: 1727857076
-                    updated_at: 1727857077
+                    id: '396'
+                    created_at: 1733321181
+                    updated_at: 1733321183
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918188'
+                      id: '403918276'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267071'
+                        id: '991267701'
                         name: Ciaran212 Lee
                         email: admin212@email.com
                       attachments: []
@@ -6214,7 +6269,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01b49ffbe52cc8b3aaa3
+                        id: 675061ddd5eefd6f04e7d0ed
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6245,15 +6300,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '72'
+                        id: '143'
                         part_type: close
                         body: "<p>Goodbye :)</p>"
-                        created_at: 1727857077
-                        updated_at: 1727857077
-                        notified_at: 1727857077
+                        created_at: 1733321183
+                        updated_at: 1733321183
+                        notified_at: 1733321183
                         assigned_to:
                         author:
-                          id: '991267071'
+                          id: '991267701'
                           type: admin
                           name: Ciaran212 Lee
                           email: admin212@email.com
@@ -6266,20 +6321,20 @@ paths:
                 Snooze a conversation:
                   value:
                     type: conversation
-                    id: '231'
-                    created_at: 1727857079
-                    updated_at: 1727857081
+                    id: '397'
+                    created_at: 1733321185
+                    updated_at: 1733321186
                     waiting_since:
-                    snoozed_until: 1727860681
+                    snoozed_until: 1733324786
                     source:
                       type: conversation
-                      id: '403918189'
+                      id: '403918277'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267073'
+                        id: '991267703'
                         name: Ciaran213 Lee
                         email: admin213@email.com
                       attachments: []
@@ -6289,7 +6344,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01b79ffbe52cc8b3aaa4
+                        id: 675061e0d5eefd6f04e7d0ee
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6320,15 +6375,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '73'
+                        id: '144'
                         part_type: snoozed
                         body:
-                        created_at: 1727857081
-                        updated_at: 1727857081
-                        notified_at: 1727857081
+                        created_at: 1733321186
+                        updated_at: 1733321186
+                        notified_at: 1733321186
                         assigned_to:
                         author:
-                          id: '991267073'
+                          id: '991267703'
                           type: admin
                           name: Ciaran213 Lee
                           email: admin213@email.com
@@ -6341,20 +6396,20 @@ paths:
                 Open a conversation:
                   value:
                     type: conversation
-                    id: '236'
-                    created_at: 1727857080
-                    updated_at: 1727857093
+                    id: '402'
+                    created_at: 1733321186
+                    updated_at: 1733321199
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918190'
+                      id: '403918278'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267075'
+                        id: '991267705'
                         name: Ciaran214 Lee
                         email: admin214@email.com
                       attachments: []
@@ -6364,7 +6419,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01bd9ffbe52cc8b3aaa9
+                        id: 675061e7d5eefd6f04e7d0f3
                         external_id: '74'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6395,15 +6450,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '75'
+                        id: '146'
                         part_type: open
                         body:
-                        created_at: 1727857094
-                        updated_at: 1727857094
-                        notified_at: 1727857094
+                        created_at: 1733321199
+                        updated_at: 1733321199
+                        notified_at: 1733321199
                         assigned_to:
                         author:
-                          id: '991267075'
+                          id: '991267705'
                           type: admin
                           name: Ciaran214 Lee
                           email: admin214@email.com
@@ -6416,20 +6471,20 @@ paths:
                 Assign a conversation:
                   value:
                     type: conversation
-                    id: '241'
-                    created_at: 1727857095
-                    updated_at: 1727857096
+                    id: '407'
+                    created_at: 1733321201
+                    updated_at: 1733321202
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918193'
+                      id: '403918281'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267078'
+                        id: '991267708'
                         name: Ciaran216 Lee
                         email: admin216@email.com
                       attachments: []
@@ -6439,10 +6494,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01c79ffbe52cc8b3aaad
+                        id: 675061f0d5eefd6f04e7d0f7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267078
+                    admin_assignee_id: 991267708
                     team_assignee_id:
                     open: true
                     state: open
@@ -6470,17 +6525,17 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '76'
+                        id: '147'
                         part_type: assign_and_reopen
                         body:
-                        created_at: 1727857096
-                        updated_at: 1727857096
-                        notified_at: 1727857096
+                        created_at: 1733321202
+                        updated_at: 1733321202
+                        notified_at: 1733321202
                         assigned_to:
                           type: admin
-                          id: '991267078'
+                          id: '991267708'
                         author:
-                          id: '991267078'
+                          id: '991267708'
                           type: admin
                           name: Ciaran216 Lee
                           email: admin216@email.com
@@ -6500,7 +6555,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 1ce8ab2b-11a4-4efc-a0a8-8bfe8ca93a63
+                    request_id: b93dc124-f2fa-4d3b-b432-9c57c247cb0c
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6514,7 +6569,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: f32e2852-e962-4ea8-bdb5-1486185178af
+                    request_id: 88a2dd5c-f472-40b1-8b3c-557f05346e6d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6528,7 +6583,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: b063ec68-5d77-41e6-bc9e-d05473a09825
+                    request_id: '07989696-56bd-40fe-8d13-0f151c3d368b'
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6549,32 +6604,32 @@ paths:
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991267071
+                  admin_id: 991267701
                   body: Goodbye :)
               snooze_a_conversation:
                 summary: Snooze a conversation
                 value:
                   message_type: snoozed
-                  admin_id: 991267073
-                  snoozed_until: 1727860681
+                  admin_id: 991267703
+                  snoozed_until: 1733324786
               open_a_conversation:
                 summary: Open a conversation
                 value:
                   message_type: open
-                  admin_id: 991267075
+                  admin_id: 991267705
               assign_a_conversation:
                 summary: Assign a conversation
                 value:
                   message_type: assignment
                   type: admin
-                  admin_id: 991267078
-                  assignee_id: 991267078
+                  admin_id: 991267708
+                  assignee_id: 991267708
               not_found:
                 summary: Not found
                 value:
                   message_type: close
                   type: admin
-                  admin_id: 991267080
+                  admin_id: 991267710
                   body: Goodbye :)
   "/conversations/{id}/run_assignment_rules":
     post:
@@ -6608,20 +6663,20 @@ paths:
                 Assign a conversation using assignment rules:
                   value:
                     type: conversation
-                    id: '245'
-                    created_at: 1727857106
-                    updated_at: 1727857107
+                    id: '411'
+                    created_at: 1733321211
+                    updated_at: 1733321212
                     waiting_since:
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918197'
+                      id: '403918285'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267086'
+                        id: '991267716'
                         name: Ciaran220 Lee
                         email: admin220@email.com
                       attachments: []
@@ -6631,7 +6686,7 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd01d19ffbe52cc8b3aab1
+                        id: 675061fad5eefd6f04e7d0fb
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id:
@@ -6662,19 +6717,19 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '77'
+                        id: '148'
                         part_type: default_assignment
                         body:
-                        created_at: 1727857107
-                        updated_at: 1727857107
-                        notified_at: 1727857107
+                        created_at: 1733321212
+                        updated_at: 1733321212
+                        notified_at: 1733321212
                         assigned_to:
                           type: nobody_admin
                           id:
                         author:
-                          id: '991267087'
+                          id: '991267717'
                           type: bot
-                          name: Operator
+                          name: Fin
                           email: operator+this_is_an_id400_that_should_be_at_least_@intercom.io
                         attachments: []
                         external_id:
@@ -6692,7 +6747,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 6d258aef-dc4e-4f71-977b-a0de678b1315
+                    request_id: 81c9550b-161f-4271-808a-de167d6b67da
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6706,7 +6761,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b6c09ad4-23d9-47e5-b569-965edf404b2b
+                    request_id: d57f1454-796c-4f50-b251-0e94b40a9f47
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6720,7 +6775,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 8d83cdfe-7a5c-4d79-b778-6ac01a137bf6
+                    request_id: 1244c147-3d4f-41a7-91f0-ec82924163e4
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6761,7 +6816,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 66fd01dc9ffbe52cc8b3aab5
+                      id: 67506204d5eefd6f04e7d0ff
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6772,7 +6827,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: b254197f-6466-48c9-8fa8-c185b376cc36
+                    request_id: e407f41f-7955-4f69-a89a-fe0fb5fcee99
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -6786,7 +6841,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 65ff1db5-088b-4f44-b65e-18b4f06b46df
+                    request_id: '0428b04d-aed7-4cd2-bf32-f07b53d9cd25'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6800,7 +6855,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: '0890263b-a009-4763-97f4-d8865ba2c8c5'
+                    request_id: fe2882f8-9fa4-4ad9-8c0a-3a231657c70b
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6815,15 +6870,15 @@ paths:
               attach_a_contact_to_a_conversation:
                 summary: Attach a contact to a conversation
                 value:
-                  admin_id: 991267094
+                  admin_id: 991267724
                   customer:
-                    intercom_user_id: 66fd01dc9ffbe52cc8b3aab5
+                    intercom_user_id: 67506204d5eefd6f04e7d0ff
               not_found:
                 summary: Not found
                 value:
-                  admin_id: 991267096
+                  admin_id: 991267726
                   customer:
-                    intercom_user_id: 66fd01df9ffbe52cc8b3aab6
+                    intercom_user_id: 67506207d5eefd6f04e7d100
   "/conversations/{conversation_id}/customers/{contact_id}":
     delete:
       summary: Detach a contact from a group conversation
@@ -6866,7 +6921,7 @@ paths:
                   value:
                     customers:
                     - type: user
-                      id: 66fd01f39ffbe52cc8b3aac1
+                      id: 67506219d5eefd6f04e7d10b
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -6877,14 +6932,14 @@ paths:
                 Conversation not found:
                   value:
                     type: error.list
-                    request_id: ca541ef4-b8cc-48a3-858b-a05a488db707
+                    request_id: 9a2966e7-ce0f-4d32-b542-67a8e0ea15ef
                     errors:
                     - code: not_found
                       message: Resource Not Found
                 Contact not found:
                   value:
                     type: error.list
-                    request_id: b75e74ba-f21e-473d-9c37-1d26c556af08
+                    request_id: ff16267a-f9c8-4934-8ad6-5a94fa474925
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -6898,7 +6953,7 @@ paths:
                 Last customer:
                   value:
                     type: error.list
-                    request_id: e82741ec-00fe-4ae4-9e7d-11ba86420b5e
+                    request_id: 9c6080e6-ce95-40bd-af40-ae8e2b65d3e8
                     errors:
                     - code: parameter_invalid
                       message: Removing the last customer is not allowed
@@ -6912,7 +6967,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dbbd5d8e-9071-4ab3-9a5f-b46b81f8f3a9
+                    request_id: 4912ddd9-927c-4db8-86f6-4f09e4fcc15e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -6926,7 +6981,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: a120e33c-f5be-4b17-806e-c8bf6650d1d3
+                    request_id: 157b13d9-a297-41d7-9919-e74b02addff2
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -6941,27 +6996,27 @@ paths:
               detach_a_contact_from_a_group_conversation:
                 summary: Detach a contact from a group conversation
                 value:
-                  admin_id: 991267102
+                  admin_id: 991267732
                   customer:
-                    intercom_user_id: 66fd01e79ffbe52cc8b3aab9
+                    intercom_user_id: 6750620dd5eefd6f04e7d103
               conversation_not_found:
                 summary: Conversation not found
                 value:
-                  admin_id: 991267105
+                  admin_id: 991267735
                   customer:
-                    intercom_user_id: 66fd01f59ffbe52cc8b3aac2
+                    intercom_user_id: 6750621ad5eefd6f04e7d10c
               contact_not_found:
                 summary: Contact not found
                 value:
-                  admin_id: 991267108
+                  admin_id: 991267738
                   customer:
-                    intercom_user_id: 66fd02029ffbe52cc8b3aaca
+                    intercom_user_id: 67506227d5eefd6f04e7d114
               last_customer:
                 summary: Last customer
                 value:
-                  admin_id: 991267111
+                  admin_id: 991267741
                   customer:
-                    intercom_user_id: 66fd020e9ffbe52cc8b3aad2
+                    intercom_user_id: 67506233d5eefd6f04e7d11c
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -6989,20 +7044,20 @@ paths:
                 Redact a conversation part:
                   value:
                     type: conversation
-                    id: '307'
-                    created_at: 1727857203
-                    updated_at: 1727857206
-                    waiting_since: 1727857204
+                    id: '473'
+                    created_at: 1733321304
+                    updated_at: 1733321307
+                    waiting_since: 1733321305
                     snoozed_until:
                     source:
                       type: conversation
-                      id: '403918223'
+                      id: '403918311'
                       delivered_as: admin_initiated
                       subject: ''
                       body: "<p>this is the message body</p>"
                       author:
                         type: admin
-                        id: '991267120'
+                        id: '991267750'
                         name: Ciaran240 Lee
                         email: admin240@email.com
                       attachments: []
@@ -7012,10 +7067,10 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd02339ffbe52cc8b3aaea
+                        id: 67506258d5eefd6f04e7d134
                         external_id: '70'
                     first_contact_reply:
-                      created_at: 1727857204
+                      created_at: 1733321305
                       type: conversation
                       url:
                     admin_assignee_id:
@@ -7046,15 +7101,15 @@ paths:
                       type: conversation_part.list
                       conversation_parts:
                       - type: conversation_part
-                        id: '85'
+                        id: '156'
                         part_type: open
                         body: "<p><i>This message was deleted</i></p>"
-                        created_at: 1727857204
-                        updated_at: 1727857206
-                        notified_at: 1727857204
+                        created_at: 1733321305
+                        updated_at: 1733321307
+                        notified_at: 1733321305
                         assigned_to:
                         author:
-                          id: 66fd02339ffbe52cc8b3aaea
+                          id: 67506258d5eefd6f04e7d134
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
@@ -7074,7 +7129,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: 44fec627-e443-4cca-9958-0b30d582b0b4
+                    request_id: bdd57f84-5ecc-4393-95eb-386585676ce0
                     errors:
                     - code: conversation_part_or_message_not_found
                       message: Conversation part or message not found
@@ -7088,7 +7143,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 46401bdb-91eb-4bbe-a396-fde65fa96c27
+                    request_id: 4bf431de-708d-4abe-b7b5-018c2a5b0475
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7104,8 +7159,8 @@ paths:
                 summary: Redact a conversation part
                 value:
                   type: conversation_part
-                  conversation_id: 307
-                  conversation_part_id: 85
+                  conversation_id: 473
+                  conversation_part_id: 156
               not_found:
                 summary: Not found
                 value:
@@ -7140,25 +7195,25 @@ paths:
                 successful:
                   value:
                     type: ticket
-                    id: '310'
-                    ticket_id: '20'
+                    id: '476'
+                    ticket_id: '39'
                     ticket_attributes: {}
                     ticket_state:
                       type: ticket_state
-                      id: '4629'
+                      id: '7597'
                       category: submitted
                       internal_label: Submitted
                       external_label: Submitted
                     ticket_type:
                       type: ticket_type
-                      id: '49'
+                      id: '97'
                       name: my-ticket-type-1
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
                       workspace_id: this_is_an_id440_that_should_be_at_least_
                       archived: false
-                      created_at: 1727857218
-                      updated_at: 1727857218
+                      created_at: 1733321319
+                      updated_at: 1733321319
                       is_internal: false
                       ticket_type_attributes:
                         type: list
@@ -7168,39 +7223,39 @@ paths:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd023e9ffbe52cc8b3aaed
+                        id: 67506262d5eefd6f04e7d137
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1727857214
-                    updated_at: 1727857219
+                    created_at: 1733321315
+                    updated_at: 1733321320
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '87'
+                        id: '158'
                         part_type: comment
                         body: "<p>Comment for message</p>"
-                        created_at: 1727857214
-                        updated_at: 1727857214
+                        created_at: 1733321315
+                        updated_at: 1733321315
                         author:
-                          id: 66fd023e9ffbe52cc8b3aaed
+                          id: 67506262d5eefd6f04e7d137
                           type: user
                           name: Joe Bloggs
                           email: joe@bloggs.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '88'
+                        id: '159'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1727857219
-                        updated_at: 1727857219
+                        created_at: 1733321320
+                        updated_at: 1733321320
                         author:
-                          id: '991267130'
+                          id: '991267760'
                           type: bot
-                          name: Operator
+                          name: Fin
                           email: operator+this_is_an_id440_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
@@ -7223,7 +7278,7 @@ paths:
                 Bad request:
                   value:
                     type: error.list
-                    request_id: 160ccb27-e177-468a-ad34-97548e488bfa
+                    request_id: 7b29ae15-5903-4bb2-9f0d-d2a3e5f43eaf
                     errors:
                     - code: parameter_invalid
                       message: Ticket type is not a customer ticket type
@@ -7238,11 +7293,11 @@ paths:
               successful:
                 summary: successful
                 value:
-                  ticket_type_id: '49'
+                  ticket_type_id: '97'
               bad_request:
                 summary: Bad request
                 value:
-                  ticket_type_id: '50'
+                  ticket_type_id: '98'
   "/custom_object_instances/{custom_object_type_identifier}":
     parameters:
     - name: custom_object_type_identifier
@@ -7271,14 +7326,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '6'
+                    id: '11'
                     type: object_type_identifier_1
                     custom_attributes: {}
                     external_id: '123'
                     external_created_at: 1392036272
                     external_updated_at: 1392036272
-                    created_at: 1727857226
-                    updated_at: 1727857226
+                    created_at: 1733321327
+                    updated_at: 1733321327
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7289,7 +7344,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ed872bd0-2442-4e59-aa3f-7f9a7fcdf169
+                    request_id: 60d781cd-7c0b-41ea-9c32-cc45a414354f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7349,14 +7404,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '8'
+                    id: '13'
                     type: object_type_identifier_4
                     custom_attributes: {}
                     external_id: '123'
                     external_created_at:
                     external_updated_at:
-                    created_at: 1727857228
-                    updated_at: 1727857228
+                    created_at: 1733321329
+                    updated_at: 1733321329
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7367,7 +7422,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7a244bcf-1487-4e1e-abb7-4f80a4d5ecef
+                    request_id: 2fece84e-67ae-487a-a72e-e64112d35ebb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7407,14 +7462,14 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '9'
+                    id: '14'
                     type: object_type_identifier_6
                     custom_attributes: {}
                     external_id: '123'
                     external_created_at:
                     external_updated_at:
-                    created_at: 1727857229
-                    updated_at: 1727857229
+                    created_at: 1733321331
+                    updated_at: 1733321331
               schema:
                 "$ref": "#/components/schemas/custom_object_instance"
         '401':
@@ -7425,7 +7480,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 72a31e34-c5c6-4f29-b387-e1e7be6fe475
+                    request_id: 875fc1dc-570a-4354-8004-5c03403a51d5
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7456,7 +7511,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '10'
+                    id: '15'
                     object: object_type_identifier_8
                     deleted: true
               schema:
@@ -7469,7 +7524,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 649b8a8f-5eb8-441e-894a-0c3c9a5874d1
+                    request_id: eaa3e544-4d28-4214-a6e1-ed3e572aed56
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7655,7 +7710,7 @@ paths:
                       custom: false
                       archived: false
                       model: company
-                    - id: 18
+                    - id: 34
                       type: data_attribute
                       name: The One Ring
                       full_name: custom_attributes.The One Ring
@@ -7668,9 +7723,9 @@ paths:
                       messenger_writable: true
                       custom: true
                       archived: false
-                      admin_id: '991267147'
-                      created_at: 1727857232
-                      updated_at: 1727857232
+                      admin_id: '991267777'
+                      created_at: 1733321335
+                      updated_at: 1733321335
                       model: company
                     - type: data_attribute
                       name: id
@@ -7742,7 +7797,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7094c9ac-50f8-4b70-8322-94a59ec22184
+                    request_id: 162b22fc-1f18-4fb9-8528-880a14465185
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7767,7 +7822,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 21
+                    id: 37
                     type: data_attribute
                     name: Mithril Shirt
                     full_name: custom_attributes.Mithril Shirt
@@ -7778,9 +7833,9 @@ paths:
                     messenger_writable: false
                     custom: true
                     archived: false
-                    admin_id: '991267149'
-                    created_at: 1727857234
-                    updated_at: 1727857234
+                    admin_id: '991267779'
+                    created_at: 1733321337
+                    updated_at: 1733321337
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -7792,7 +7847,7 @@ paths:
                 Same name already exists:
                   value:
                     type: error.list
-                    request_id: 16e616ae-1e20-460d-b414-c1334789ecbb
+                    request_id: f7cc119a-5f42-4fa4-bc99-743983b7b3db
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -7800,7 +7855,7 @@ paths:
                 Invalid name:
                   value:
                     type: error.list
-                    request_id: c6c87a7e-49ca-46f9-82ff-8d82dd61ccdf
+                    request_id: c0de5887-79ed-4d4c-b908-529634c0c5ae
                     errors:
                     - code: parameter_invalid
                       message: Your name for this attribute must only contain alphanumeric
@@ -7808,7 +7863,7 @@ paths:
                 Attribute already exists:
                   value:
                     type: error.list
-                    request_id: e2233d83-6518-4559-91e8-87770036d6fe
+                    request_id: e8967c91-974e-4724-86d1-9f943bffc371
                     errors:
                     - code: parameter_invalid
                       message: You already have 'The One Ring' in your company data.
@@ -7816,14 +7871,14 @@ paths:
                 Invalid Data Type:
                   value:
                     type: error.list
-                    request_id: 6a37d4c7-7cef-4a41-a128-5335e2ee6b72
+                    request_id: 62172ee9-98db-4b32-be76-272832b03ad1
                     errors:
                     - code: parameter_invalid
                       message: Data Type isn't an option
                 Too few options for list:
                   value:
                     type: error.list
-                    request_id: f5f1d0aa-2ffc-43a6-815e-439a4adca8af
+                    request_id: 988b5bde-5768-4cf1-a777-c15be175d3cf
                     errors:
                     - code: parameter_invalid
                       message: The Data Attribute model field must be either contact
@@ -7838,7 +7893,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 2e9f4e21-5ef0-4047-95a1-58e5f052d09e
+                    request_id: 25a0616b-0d6a-47e6-8bd1-207ff4feaf41
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -7917,7 +7972,7 @@ paths:
               examples:
                 Successful:
                   value:
-                    id: 28
+                    id: 44
                     type: data_attribute
                     name: The One Ring
                     full_name: custom_attributes.The One Ring
@@ -7932,9 +7987,9 @@ paths:
                     messenger_writable: true
                     custom: true
                     archived: false
-                    admin_id: '991267156'
-                    created_at: 1727857239
-                    updated_at: 1727857239
+                    admin_id: '991267786'
+                    created_at: 1733321343
+                    updated_at: 1733321344
                     model: company
               schema:
                 "$ref": "#/components/schemas/data_attribute"
@@ -7946,7 +8001,7 @@ paths:
                 Too few options in list:
                   value:
                     type: error.list
-                    request_id: dc4a4575-c686-43b7-b695-96d63dc87cca
+                    request_id: e7907e7d-9461-40e1-ba7f-805a5ce8fc14
                     errors:
                     - code: parameter_invalid
                       message: Options isn't an array
@@ -7960,7 +8015,7 @@ paths:
                 Attribute Not Found:
                   value:
                     type: error.list
-                    request_id: 145c272e-06ba-46cc-b8b5-cc438635063f
+                    request_id: 9d3633d3-0ad4-4a3a-8fa6-5113c521008a
                     errors:
                     - code: field_not_found
                       message: We couldn't find that data attribute to update
@@ -7974,7 +8029,7 @@ paths:
                 Has Dependant Object:
                   value:
                     type: error.list
-                    request_id: 8e16d3a3-7458-4910-a900-91c8d4329d3b
+                    request_id: 0c73c6c7-d78c-4f0b-80ff-c0f73dddbfcb
                     errors:
                     - code: data_invalid
                       message: The Data Attribute you are trying to archive has a
@@ -7989,7 +8044,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b6d77524-7f36-49ce-b8bc-501ad11b6fd6
+                    request_id: e331a36b-968f-45fa-9daf-7fd8833a504f
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8094,7 +8149,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 913a60e0-4025-4a1a-a60f-82051a8f9fcf
+                    request_id: 18ac76c7-3a43-41d0-89a2-0e1d026c79c3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8181,7 +8236,7 @@ paths:
                     pages:
                       next: http://api.intercom.test/events?next page
                     email: user26@email.com
-                    intercom_user_id: 66fd025f9ffbe52cc8b3aaf3
+                    intercom_user_id: 67506288d5eefd6f04e7d13d
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
               schema:
                 "$ref": "#/components/schemas/data_event_summary"
@@ -8193,7 +8248,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1d331cf2-3933-4007-a81e-c292880681bf
+                    request_id: '09b5125e-5991-4b94-a974-e8dd50cb4306'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8224,7 +8279,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 62219d74-e6fa-4e6e-9583-f23ed87b2324
+                    request_id: 98bdc0cf-cfd5-438e-84e4-02bed25124b0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8268,7 +8323,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: 4vvfpiq2mhutwxkv
+                    job_identifier: 895ztzx2610q27fu
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -8283,8 +8338,8 @@ paths:
               successful:
                 summary: successful
                 value:
-                  created_at_after: 1727839250
-                  created_at_before: 1727857250
+                  created_at_after: 1733303356
+                  created_at_before: 1733321356
   "/export/content/data/{job_identifier}":
     get:
       summary: Show content data export
@@ -8318,7 +8373,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: f0rved8dp1h88atr
+                    job_identifier: 2bzh1lm47w0f32v9
                     status: pending
                     download_url: ''
                     download_expires_at: ''
@@ -8350,7 +8405,7 @@ paths:
               examples:
                 successful:
                   value:
-                    job_identifier: cuxq4lepfgt53o2m
+                    job_identifier: 4zkz3qc4ivxeifee
                     status: canceled
                     download_url: ''
                     download_expires_at: ''
@@ -8411,30 +8466,30 @@ paths:
                 user message created:
                   value:
                     type: user_message
-                    id: '403918228'
-                    created_at: 1727857254
+                    id: '403918316'
+                    created_at: 1733321360
                     body: heyy
                     message_type: inapp
-                    conversation_id: '312'
+                    conversation_id: '478'
                 lead message created:
                   value:
                     type: user_message
-                    id: '403918229'
-                    created_at: 1727857256
+                    id: '403918317'
+                    created_at: 1733321363
                     body: heyy
                     message_type: inapp
-                    conversation_id: '313'
+                    conversation_id: '479'
                 admin message created:
                   value:
                     type: admin_message
-                    id: '10'
-                    created_at: 1727857258
+                    id: '15'
+                    created_at: 1733321365
                     subject: heyy
                     body: heyy
                     message_type: inapp
                     owner:
                       type: admin
-                      id: '991267179'
+                      id: '991267809'
                       name: Ciaran292 Lee
                       email: admin292@email.com
                       away_mode_enabled: false
@@ -8449,14 +8504,14 @@ paths:
                 No body supplied for message:
                   value:
                     type: error.list
-                    request_id: c0c38cb5-63d4-44e1-b418-4eaba75fdb7c
+                    request_id: 11522dc9-2fc9-42a2-836b-808006732cc9
                     errors:
                     - code: parameter_invalid
                       message: Body is required
                 No body supplied for email message:
                   value:
                     type: error.list
-                    request_id: 18a870a1-2994-4b9c-b5e0-cb36e3b6edce
+                    request_id: 9466fb36-f866-4ed2-8f62-dfb3d5bd43ed
                     errors:
                     - code: parameter_invalid
                       message: Body is required
@@ -8470,7 +8525,7 @@ paths:
                 No subject supplied for email message:
                   value:
                     type: error.list
-                    request_id: ec3fd41b-0f1c-4146-92bf-429d634b0476
+                    request_id: eb0845b3-2189-4f52-aec9-d19508e956f6
                     errors:
                     - code: parameter_not_found
                       message: No subject supplied for email message
@@ -8484,7 +8539,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b44aa0fc-e600-4830-bef0-a16e1e7180b8
+                    request_id: 7eba679a-d3b0-4339-a1d5-a96b7ba2da8b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8498,7 +8553,7 @@ paths:
                 API plan restricted:
                   value:
                     type: error.list
-                    request_id: 3ad5b261-9a63-4571-b2ed-5c9aa98a5003
+                    request_id: 275020a3-22d8-4464-8d45-9a0c5295421d
                     errors:
                     - code: api_plan_restricted
                       message: Active subscription needed.
@@ -8515,7 +8570,7 @@ paths:
                 value:
                   from:
                     type: user
-                    id: 66fd02669ffbe52cc8b3aaf8
+                    id: 67506290d5eefd6f04e7d142
                   body: heyy
                   referer: https://twitter.com/bob
               lead_message_created:
@@ -8523,7 +8578,7 @@ paths:
                 value:
                   from:
                     type: lead
-                    id: 66fd02689ffbe52cc8b3aaf9
+                    id: 67506292d5eefd6f04e7d143
                   body: heyy
                   referer: https://twitter.com/bob
               admin_message_created:
@@ -8531,10 +8586,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267179'
+                    id: '991267809'
                   to:
                     type: user
-                    id: 66fd026a9ffbe52cc8b3aafa
+                    id: 67506294d5eefd6f04e7d144
                   message_type: conversation
                   body: heyy
               no_body_supplied_for_message:
@@ -8542,10 +8597,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267181'
+                    id: '991267811'
                   to:
                     type: user
-                    id: 66fd026b9ffbe52cc8b3aafb
+                    id: 67506296d5eefd6f04e7d145
                   message_type: inapp
                   body:
                   subject: heyy
@@ -8554,7 +8609,7 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267182'
+                    id: '991267812'
                   to:
                     type: user
                     user_id: '70'
@@ -8565,10 +8620,10 @@ paths:
                 value:
                   from:
                     type: admin
-                    id: '991267183'
+                    id: '991267813'
                   to:
                     type: user
-                    id: 66fd026d9ffbe52cc8b3aafd
+                    id: 67506298d5eefd6f04e7d147
                   message_type: email
                   body:
                   subject: heyy
@@ -8599,12 +8654,12 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '15'
+                    - id: '29'
                       type: news-item
-                      workspace_id: this_is_an_id530_that_should_be_at_least_
+                      workspace_id: this_is_an_id528_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991267188
+                      sender_id: 991267818
                       state: draft
                       labels: []
                       cover_image_url:
@@ -8614,15 +8669,15 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1727857264
-                      updated_at: 1727857264
+                      created_at: 1733321371
+                      updated_at: 1733321371
                       newsfeed_assignments: []
-                    - id: '16'
+                    - id: '30'
                       type: news-item
-                      workspace_id: this_is_an_id530_that_should_be_at_least_
+                      workspace_id: this_is_an_id528_that_should_be_at_least_
                       title: We have news
                       body: "<p>Hello there,</p>"
-                      sender_id: 991267190
+                      sender_id: 991267820
                       state: draft
                       labels: []
                       cover_image_url:
@@ -8632,8 +8687,8 @@ paths:
                       -
                       -
                       deliver_silently: false
-                      created_at: 1727857264
-                      updated_at: 1727857264
+                      created_at: 1733321371
+                      updated_at: 1733321371
                       newsfeed_assignments: []
                     total_count: 2
               schema:
@@ -8646,7 +8701,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: d485bf96-c6e6-445c-84d0-5606708e4474
+                    request_id: 53895fe5-9f42-4788-8d19-b52640e33c52
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8671,12 +8726,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '19'
+                    id: '33'
                     type: news-item
-                    workspace_id: this_is_an_id534_that_should_be_at_least_
+                    workspace_id: this_is_an_id532_that_should_be_at_least_
                     title: Halloween is here!
                     body: "<p>New costumes in store for this spooky season</p>"
-                    sender_id: 991267197
+                    sender_id: 991267827
                     state: live
                     labels:
                     - New
@@ -8687,10 +8742,10 @@ paths:
                     - "\U0001F606"
                     - "\U0001F605"
                     deliver_silently: true
-                    created_at: 1727857267
-                    updated_at: 1727857267
+                    created_at: 1733321374
+                    updated_at: 1733321374
                     newsfeed_assignments:
-                    - newsfeed_id: 28
+                    - newsfeed_id: 53
                       published_at: 1664638214
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -8702,7 +8757,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c510fe9a-3843-4446-b25c-48cf23e4a0ea
+                    request_id: 2aab4b74-ae96-41c4-b95d-f2933fe6b5d0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8723,14 +8778,14 @@ paths:
                   - Product
                   - Update
                   - New
-                  sender_id: 991267197
+                  sender_id: 991267827
                   deliver_silently: true
                   reactions:
                   - "\U0001F606"
                   - "\U0001F605"
                   state: live
                   newsfeed_assignments:
-                  - newsfeed_id: 28
+                  - newsfeed_id: 53
                     published_at: 1664638214
   "/news/news_items/{id}":
     get:
@@ -8759,12 +8814,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '20'
+                    id: '34'
                     type: news-item
-                    workspace_id: this_is_an_id538_that_should_be_at_least_
+                    workspace_id: this_is_an_id536_that_should_be_at_least_
                     title: We have news
                     body: "<p>Hello there,</p>"
-                    sender_id: 991267200
+                    sender_id: 991267830
                     state: live
                     labels: []
                     cover_image_url:
@@ -8774,11 +8829,11 @@ paths:
                     -
                     -
                     deliver_silently: false
-                    created_at: 1727857269
-                    updated_at: 1727857269
+                    created_at: 1733321376
+                    updated_at: 1733321376
                     newsfeed_assignments:
-                    - newsfeed_id: 30
-                      published_at: 1727857269
+                    - newsfeed_id: 55
+                      published_at: 1733321376
               schema:
                 "$ref": "#/components/schemas/news_item"
         '404':
@@ -8789,7 +8844,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: f68cd910-d16a-498d-9711-1af86e2348a0
+                    request_id: b10cf90d-5ca8-4b66-87c2-6b1ba4cb31ea
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8803,7 +8858,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dd9fe9e2-c88c-42e7-82ce-08ed3d8ee0e0
+                    request_id: cfa42c7a-2630-4571-b1fe-f0ad0a7f5dce
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8834,12 +8889,12 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '23'
+                    id: '37'
                     type: news-item
-                    workspace_id: this_is_an_id544_that_should_be_at_least_
+                    workspace_id: this_is_an_id542_that_should_be_at_least_
                     title: Christmas is here!
                     body: "<p>New gifts in store for the jolly season</p>"
-                    sender_id: 991267208
+                    sender_id: 991267838
                     state: live
                     labels: []
                     cover_image_url:
@@ -8847,8 +8902,8 @@ paths:
                     - "\U0001F61D"
                     - "\U0001F602"
                     deliver_silently: false
-                    created_at: 1727857272
-                    updated_at: 1727857272
+                    created_at: 1733321379
+                    updated_at: 1733321380
                     newsfeed_assignments: []
               schema:
                 "$ref": "#/components/schemas/news_item"
@@ -8860,7 +8915,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: 6d5f0200-a2bd-458f-9812-fe2d09dc59a5
+                    request_id: 9a56a325-7bbe-441a-b016-80c46bcbf1e9
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8874,7 +8929,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6deaed9c-3eeb-4da9-8fe7-990bb8ec2006
+                    request_id: 0b3df46a-71e1-464f-814d-7fd121c07685
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -8891,7 +8946,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991267208
+                  sender_id: 991267838
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -8900,7 +8955,7 @@ paths:
                 value:
                   title: Christmas is here!
                   body: "<p>New gifts in store for the jolly season</p>"
-                  sender_id: 991267211
+                  sender_id: 991267841
                   reactions:
                   - "\U0001F61D"
                   - "\U0001F602"
@@ -8930,7 +8985,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '26'
+                    id: '40'
                     object: news-item
                     deleted: true
               schema:
@@ -8943,7 +8998,7 @@ paths:
                 News Item Not Found:
                   value:
                     type: error.list
-                    request_id: ca1cea72-f3da-442c-a726-18a39cd9f372
+                    request_id: 39260cab-67b5-4966-aff9-b21393f710b8
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -8957,7 +9012,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fb278bb8-7a96-4d09-b032-90fecda2410e
+                    request_id: 8cbde2a6-12f2-49fc-b4c3-08e30c92b35c
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9010,7 +9065,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 0c6d76c8-bdfc-4e54-a6d6-9b8d551a3aba
+                    request_id: 216da798-d0ae-4d19-a026-e3f079f518d6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9043,16 +9098,16 @@ paths:
                       total_pages: 1
                       type: pages
                     data:
-                    - id: '44'
+                    - id: '68'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1727857280
-                      updated_at: 1727857280
-                    - id: '43'
+                      created_at: 1733321389
+                      updated_at: 1733321389
+                    - id: '69'
                       type: newsfeed
                       name: Visitor Feed
-                      created_at: 1727857279
-                      updated_at: 1727857279
+                      created_at: 1733321389
+                      updated_at: 1733321389
                     total_count: 2
               schema:
                 "$ref": "#/components/schemas/paginated_response"
@@ -9064,7 +9119,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 6f2be0c1-27aa-4397-b31a-0169dbe542a3
+                    request_id: d7a4949a-2d34-4f4b-99e5-b9a433badb20
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9098,11 +9153,11 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '47'
+                    id: '72'
                     type: newsfeed
                     name: Visitor Feed
-                    created_at: 1727857281
-                    updated_at: 1727857281
+                    created_at: 1733321391
+                    updated_at: 1733321391
               schema:
                 "$ref": "#/components/schemas/newsfeed"
         '401':
@@ -9113,7 +9168,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 538c5dc6-7fbd-4e7f-b8f9-6a080d761895
+                    request_id: 9d8215c2-920d-4502-be7b-a0a79c192e88
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9147,14 +9202,14 @@ paths:
                 Note found:
                   value:
                     type: note
-                    id: '24'
-                    created_at: 1727166083
+                    id: '37'
+                    created_at: 1732630192
                     contact:
                       type: contact
-                      id: 66fd02839ffbe52cc8b3ab00
+                      id: 675062b0d5eefd6f04e7d14a
                     author:
                       type: admin
-                      id: '991267227'
+                      id: '991267857'
                       name: Ciaran339 Lee
                       email: admin339@email.com
                       away_mode_enabled: false
@@ -9170,7 +9225,7 @@ paths:
                 Note not found:
                   value:
                     type: error.list
-                    request_id: 33d614dd-e3bb-47a0-ac62-c9011db026bf
+                    request_id: f937d596-db3d-41b7-b08f-3aba8ded16c0
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9184,7 +9239,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: eecbbfee-4640-4c7e-8b04-03bed46d7341
+                    request_id: '09d98031-ab1c-48e2-91b9-2056a6080df9'
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9220,16 +9275,16 @@ paths:
                     type: segment.list
                     segments:
                     - type: segment
-                      id: 66fd02869ffbe52cc8b3ab03
+                      id: 675062b3d5eefd6f04e7d14d
                       name: John segment
-                      created_at: 1727857286
-                      updated_at: 1727857286
+                      created_at: 1733321395
+                      updated_at: 1733321395
                       person_type: user
                     - type: segment
-                      id: 66fd02869ffbe52cc8b3ab04
+                      id: 675062b3d5eefd6f04e7d14e
                       name: Jane segment
-                      created_at: 1727857286
-                      updated_at: 1727857286
+                      created_at: 1733321395
+                      updated_at: 1733321395
                       person_type: user
               schema:
                 "$ref": "#/components/schemas/segment_list"
@@ -9241,7 +9296,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: ce940eba-89d4-4ac7-a629-0b9c1b53de37
+                    request_id: ba3280a2-cf00-43bf-8b5b-f0af530a590e
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9275,10 +9330,10 @@ paths:
                 Successful response:
                   value:
                     type: segment
-                    id: 66fd02889ffbe52cc8b3ab07
+                    id: 675062b5d5eefd6f04e7d151
                     name: John segment
-                    created_at: 1727857288
-                    updated_at: 1727857288
+                    created_at: 1733321397
+                    updated_at: 1733321397
                     person_type: user
               schema:
                 "$ref": "#/components/schemas/segment"
@@ -9290,7 +9345,7 @@ paths:
                 Segment not found:
                   value:
                     type: error.list
-                    request_id: 07e00389-c67c-4cc7-ad63-6cdd2c3c6460
+                    request_id: 0f7b6a64-4da1-4ed5-908a-3cb689562668
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9304,7 +9359,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 77dcef51-06dd-4525-bbf8-6044f11b08cc
+                    request_id: e03816d0-bf07-48e5-9004-9a4e22d15de3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9334,7 +9389,7 @@ paths:
                     type: list
                     data:
                     - type: subscription
-                      id: '91'
+                      id: '137'
                       state: live
                       consent_type: opt_out
                       default_translation:
@@ -9357,7 +9412,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7c62cfef-e04c-44bc-a19f-07941561885f
+                    request_id: 3d04b760-4fa7-433e-935b-d14ccc89e0a6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9387,7 +9442,7 @@ paths:
               examples:
                 successful:
                   value:
-                    url: http://via.intercom.io/msgr/24f320ac-246f-4386-a94e-f04821314dc1
+                    url: http://via.intercom.io/msgr/003bff75-74ca-478f-bd2c-93b7a5ac912b
                     type: phone_call_redirect
               schema:
                 "$ref": "#/components/schemas/phone_switch"
@@ -9420,7 +9475,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 937454ce-d9af-4b74-8763-8cfe11dce51c
+                    request_id: 9f4cdf45-78e2-41d1-93c8-d6811080f06b
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9483,7 +9538,7 @@ paths:
                     type: list
                     data:
                     - type: tag
-                      id: '69'
+                      id: '115'
                       name: Manual tag 1
               schema:
                 "$ref": "#/components/schemas/tag_list"
@@ -9495,7 +9550,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 728e6de8-83df-4466-a83f-0dbd68d87b12
+                    request_id: f14ccee6-e684-44c6-9a83-7a779fad43f0
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9534,7 +9589,7 @@ paths:
                 Action successful:
                   value:
                     type: tag
-                    id: '72'
+                    id: '118'
                     name: test
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9546,7 +9601,7 @@ paths:
                 Invalid parameters:
                   value:
                     type: error.list
-                    request_id: 47e1978a-ce1c-40f2-91c6-dc7df400667a
+                    request_id: c36d66fb-4a03-4e45-be54-e74715e5ddf4
                     errors:
                     - code: parameter_invalid
                       message: invalid tag parameters
@@ -9560,14 +9615,14 @@ paths:
                 Company not found:
                   value:
                     type: error.list
-                    request_id: c09821b3-0d4c-48cd-b098-bec827484232
+                    request_id: b3ee584c-cb7c-4579-8685-ee8534435b8d
                     errors:
                     - code: company_not_found
                       message: Company Not Found
                 User  not found:
                   value:
                     type: error.list
-                    request_id: c2658060-aa56-47ef-a501-c69a480dc7d4
+                    request_id: 2f4f4168-6882-4c0f-8a33-57e0b611e8e5
                     errors:
                     - code: not_found
                       message: User Not Found
@@ -9581,7 +9636,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b221bfd5-2423-4365-892b-c8766ad97701
+                    request_id: a3d21165-6291-4e9c-9128-bf0f9ff0c30d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9647,7 +9702,7 @@ paths:
                 Tag found:
                   value:
                     type: tag
-                    id: '80'
+                    id: '126'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -9659,7 +9714,7 @@ paths:
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: d016c66d-e66c-4574-9d6e-d5523444d8a2
+                    request_id: c9a8c1b1-2c64-4573-ac3e-177801e0539b
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9673,7 +9728,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 75ecbc66-a998-4d5d-9450-44fc56846a54
+                    request_id: b8227539-a035-406f-a356-2fe4a4830b3a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9709,7 +9764,7 @@ paths:
                 Resource not found:
                   value:
                     type: error.list
-                    request_id: 5b4fe9e5-b5bb-4249-ae2b-0d8d87cf0490
+                    request_id: 287419ef-a935-4ba8-bace-0db9c7bf0f77
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -9723,7 +9778,7 @@ paths:
                 Tag has dependent objects:
                   value:
                     type: error.list
-                    request_id: 05547561-8902-4734-a1d1-67e9019d1847
+                    request_id: 210de013-e17f-4019-989f-5210294a6164
                     errors:
                     - code: tag_has_dependent_objects
                       message: 'Unable to delete Tag with dependent objects. Segments:
@@ -9738,7 +9793,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 89c8f6cd-9ee0-403b-b42e-605022cbb921
+                    request_id: 529e9949-03f9-43bb-a6e9-c70973369058
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9776,7 +9831,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 55d69964-d923-4702-ae43-dd82b459469c
+                    request_id: 6faf4c39-61bc-4510-b5f3-65f2b874b624
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9811,7 +9866,7 @@ paths:
                 successful:
                   value:
                     type: team
-                    id: '991267265'
+                    id: '991267895'
                     name: team 1
                     admin_ids: []
               schema:
@@ -9824,7 +9879,7 @@ paths:
                 Team not found:
                   value:
                     type: error.list
-                    request_id: 37abcb7a-7e0f-4c09-a1a6-5d27bc16708c
+                    request_id: 73d2ca2a-aa5e-4875-bed5-97fadccccf2b
                     errors:
                     - code: team_not_found
                       message: Team not found
@@ -9838,7 +9893,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: effb9bb2-e20b-444c-810a-ef8e3840ee6c
+                    request_id: 75bfa210-0f09-4af0-8b64-b9fd26ebd4f6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -9867,7 +9922,7 @@ paths:
                     type: list
                     data:
                     - type: ticket_state
-                      id: '5413'
+                      id: '8373'
                       category: submitted
                       internal_label: Submitted
                       external_label: Submitted
@@ -9875,7 +9930,7 @@ paths:
                         type: list
                         data:
                         - type: ticket_type
-                          id: '51'
+                          id: '99'
                           name: my-ticket-type-3
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9883,7 +9938,7 @@ paths:
                           is_internal: false
                           category: Back-office
                         - type: ticket_type
-                          id: '52'
+                          id: '100'
                           name: my-ticket-type-4
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9891,7 +9946,7 @@ paths:
                           is_internal: false
                           category: Back-office
                         - type: ticket_type
-                          id: '54'
+                          id: '102'
                           name: my-ticket-type-6
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9900,7 +9955,7 @@ paths:
                           category: Back-office
                       archived: false
                     - type: ticket_state
-                      id: '5414'
+                      id: '8374'
                       category: in_progress
                       internal_label: In progress
                       external_label: In progress
@@ -9908,7 +9963,7 @@ paths:
                         type: list
                         data:
                         - type: ticket_type
-                          id: '51'
+                          id: '99'
                           name: my-ticket-type-3
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9916,7 +9971,7 @@ paths:
                           is_internal: false
                           category: Back-office
                         - type: ticket_type
-                          id: '52'
+                          id: '100'
                           name: my-ticket-type-4
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9924,7 +9979,7 @@ paths:
                           is_internal: false
                           category: Back-office
                         - type: ticket_type
-                          id: '54'
+                          id: '102'
                           name: my-ticket-type-6
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9933,7 +9988,7 @@ paths:
                           category: Back-office
                       archived: false
                     - type: ticket_state
-                      id: '5415'
+                      id: '8375'
                       category: waiting_on_customer
                       internal_label: Waiting on customer
                       external_label: Waiting on you
@@ -9941,7 +9996,7 @@ paths:
                         type: list
                         data:
                         - type: ticket_type
-                          id: '51'
+                          id: '99'
                           name: my-ticket-type-3
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9949,7 +10004,7 @@ paths:
                           is_internal: false
                           category: Back-office
                         - type: ticket_type
-                          id: '52'
+                          id: '100'
                           name: my-ticket-type-4
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9957,7 +10012,7 @@ paths:
                           is_internal: false
                           category: Back-office
                         - type: ticket_type
-                          id: '54'
+                          id: '102'
                           name: my-ticket-type-6
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9966,7 +10021,7 @@ paths:
                           category: Back-office
                       archived: false
                     - type: ticket_state
-                      id: '5416'
+                      id: '8376'
                       category: resolved
                       internal_label: Resolved
                       external_label: Resolved
@@ -9974,7 +10029,7 @@ paths:
                         type: list
                         data:
                         - type: ticket_type
-                          id: '51'
+                          id: '99'
                           name: my-ticket-type-3
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9982,7 +10037,7 @@ paths:
                           is_internal: false
                           category: Back-office
                         - type: ticket_type
-                          id: '52'
+                          id: '100'
                           name: my-ticket-type-4
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9990,7 +10045,7 @@ paths:
                           is_internal: false
                           category: Back-office
                         - type: ticket_type
-                          id: '54'
+                          id: '102'
                           name: my-ticket-type-6
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -9999,7 +10054,7 @@ paths:
                           category: Back-office
                       archived: false
                     - type: ticket_state
-                      id: '5417'
+                      id: '8377'
                       category: submitted
                       internal_label: Admin label 1
                       external_label: User label
@@ -10007,7 +10062,7 @@ paths:
                         type: list
                         data:
                         - type: ticket_type
-                          id: '51'
+                          id: '99'
                           name: my-ticket-type-3
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -10015,7 +10070,7 @@ paths:
                           is_internal: false
                           category: Back-office
                         - type: ticket_type
-                          id: '52'
+                          id: '100'
                           name: my-ticket-type-4
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -10024,7 +10079,7 @@ paths:
                           category: Back-office
                       archived: false
                     - type: ticket_state
-                      id: '5418'
+                      id: '8378'
                       category: submitted
                       internal_label: Admin label 2
                       external_label: User label
@@ -10032,7 +10087,7 @@ paths:
                         type: list
                         data:
                         - type: ticket_type
-                          id: '54'
+                          id: '102'
                           name: my-ticket-type-6
                           description: my ticket type description is awesome.
                           icon: "\U0001F981"
@@ -10050,7 +10105,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: dbd44320-b1c6-4a0f-a798-2b0f61a7716d
+                    request_id: f1a0d247-5a5b-4a62-a042-ef6bade08a04
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10083,8 +10138,8 @@ paths:
                 Ticket Type Attribute created:
                   value:
                     type: ticket_type_attribute
-                    id: '106'
-                    workspace_id: this_is_an_id640_that_should_be_at_least_
+                    id: '191'
+                    workspace_id: this_is_an_id638_that_should_be_at_least_
                     name: Attribute Title
                     description: Attribute Description
                     data_type: string
@@ -10096,10 +10151,10 @@ paths:
                     visible_on_create: true
                     visible_to_contacts: true
                     default: false
-                    ticket_type_id: 59
+                    ticket_type_id: 107
                     archived: false
-                    created_at: 1727857320
-                    updated_at: 1727857320
+                    created_at: 1733321430
+                    updated_at: 1733321430
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -10110,7 +10165,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 94f6ab96-e21f-408c-a8b3-11737aa7ce3c
+                    request_id: 91d28153-36b2-40fa-9fd4-4284c9146270
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10163,8 +10218,8 @@ paths:
                 Ticket Type Attribute updated:
                   value:
                     type: ticket_type_attribute
-                    id: '111'
-                    workspace_id: this_is_an_id644_that_should_be_at_least_
+                    id: '196'
+                    workspace_id: this_is_an_id642_that_should_be_at_least_
                     name: name
                     description: New Attribute Description
                     data_type: string
@@ -10174,10 +10229,10 @@ paths:
                     visible_on_create: false
                     visible_to_contacts: false
                     default: false
-                    ticket_type_id: 61
+                    ticket_type_id: 109
                     archived: false
-                    created_at: 1727857322
-                    updated_at: 1727857322
+                    created_at: 1733321432
+                    updated_at: 1733321432
               schema:
                 "$ref": "#/components/schemas/ticket_type_attribute"
         '401':
@@ -10188,7 +10243,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 7fb51e03-1418-41c8-8439-0a70b46f8d2b
+                    request_id: d4a58e18-ac35-4bae-9ac9-02fee6028493
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10227,21 +10282,21 @@ paths:
                     type: list
                     data:
                     - type: ticket_type
-                      id: '63'
+                      id: '111'
                       name: Bug Report
                       description: Bug Report Template
                       icon: "\U0001F39F️"
-                      workspace_id: this_is_an_id648_that_should_be_at_least_
+                      workspace_id: this_is_an_id646_that_should_be_at_least_
                       archived: false
-                      created_at: 1727857323
-                      updated_at: 1727857323
+                      created_at: 1733321434
+                      updated_at: 1733321434
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '114'
-                          workspace_id: this_is_an_id648_that_should_be_at_least_
+                          id: '199'
+                          workspace_id: this_is_an_id646_that_should_be_at_least_
                           name: _default_title_
                           description: ''
                           data_type: string
@@ -10253,13 +10308,13 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 63
+                          ticket_type_id: 111
                           archived: false
-                          created_at: 1727857323
-                          updated_at: 1727857323
+                          created_at: 1733321434
+                          updated_at: 1733321434
                         - type: ticket_type_attribute
-                          id: '116'
-                          workspace_id: this_is_an_id648_that_should_be_at_least_
+                          id: '201'
+                          workspace_id: this_is_an_id646_that_should_be_at_least_
                           name: name
                           description: description
                           data_type: string
@@ -10270,13 +10325,13 @@ paths:
                           visible_on_create: false
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 63
+                          ticket_type_id: 111
                           archived: false
-                          created_at: 1727857324
-                          updated_at: 1727857324
+                          created_at: 1733321434
+                          updated_at: 1733321434
                         - type: ticket_type_attribute
-                          id: '115'
-                          workspace_id: this_is_an_id648_that_should_be_at_least_
+                          id: '200'
+                          workspace_id: this_is_an_id646_that_should_be_at_least_
                           name: _default_description_
                           description: ''
                           data_type: string
@@ -10288,31 +10343,31 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: true
                           default: true
-                          ticket_type_id: 63
+                          ticket_type_id: 111
                           archived: false
-                          created_at: 1727857323
-                          updated_at: 1727857323
+                          created_at: 1733321434
+                          updated_at: 1733321434
                       category: Customer
                       ticket_states:
                         type: list
                         data:
                         - type: ticket_state
-                          id: '5465'
+                          id: '8425'
                           category: submitted
                           internal_label: Submitted
                           external_label: Submitted
                         - type: ticket_state
-                          id: '5466'
+                          id: '8426'
                           category: in_progress
                           internal_label: In progress
                           external_label: In progress
                         - type: ticket_state
-                          id: '5467'
+                          id: '8427'
                           category: waiting_on_customer
                           internal_label: Waiting on customer
                           external_label: Waiting on you
                         - type: ticket_state
-                          id: '5468'
+                          id: '8428'
                           category: resolved
                           internal_label: Resolved
                           external_label: Resolved
@@ -10326,7 +10381,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: c8086fd8-b402-4c44-a87e-11fbea550dea
+                    request_id: 225ebbcb-0a23-4fed-8a6b-db3ff26265bb
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10355,21 +10410,21 @@ paths:
                 Ticket type created:
                   value:
                     type: ticket_type
-                    id: '66'
+                    id: '114'
                     name: Customer Issue
                     description: Customer Report Template
                     icon: "\U0001F39F️"
-                    workspace_id: this_is_an_id652_that_should_be_at_least_
+                    workspace_id: this_is_an_id650_that_should_be_at_least_
                     archived: false
-                    created_at: 1727857326
-                    updated_at: 1727857326
+                    created_at: 1733321436
+                    updated_at: 1733321436
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '123'
-                        workspace_id: this_is_an_id652_that_should_be_at_least_
+                        id: '208'
+                        workspace_id: this_is_an_id650_that_should_be_at_least_
                         name: _default_title_
                         description: ''
                         data_type: string
@@ -10381,13 +10436,13 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 66
+                        ticket_type_id: 114
                         archived: false
-                        created_at: 1727857326
-                        updated_at: 1727857326
+                        created_at: 1733321436
+                        updated_at: 1733321436
                       - type: ticket_type_attribute
-                        id: '124'
-                        workspace_id: this_is_an_id652_that_should_be_at_least_
+                        id: '209'
+                        workspace_id: this_is_an_id650_that_should_be_at_least_
                         name: _default_description_
                         description: ''
                         data_type: string
@@ -10399,31 +10454,31 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 66
+                        ticket_type_id: 114
                         archived: false
-                        created_at: 1727857326
-                        updated_at: 1727857326
+                        created_at: 1733321436
+                        updated_at: 1733321436
                     category: Customer
                     ticket_states:
                       type: list
                       data:
                       - type: ticket_state
-                        id: '5481'
+                        id: '8441'
                         category: submitted
                         internal_label: Submitted
                         external_label: Submitted
                       - type: ticket_state
-                        id: '5482'
+                        id: '8442'
                         category: in_progress
                         internal_label: In progress
                         external_label: In progress
                       - type: ticket_state
-                        id: '5483'
+                        id: '8443'
                         category: waiting_on_customer
                         internal_label: Waiting on customer
                         external_label: Waiting on you
                       - type: ticket_state
-                        id: '5484'
+                        id: '8444'
                         category: resolved
                         internal_label: Resolved
                         external_label: Resolved
@@ -10437,7 +10492,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b83bb13d-ae98-4163-91c3-b067c573bbe2
+                    request_id: a6b3bf86-488f-4d38-b239-d50ca536a17d
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10483,21 +10538,21 @@ paths:
                 Ticket type found:
                   value:
                     type: ticket_type
-                    id: '68'
+                    id: '116'
                     name: Bug Report
                     description: Bug Report Template
                     icon: "\U0001F39F️"
-                    workspace_id: this_is_an_id656_that_should_be_at_least_
+                    workspace_id: this_is_an_id654_that_should_be_at_least_
                     archived: false
-                    created_at: 1727857327
-                    updated_at: 1727857327
+                    created_at: 1733321438
+                    updated_at: 1733321438
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '128'
-                        workspace_id: this_is_an_id656_that_should_be_at_least_
+                        id: '213'
+                        workspace_id: this_is_an_id654_that_should_be_at_least_
                         name: _default_title_
                         description: ''
                         data_type: string
@@ -10509,13 +10564,13 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 68
+                        ticket_type_id: 116
                         archived: false
-                        created_at: 1727857327
-                        updated_at: 1727857327
+                        created_at: 1733321438
+                        updated_at: 1733321438
                       - type: ticket_type_attribute
-                        id: '130'
-                        workspace_id: this_is_an_id656_that_should_be_at_least_
+                        id: '215'
+                        workspace_id: this_is_an_id654_that_should_be_at_least_
                         name: name
                         description: description
                         data_type: string
@@ -10526,13 +10581,13 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 68
+                        ticket_type_id: 116
                         archived: false
-                        created_at: 1727857328
-                        updated_at: 1727857328
+                        created_at: 1733321438
+                        updated_at: 1733321438
                       - type: ticket_type_attribute
-                        id: '129'
-                        workspace_id: this_is_an_id656_that_should_be_at_least_
+                        id: '214'
+                        workspace_id: this_is_an_id654_that_should_be_at_least_
                         name: _default_description_
                         description: ''
                         data_type: string
@@ -10544,31 +10599,31 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 68
+                        ticket_type_id: 116
                         archived: false
-                        created_at: 1727857327
-                        updated_at: 1727857327
+                        created_at: 1733321438
+                        updated_at: 1733321438
                     category: Customer
                     ticket_states:
                       type: list
                       data:
                       - type: ticket_state
-                        id: '5497'
+                        id: '8457'
                         category: submitted
                         internal_label: Submitted
                         external_label: Submitted
                       - type: ticket_state
-                        id: '5498'
+                        id: '8458'
                         category: in_progress
                         internal_label: In progress
                         external_label: In progress
                       - type: ticket_state
-                        id: '5499'
+                        id: '8459'
                         category: waiting_on_customer
                         internal_label: Waiting on customer
                         external_label: Waiting on you
                       - type: ticket_state
-                        id: '5500'
+                        id: '8460'
                         category: resolved
                         internal_label: Resolved
                         external_label: Resolved
@@ -10582,7 +10637,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: fcd072d9-9d08-4ec8-8e0e-1b539b66bd02
+                    request_id: 4959f0f1-4132-4184-a359-197973ea0f7a
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10615,21 +10670,21 @@ paths:
                 Ticket type updated:
                   value:
                     type: ticket_type
-                    id: '70'
+                    id: '118'
                     name: Bug Report 2
                     description: Bug Report Template
                     icon: "\U0001F39F️"
-                    workspace_id: this_is_an_id660_that_should_be_at_least_
+                    workspace_id: this_is_an_id658_that_should_be_at_least_
                     archived: false
-                    created_at: 1727857329
-                    updated_at: 1727857330
+                    created_at: 1733321440
+                    updated_at: 1733321441
                     is_internal: false
                     ticket_type_attributes:
                       type: list
                       data:
                       - type: ticket_type_attribute
-                        id: '134'
-                        workspace_id: this_is_an_id660_that_should_be_at_least_
+                        id: '219'
+                        workspace_id: this_is_an_id658_that_should_be_at_least_
                         name: _default_title_
                         description: ''
                         data_type: string
@@ -10641,13 +10696,13 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 70
+                        ticket_type_id: 118
                         archived: false
-                        created_at: 1727857329
-                        updated_at: 1727857329
+                        created_at: 1733321440
+                        updated_at: 1733321440
                       - type: ticket_type_attribute
-                        id: '136'
-                        workspace_id: this_is_an_id660_that_should_be_at_least_
+                        id: '221'
+                        workspace_id: this_is_an_id658_that_should_be_at_least_
                         name: name
                         description: description
                         data_type: string
@@ -10658,13 +10713,13 @@ paths:
                         visible_on_create: false
                         visible_to_contacts: false
                         default: false
-                        ticket_type_id: 70
+                        ticket_type_id: 118
                         archived: false
-                        created_at: 1727857329
-                        updated_at: 1727857329
+                        created_at: 1733321440
+                        updated_at: 1733321440
                       - type: ticket_type_attribute
-                        id: '135'
-                        workspace_id: this_is_an_id660_that_should_be_at_least_
+                        id: '220'
+                        workspace_id: this_is_an_id658_that_should_be_at_least_
                         name: _default_description_
                         description: ''
                         data_type: string
@@ -10676,31 +10731,31 @@ paths:
                         visible_on_create: true
                         visible_to_contacts: true
                         default: true
-                        ticket_type_id: 70
+                        ticket_type_id: 118
                         archived: false
-                        created_at: 1727857329
-                        updated_at: 1727857329
+                        created_at: 1733321440
+                        updated_at: 1733321440
                     category: Customer
                     ticket_states:
                       type: list
                       data:
                       - type: ticket_state
-                        id: '5513'
+                        id: '8473'
                         category: submitted
                         internal_label: Submitted
                         external_label: Submitted
                       - type: ticket_state
-                        id: '5514'
+                        id: '8474'
                         category: in_progress
                         internal_label: In progress
                         external_label: In progress
                       - type: ticket_state
-                        id: '5515'
+                        id: '8475'
                         category: waiting_on_customer
                         internal_label: Waiting on customer
                         external_label: Waiting on you
                       - type: ticket_state
-                        id: '5516'
+                        id: '8476'
                         category: resolved
                         internal_label: Resolved
                         external_label: Resolved
@@ -10714,7 +10769,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 8fb6d693-a5a9-4cea-bf06-361fcbf8e3b9
+                    request_id: a809e462-a1fb-4cef-af5d-a1d1a391d374
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10760,7 +10815,7 @@ paths:
                 User reply:
                   value:
                     type: error.list
-                    request_id: 97e531a7-65bf-4cb3-a108-ea68c7ec4f9a
+                    request_id: bee0a6d8-b709-4106-a0f1-206cf26be98d
                     errors:
                     - code: parameter_mismatch
                       message: User replies are not allowed on Backoffice tickets
@@ -10774,7 +10829,7 @@ paths:
                 Admin note reply:
                   value:
                     type: ticket_part
-                    id: '92'
+                    id: '163'
                     part_type: note
                     body: |-
                       <h2>An Unordered HTML List</h2>
@@ -10789,10 +10844,10 @@ paths:
                       <li>Tea</li>
                       <li>Milk</li>
                       </ol>
-                    created_at: 1727857342
-                    updated_at: 1727857342
+                    created_at: 1733321451
+                    updated_at: 1733321451
                     author:
-                      id: '991267306'
+                      id: '991267936'
                       type: admin
                       name: Ciaran412 Lee
                       email: admin412@email.com
@@ -10801,12 +10856,12 @@ paths:
                 Admin quick_reply reply:
                   value:
                     type: ticket_part
-                    id: '94'
+                    id: '165'
                     part_type: quick_reply
-                    created_at: 1727857348
-                    updated_at: 1727857348
+                    created_at: 1733321456
+                    updated_at: 1733321456
                     author:
-                      id: '991267311'
+                      id: '991267941'
                       type: admin
                       name: Ciaran416 Lee
                       email: admin416@email.com
@@ -10822,7 +10877,7 @@ paths:
                 Not found:
                   value:
                     type: error.list
-                    request_id: a0ee157b-43d6-4a68-902b-e32c13214566
+                    request_id: 2853cd38-6f73-4b74-922e-0b1e272046b0
                     errors:
                     - code: not_found
                       message: Resource Not Found
@@ -10836,7 +10891,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 1613ae6b-4f02-4134-a9a2-3087a5430fd0
+                    request_id: b70c2d40-d867-42b5-8312-ee4164f36817
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10861,14 +10916,14 @@ paths:
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 66fd02b89ffbe52cc8b3ab2a
+                  intercom_user_id: 675062e6d5eefd6f04e7d174
                   body: Thanks again :)
               admin_note_reply:
                 summary: Admin note reply
                 value:
                   message_type: note
                   type: admin
-                  admin_id: 991267306
+                  admin_id: 991267936
                   body: "<html> <body>  <h2>An Unordered HTML List</h2>  <ul>   <li>Coffee</li>
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
@@ -10878,18 +10933,18 @@ paths:
                 value:
                   message_type: quick_reply
                   type: admin
-                  admin_id: 991267311
+                  admin_id: 991267941
                   reply_options:
                   - text: 'Yes'
-                    uuid: 992196aa-7c1e-4efa-b010-898e540e31e9
+                    uuid: ffb3b962-988a-47ec-817e-9eb47e12ed7d
                   - text: 'No'
-                    uuid: a2840bb0-6acc-42e5-9d14-f561ae7015f5
+                    uuid: 7fd069fe-6266-41f5-8bd5-fff044df3ea6
               not_found:
                 summary: Not found
                 value:
                   message_type: comment
                   type: user
-                  intercom_user_id: 66fd02c69ffbe52cc8b3ab2d
+                  intercom_user_id: 675062f1d5eefd6f04e7d177
                   body: Thanks again :)
   "/tickets/{ticket_id}/tags":
     post:
@@ -10921,7 +10976,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '88'
+                    id: '134'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -10933,7 +10988,7 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: 043502bf-c192-4bf5-bb44-0bf721135e17
+                    request_id: 5dbbbb0e-c555-4702-85cd-8353c5124b7f
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
@@ -10947,7 +11002,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 35f4e126-b7db-40a5-8f83-c080bac87d9e
+                    request_id: 895d9a3c-e4c5-403e-b840-222fda622814
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -10976,13 +11031,13 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 88
-                  admin_id: 991267321
+                  id: 134
+                  admin_id: 991267951
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  id: 89
-                  admin_id: 991267326
+                  id: 135
+                  admin_id: 991267956
   "/tickets/{ticket_id}/tags/{id}":
     delete:
       summary: Remove tag from a ticket
@@ -11020,7 +11075,7 @@ paths:
                 successful:
                   value:
                     type: tag
-                    id: '91'
+                    id: '137'
                     name: Manual tag
               schema:
                 "$ref": "#/components/schemas/tag"
@@ -11032,14 +11087,14 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: ddcaec90-16e4-4fda-8e90-9425950fbf69
+                    request_id: 0df5994c-ec1b-4f00-b5e4-ebd52c991ec8
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
                 Tag not found:
                   value:
                     type: error.list
-                    request_id: bb38ed23-9af4-4b6e-a7a8-5af78f1e79d8
+                    request_id: fd0667f1-d9b0-48e6-9cce-b318c1674bec
                     errors:
                     - code: tag_not_found
                       message: Tag not found
@@ -11053,7 +11108,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4363447e-e266-4190-a81e-ccb30b700d2c
+                    request_id: 94852eb5-80d4-4fa6-925f-e23538dabf57
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11076,15 +11131,15 @@ paths:
               successful:
                 summary: successful
                 value:
-                  admin_id: 991267336
+                  admin_id: 991267966
               ticket_not_found:
                 summary: Ticket not found
                 value:
-                  admin_id: 991267341
+                  admin_id: 991267971
               tag_not_found:
                 summary: Tag not found
                 value:
-                  admin_id: 991267346
+                  admin_id: 991267976
   "/tickets":
     post:
       summary: Create a ticket
@@ -11106,34 +11161,34 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '325'
-                    ticket_id: '31'
+                    id: '491'
+                    ticket_id: '50'
                     ticket_attributes:
                       _default_title_: example
                       _default_description_: there is a problem
                     ticket_state:
                       type: ticket_state
-                      id: '5625'
+                      id: '8585'
                       category: submitted
                       internal_label: Submitted
                       external_label: Submitted
                     ticket_type:
                       type: ticket_type
-                      id: '84'
+                      id: '132'
                       name: my-ticket-type-23
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
-                      workspace_id: this_is_an_id688_that_should_be_at_least_
+                      workspace_id: this_is_an_id686_that_should_be_at_least_
                       archived: false
-                      created_at: 1727857399
-                      updated_at: 1727857399
+                      created_at: 1733321504
+                      updated_at: 1733321504
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '145'
-                          workspace_id: this_is_an_id688_that_should_be_at_least_
+                          id: '230'
+                          workspace_id: this_is_an_id686_that_should_be_at_least_
                           name: _default_title_
                           description: ola
                           data_type: string
@@ -11144,13 +11199,13 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 84
+                          ticket_type_id: 132
                           archived: false
-                          created_at: 1727857399
-                          updated_at: 1727857399
+                          created_at: 1733321504
+                          updated_at: 1733321504
                         - type: ticket_type_attribute
-                          id: '146'
-                          workspace_id: this_is_an_id688_that_should_be_at_least_
+                          id: '231'
+                          workspace_id: this_is_an_id686_that_should_be_at_least_
                           name: _default_description_
                           description: ola
                           data_type: string
@@ -11161,36 +11216,36 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 84
+                          ticket_type_id: 132
                           archived: false
-                          created_at: 1727857399
-                          updated_at: 1727857399
+                          created_at: 1733321504
+                          updated_at: 1733321504
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd02f79ffbe52cc8b3ab35
+                        id: 67506320d5eefd6f04e7d17f
                         external_id: '70'
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1727857400
-                    updated_at: 1727857401
+                    created_at: 1733321505
+                    updated_at: 1733321506
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '109'
+                        id: '182'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1727857401
-                        updated_at: 1727857401
+                        created_at: 1733321506
+                        updated_at: 1733321506
                         author:
-                          id: '991267362'
+                          id: '991267992'
                           type: bot
-                          name: Operator
-                          email: operator+this_is_an_id688_that_should_be_at_least_@intercom.io
+                          name: Fin
+                          email: operator+this_is_an_id686_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       total_count: 1
@@ -11212,7 +11267,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: '09018f45-6f49-485d-ada1-25a37a0e27a9'
+                    request_id: 8929eb91-c269-4620-890f-be7829c1d060
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11233,9 +11288,9 @@ paths:
               successful_response:
                 summary: Successful response
                 value:
-                  ticket_type_id: 84
+                  ticket_type_id: 132
                   contacts:
-                  - id: 66fd02f79ffbe52cc8b3ab35
+                  - id: 67506320d5eefd6f04e7d17f
                   ticket_attributes:
                     _default_title_: example
                     _default_description_: there is a problem
@@ -11266,34 +11321,34 @@ paths:
                 Successful response:
                   value:
                     type: ticket
-                    id: '326'
-                    ticket_id: '32'
+                    id: '492'
+                    ticket_id: '51'
                     ticket_attributes:
                       _default_title_: example
                       _default_description_: there is a problem
                     ticket_state:
                       type: ticket_state
-                      id: '5642'
+                      id: '8602'
                       category: in_progress
                       internal_label: In progress
                       external_label: In progress
                     ticket_type:
                       type: ticket_type
-                      id: '86'
+                      id: '134'
                       name: my-ticket-type-25
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
-                      workspace_id: this_is_an_id692_that_should_be_at_least_
+                      workspace_id: this_is_an_id690_that_should_be_at_least_
                       archived: false
-                      created_at: 1727857403
-                      updated_at: 1727857403
+                      created_at: 1733321509
+                      updated_at: 1733321509
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '149'
-                          workspace_id: this_is_an_id692_that_should_be_at_least_
+                          id: '234'
+                          workspace_id: this_is_an_id690_that_should_be_at_least_
                           name: _default_title_
                           description: ola
                           data_type: string
@@ -11304,13 +11359,13 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 86
+                          ticket_type_id: 134
                           archived: false
-                          created_at: 1727857403
-                          updated_at: 1727857403
+                          created_at: 1733321509
+                          updated_at: 1733321509
                         - type: ticket_type_attribute
-                          id: '150'
-                          workspace_id: this_is_an_id692_that_should_be_at_least_
+                          id: '235'
+                          workspace_id: this_is_an_id690_that_should_be_at_least_
                           name: _default_description_
                           description: ola
                           data_type: string
@@ -11321,106 +11376,106 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 86
+                          ticket_type_id: 134
                           archived: false
-                          created_at: 1727857404
-                          updated_at: 1727857404
+                          created_at: 1733321509
+                          updated_at: 1733321509
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd02fc9ffbe52cc8b3ab36
-                        external_id: 5541ee93-e8b8-4b09-b084-1e0b30d7e06b
-                    admin_assignee_id: '991267376'
+                        id: 67506325d5eefd6f04e7d180
+                        external_id: 73484aee-e522-4c2f-afc6-2ca3c667821c
+                    admin_assignee_id: '991268006'
                     team_assignee_id: '0'
-                    created_at: 1727857404
-                    updated_at: 1727857410
+                    created_at: 1733321510
+                    updated_at: 1733321514
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '110'
+                        id: '183'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1727857405
-                        updated_at: 1727857405
+                        created_at: 1733321511
+                        updated_at: 1733321511
                         author:
-                          id: '991267374'
+                          id: '991268004'
                           type: admin
                           name: Ciaran470 Lee
                           email: admin470@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '111'
+                        id: '184'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1727857408
-                        updated_at: 1727857408
+                        created_at: 1733321513
+                        updated_at: 1733321513
                         author:
-                          id: '991267375'
+                          id: '991268005'
                           type: bot
-                          name: Operator
-                          email: operator+this_is_an_id692_that_should_be_at_least_@intercom.io
+                          name: Fin
+                          email: operator+this_is_an_id690_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '112'
+                        id: '185'
                         part_type: ticket_attribute_updated_by_admin
-                        created_at: 1727857408
-                        updated_at: 1727857408
+                        created_at: 1733321513
+                        updated_at: 1733321513
                         author:
-                          id: '991267375'
+                          id: '991268005'
                           type: bot
-                          name: Operator
-                          email: operator+this_is_an_id692_that_should_be_at_least_@intercom.io
+                          name: Fin
+                          email: operator+this_is_an_id690_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '113'
+                        id: '186'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: in_progress
                         previous_ticket_state: submitted
-                        created_at: 1727857408
-                        updated_at: 1727857408
+                        created_at: 1733321513
+                        updated_at: 1733321513
                         author:
-                          id: '991267375'
+                          id: '991268005'
                           type: bot
-                          name: Operator
-                          email: operator+this_is_an_id692_that_should_be_at_least_@intercom.io
+                          name: Fin
+                          email: operator+this_is_an_id690_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '114'
+                        id: '187'
                         part_type: assignment
-                        created_at: 1727857409
-                        updated_at: 1727857409
+                        created_at: 1733321514
+                        updated_at: 1733321514
                         assigned_to:
                           type: admin
-                          id: '991267376'
+                          id: '991268006'
                         author:
-                          id: '991267374'
+                          id: '991268004'
                           type: admin
                           name: Ciaran470 Lee
                           email: admin470@email.com
                         attachments: []
                         redacted: false
                       - type: ticket_part
-                        id: '115'
+                        id: '188'
                         part_type: snoozed
-                        created_at: 1727857410
-                        updated_at: 1727857410
+                        created_at: 1733321514
+                        updated_at: 1733321514
                         author:
-                          id: '991267375'
+                          id: '991268005'
                           type: bot
-                          name: Operator
-                          email: operator+this_is_an_id692_that_should_be_at_least_@intercom.io
+                          name: Fin
+                          email: operator+this_is_an_id690_that_should_be_at_least_@intercom.io
                         attachments: []
                         redacted: false
                       total_count: 6
                     open: true
-                    snoozed_until: 1727971200
+                    snoozed_until: 1733418000
                     linked_objects:
                       type: list
                       data: []
@@ -11438,14 +11493,14 @@ paths:
                 Admin not found:
                   value:
                     type: error.list
-                    request_id: da26b7c9-6e36-4c8b-b9bd-4e49ba0c7188
+                    request_id: 72497472-38da-41e4-825b-443fc8701b74
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
                 Assignee not found:
                   value:
                     type: error.list
-                    request_id: 1da0e75f-fa8a-4510-bdb9-26ce477d205f
+                    request_id: 6920db84-74f0-41f7-a442-14e339fe6015
                     errors:
                     - code: assignee_not_found
                       message: Assignee not found
@@ -11458,7 +11513,7 @@ paths:
                 Ticket state id is not valid or is not associated with the ticket type.:
                   value:
                     type: error.list
-                    request_id: e182c683-6225-46af-9240-89f82130cd45
+                    request_id: 7ef68b67-a957-4360-8f7d-5041d22cfd1b
                     errors:
                     - code: ticket_state_id_invalid
                       message: Ticket state id is not valid or is not associated with
@@ -11471,7 +11526,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 4e23008e-87a3-4702-9917-517c9fd6da1f
+                    request_id: 81453c47-3ac5-4acc-9f76-a5c9c40e6ffd
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11490,11 +11545,11 @@ paths:
                     _default_title_: example
                     _default_description_: there is a problem
                   assignment:
-                    admin_id: '991267374'
-                    assignee_id: '991267376'
+                    admin_id: '991268004'
+                    assignee_id: '991268006'
                   open: true
                   snoozed_until: 1673609604
-                  ticket_state_id: 5642
+                  ticket_state_id: 8602
               admin_not_found:
                 summary: Admin not found
                 value:
@@ -11503,8 +11558,8 @@ paths:
                     _default_description_: there is a problem
                   assignment:
                     admin_id: '123'
-                    assignee_id: '991267384'
-                  ticket_state_id: 5650
+                    assignee_id: '991268014'
+                  ticket_state_id: 8610
               assignee_not_found:
                 summary: Assignee not found
                 value:
@@ -11512,9 +11567,9 @@ paths:
                     _default_title_: example
                     _default_description_: there is a problem
                   assignment:
-                    admin_id: '991267390'
+                    admin_id: '991268020'
                     assignee_id: '456'
-                  ticket_state_id: 5658
+                  ticket_state_id: 8618
               ticket_state_id_is_not_valid_or_is_not_associated_with_the_ticket_type:
                 summary: Ticket state id is not valid or is not associated with the
                   ticket type.
@@ -11546,34 +11601,34 @@ paths:
                 Ticket found:
                   value:
                     type: ticket
-                    id: '330'
-                    ticket_id: '36'
+                    id: '496'
+                    ticket_id: '55'
                     ticket_attributes:
                       _default_title_: attribute_value
                       _default_description_:
                     ticket_state:
                       type: ticket_state
-                      id: '5681'
+                      id: '8641'
                       category: submitted
                       internal_label: Submitted
                       external_label: Submitted
                     ticket_type:
                       type: ticket_type
-                      id: '91'
+                      id: '139'
                       name: my-ticket-type-30
                       description: my ticket type description is awesome.
                       icon: "\U0001F981"
-                      workspace_id: this_is_an_id702_that_should_be_at_least_
+                      workspace_id: this_is_an_id700_that_should_be_at_least_
                       archived: false
-                      created_at: 1727857428
-                      updated_at: 1727857428
+                      created_at: 1733321529
+                      updated_at: 1733321529
                       is_internal: false
                       ticket_type_attributes:
                         type: list
                         data:
                         - type: ticket_type_attribute
-                          id: '159'
-                          workspace_id: this_is_an_id702_that_should_be_at_least_
+                          id: '244'
+                          workspace_id: this_is_an_id700_that_should_be_at_least_
                           name: _default_title_
                           description: ola
                           data_type: string
@@ -11584,13 +11639,13 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 91
+                          ticket_type_id: 139
                           archived: false
-                          created_at: 1727857428
-                          updated_at: 1727857428
+                          created_at: 1733321530
+                          updated_at: 1733321530
                         - type: ticket_type_attribute
-                          id: '160'
-                          workspace_id: this_is_an_id702_that_should_be_at_least_
+                          id: '245'
+                          workspace_id: this_is_an_id700_that_should_be_at_least_
                           name: _default_description_
                           description: ola
                           data_type: string
@@ -11601,33 +11656,33 @@ paths:
                           visible_on_create: true
                           visible_to_contacts: false
                           default: false
-                          ticket_type_id: 91
+                          ticket_type_id: 139
                           archived: false
-                          created_at: 1727857428
-                          updated_at: 1727857428
+                          created_at: 1733321530
+                          updated_at: 1733321530
                       category: Back-office
                     contacts:
                       type: contact.list
                       contacts:
                       - type: contact
-                        id: 66fd03159ffbe52cc8b3ab3a
-                        external_id: 152a82f6-36b2-484b-a049-a02b530561d4
+                        id: 6750633ad5eefd6f04e7d184
+                        external_id: 6c48ca25-a3da-4dc0-9acd-45ee9e9a966c
                     admin_assignee_id: '0'
                     team_assignee_id: '0'
-                    created_at: 1727857429
-                    updated_at: 1727857431
+                    created_at: 1733321531
+                    updated_at: 1733321532
                     ticket_parts:
                       type: ticket_part.list
                       ticket_parts:
                       - type: ticket_part
-                        id: '119'
+                        id: '192'
                         part_type: ticket_state_updated_by_admin
                         ticket_state: submitted
                         previous_ticket_state: submitted
-                        created_at: 1727857429
-                        updated_at: 1727857429
+                        created_at: 1733321531
+                        updated_at: 1733321531
                         author:
-                          id: '991267410'
+                          id: '991268040'
                           type: admin
                           name: Ciaran502 Lee
                           email: admin502@email.com
@@ -11652,7 +11707,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: e64cf768-c096-4660-a10f-3e4576552dcf
+                    request_id: 4da637bd-3e4e-4b14-baf5-83c850ddb6f2
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11683,7 +11738,7 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '331'
+                    id: '497'
                     object: ticket
                     deleted: true
               schema:
@@ -11713,7 +11768,7 @@ paths:
                 Ticket not found:
                   value:
                     type: error.list
-                    request_id: 0734062a-278f-4d71-b9eb-95d3d0836e88
+                    request_id: 9022678b-fd18-4dfb-bd65-9b344a67757c
                     errors:
                     - code: ticket_not_found
                       message: Ticket not found
@@ -11758,7 +11813,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 392d5127-e1e3-4e2a-b2b3-99c2fd576c07
+                    request_id: fb21fb90-caf9-4f15-9fa4-fc9a8eba85a3
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -11854,34 +11909,34 @@ paths:
                     total_count: 1
                     tickets:
                     - type: ticket
-                      id: '332'
-                      ticket_id: '38'
+                      id: '498'
+                      ticket_id: '57'
                       ticket_attributes:
                         _default_title_: attribute_value
                         _default_description_:
                       ticket_state:
                         type: ticket_state
-                        id: '5721'
+                        id: '8681'
                         category: submitted
                         internal_label: Submitted
                         external_label: Submitted
                       ticket_type:
                         type: ticket_type
-                        id: '96'
+                        id: '144'
                         name: my-ticket-type-35
                         description: my ticket type description is awesome.
                         icon: "\U0001F981"
-                        workspace_id: this_is_an_id712_that_should_be_at_least_
+                        workspace_id: this_is_an_id710_that_should_be_at_least_
                         archived: false
-                        created_at: 1727857444
-                        updated_at: 1727857444
+                        created_at: 1733321545
+                        updated_at: 1733321545
                         is_internal: false
                         ticket_type_attributes:
                           type: list
                           data:
                           - type: ticket_type_attribute
-                            id: '169'
-                            workspace_id: this_is_an_id712_that_should_be_at_least_
+                            id: '254'
+                            workspace_id: this_is_an_id710_that_should_be_at_least_
                             name: _default_title_
                             description: ola
                             data_type: string
@@ -11892,13 +11947,13 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 96
+                            ticket_type_id: 144
                             archived: false
-                            created_at: 1727857444
-                            updated_at: 1727857444
+                            created_at: 1733321545
+                            updated_at: 1733321545
                           - type: ticket_type_attribute
-                            id: '170'
-                            workspace_id: this_is_an_id712_that_should_be_at_least_
+                            id: '255'
+                            workspace_id: this_is_an_id710_that_should_be_at_least_
                             name: _default_description_
                             description: ola
                             data_type: string
@@ -11909,33 +11964,33 @@ paths:
                             visible_on_create: true
                             visible_to_contacts: false
                             default: false
-                            ticket_type_id: 96
+                            ticket_type_id: 144
                             archived: false
-                            created_at: 1727857445
-                            updated_at: 1727857445
+                            created_at: 1733321545
+                            updated_at: 1733321545
                         category: Back-office
                       contacts:
                         type: contact.list
                         contacts:
                         - type: contact
-                          id: 66fd03259ffbe52cc8b3ab3c
-                          external_id: db14385b-0bfc-4275-ba1c-d4cad2293516
+                          id: 67506349d5eefd6f04e7d186
+                          external_id: f9cac606-ab66-4e1c-abb1-46bf708ffc1d
                       admin_assignee_id: '0'
                       team_assignee_id: '0'
-                      created_at: 1727857445
-                      updated_at: 1727857447
+                      created_at: 1733321546
+                      updated_at: 1733321547
                       ticket_parts:
                         type: ticket_part.list
                         ticket_parts:
                         - type: ticket_part
-                          id: '122'
+                          id: '195'
                           part_type: ticket_state_updated_by_admin
                           ticket_state: submitted
                           previous_ticket_state: submitted
-                          created_at: 1727857446
-                          updated_at: 1727857446
+                          created_at: 1733321546
+                          updated_at: 1733321546
                           author:
-                            id: '991267442'
+                            id: '991268072'
                             type: admin
                             name: Ciaran532 Lee
                             email: admin532@email.com
@@ -11995,26 +12050,26 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 66fd032b9ffbe52cc8b3ab3f
+                    id: 6750634ed5eefd6f04e7d189
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
                     phone:
                     name: Gareth Bale
-                    pseudonym: Green Lamp
+                    pseudonym: Lilac Glasses
                     avatar:
                       type: avatar
-                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/green-lamp.png
-                    app_id: this_is_an_id716_that_should_be_at_least_
+                      image_url: https://static.intercomassets.com/app/pseudonym_avatars_2019/lilac-glasses.png
+                    app_id: this_is_an_id714_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1727857451
-                    remote_created_at: 1727857451
-                    signed_up_at: 1727857451
-                    updated_at: 1727857452
+                    created_at: 1733321550
+                    remote_created_at: 1733321550
+                    signed_up_at: 1733321550
+                    updated_at: 1733321551
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -12047,7 +12102,7 @@ paths:
                 visitor Not Found:
                   value:
                     type: error.list
-                    request_id: 9f8a197d-d8bd-425a-a09a-d09afc9ac9c3
+                    request_id: 94893651-7555-4262-a981-e4a70195d320
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -12061,7 +12116,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 5e7fe5b0-cf18-4034-a284-ea8ecb989d6a
+                    request_id: 2dd60f2d-09b4-4e1b-92c7-8bfcc4169ad8
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -12076,7 +12131,7 @@ paths:
               successful:
                 summary: successful
                 value:
-                  id: 66fd032b9ffbe52cc8b3ab3f
+                  id: 6750634ed5eefd6f04e7d189
                   name: Gareth Bale
               visitor_not_found:
                 summary: visitor Not Found
@@ -12109,7 +12164,7 @@ paths:
                 successful:
                   value:
                     type: visitor
-                    id: 66fd032e9ffbe52cc8b3ab45
+                    id: 67506351d5eefd6f04e7d18f
                     user_id: 3ecf64d0-9ed1-4e9f-88e1-da7d6e6782f3
                     anonymous: true
                     email: ''
@@ -12119,16 +12174,16 @@ paths:
                     avatar:
                       type: avatar
                       image_url:
-                    app_id: this_is_an_id722_that_should_be_at_least_
+                    app_id: this_is_an_id720_that_should_be_at_least_
                     companies:
                       type: company.list
                       companies: []
                     location_data: {}
                     last_request_at:
-                    created_at: 1727857454
-                    remote_created_at: 1727857454
-                    signed_up_at: 1727857454
-                    updated_at: 1727857454
+                    created_at: 1733321553
+                    remote_created_at: 1733321553
+                    signed_up_at: 1733321553
+                    updated_at: 1733321553
                     session_count: 0
                     social_profiles:
                       type: social_profile.list
@@ -12161,7 +12216,7 @@ paths:
                 Visitor not found:
                   value:
                     type: error.list
-                    request_id: 312d4805-5369-47e3-b73e-f7c3bdbb8743
+                    request_id: d274db5c-b5e9-4f3d-b64b-e1fadd8d4b23
                     errors:
                     - code: not_found
                       message: Visitor Not Found
@@ -12175,7 +12230,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: b9f098b2-bdb5-4260-8ceb-78aa84f22c59
+                    request_id: 499c295c-5cd6-4c64-bddb-12e1ccf41839
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -12206,8 +12261,8 @@ paths:
                 successful:
                   value:
                     type: contact
-                    id: 66fd03319ffbe52cc8b3ab4c
-                    workspace_id: this_is_an_id728_that_should_be_at_least_
+                    id: 67506355d5eefd6f04e7d196
+                    workspace_id: this_is_an_id726_that_should_be_at_least_
                     external_id:
                     role: user
                     email: foo@bar.com
@@ -12222,9 +12277,9 @@ paths:
                     has_hard_bounced: false
                     marked_email_as_spam: false
                     unsubscribed_from_emails: false
-                    created_at: 1727857457
-                    updated_at: 1727857458
-                    signed_up_at: 1727857457
+                    created_at: 1733321557
+                    updated_at: 1733321558
+                    signed_up_at: 1733321557
                     last_seen_at:
                     last_replied_at:
                     last_contacted_at:
@@ -12258,31 +12313,31 @@ paths:
                     tags:
                       type: list
                       data: []
-                      url: "/contacts/66fd03319ffbe52cc8b3ab4c/tags"
+                      url: "/contacts/67506355d5eefd6f04e7d196/tags"
                       total_count: 0
                       has_more: false
                     notes:
                       type: list
                       data: []
-                      url: "/contacts/66fd03319ffbe52cc8b3ab4c/notes"
+                      url: "/contacts/67506355d5eefd6f04e7d196/notes"
                       total_count: 0
                       has_more: false
                     companies:
                       type: list
                       data: []
-                      url: "/contacts/66fd03319ffbe52cc8b3ab4c/companies"
+                      url: "/contacts/67506355d5eefd6f04e7d196/companies"
                       total_count: 0
                       has_more: false
                     opted_out_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd03319ffbe52cc8b3ab4c/subscriptions"
+                      url: "/contacts/67506355d5eefd6f04e7d196/subscriptions"
                       total_count: 0
                       has_more: false
                     opted_in_subscription_types:
                       type: list
                       data: []
-                      url: "/contacts/66fd03319ffbe52cc8b3ab4c/subscriptions"
+                      url: "/contacts/67506355d5eefd6f04e7d196/subscriptions"
                       total_count: 0
                       has_more: false
                     utm_campaign:
@@ -12291,6 +12346,7 @@ paths:
                     utm_source:
                     utm_term:
                     referrer:
+                    enabled_push_messaging:
               schema:
                 "$ref": "#/components/schemas/contact"
         '401':
@@ -12301,7 +12357,7 @@ paths:
                 Unauthorized:
                   value:
                     type: error.list
-                    request_id: 632444f2-db4e-421d-916f-1f229ca2ea1e
+                    request_id: c491f8ab-3267-4ea0-a363-726d430dfdb6
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
@@ -12506,7 +12562,7 @@ components:
           type: string
           nullable: true
           description: The name of the Admin who initiated the activity.
-          example: Joe Bloggs
+          example: Joe Example
     addressable_list:
       title: Addressable List
       type: object
@@ -12547,15 +12603,15 @@ components:
         name:
           type: string
           description: The name of the admin.
-          example: Hoban Washburne
+          example: Joe Example
         email:
           type: string
           description: The email of the admin.
-          example: wash@serenity.io
+          example: jdoe@example.com
         job_title:
           type: string
           description: The job title of the admin.
-          example: Philosopher
+          example: Associate
         away_mode_enabled:
           type: boolean
           description: Identifies if this admin is currently set in away mode.
@@ -12775,15 +12831,15 @@ components:
         name:
           type: string
           description: The name of the admin.
-          example: Hoban Washburne
+          example: Joe Example
         email:
           type: string
           description: The email of the admin.
-          example: wash@serenity.io
+          example: jdoe@example.com
         job_title:
           type: string
           description: The job title of the admin.
-          example: Philosopher
+          example: Associate
         away_mode_enabled:
           type: boolean
           description: Identifies if this admin is currently set in away mode.
@@ -13794,8 +13850,8 @@ components:
       type: object
       x-tags:
       - Contacts
-      description: Contact are the objects that represent your leads and users in
-        Intercom.
+      x-fern-sdk-group-name: contacts
+      description: Contacts represent your leads and users in Intercom.
       properties:
         type:
           type: string
@@ -15616,13 +15672,20 @@ components:
         url:
           type: string
           description: The URL of the external page. This will be used by Fin to link
-            end users to the page it based its answer on.
+            end users to the page it based its answer on. When a URL is not present,
+            Fin will not reference the source.
           example: https://help.example.com/en/articles/1234-getting-started
-        fin_availability:
+        ai_agent_availability:
           type: boolean
           description: Whether the external page should be used to answer questions
-            by Fin.
-          default: true
+            by AI Agent. Will not default when updating an existing external page.
+          default: false
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the external page should be used to answer questions
+            by AI Copilot. Will not default when updating an existing external page.
+          default: false
           example: true
         locale:
           type: string
@@ -15648,9 +15711,9 @@ components:
       required:
       - title
       - html
-      - url
       - locale
       - source_id
+      - external_id
     create_message_request:
       description: You can create a message
       type: object
@@ -16610,12 +16673,12 @@ components:
         email_address:
           type: string
           description: The email address
-          example: wash@serenity.io
+          example: jdoe@example.com
         name:
           type: string
           nullable: true
           description: The name associated with the email address
-          example: Hoban Washburne
+          example: Joe Example
     email_message_metadata:
       title: Email Message Metadata
       type: object
@@ -16762,7 +16825,6 @@ components:
       - type
       - title
       - html
-      - url
       - ai_agent_availability
       - ai_copilot_availability
       - locale
@@ -16770,6 +16832,7 @@ components:
       - created_at
       - updated_at
       - last_ingested_at
+      - external_id
     external_pages_list:
       title: External Pages
       type: object


### PR DESCRIPTION
# Why?
To prepare for AI Content API Promotion, change api docs
Changes include
- URLs no longer required on external pages
- `external_id`s are required on external pages
- Retire old `fin_availability`
- Change defaults for `ai_agent_availability` and `ai_copilot_availability` to false
- Change some text for better context

https://coda.io/d/Tutorial-Writing-an-Open-API-Spec_d5sgfpSuPw9/Tutorial-Writing-an-Open-API-Spec_surCC0Qp#_luF9pvEq