### PR TITLE
feat: add `required` to 2.11 OpenAPI objects

### DIFF
--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -10964,6 +10964,15 @@ components:
       - Admins
       description: Admins are teammate accounts that have access to a workspace.
       nullable: true
+      required:
+        - id
+        - name
+        - email
+        - job_title
+        - away_mode_enabled
+        - away_mode_reassign
+        - has_inbox_seat
+        - team_ids
       properties:
         type:
           type: string
@@ -11422,6 +11431,22 @@ components:
     article_list_item:
       title: Articles
       type: object
+      required:
+        - id
+        - workspace_id 
+        - title
+        - description
+        - body
+        - author_id
+        - state
+        - created_at
+        - updated_at
+        - url
+        - parent_id
+        - parent_type
+        - default_locale
+        - translated_content
+        - statistics
       x-tags:
       - Articles
       description: The data returned about your articles when you list them.
@@ -11991,6 +12016,21 @@ components:
       description: Companies allow you to represent organizations using your product.
         Each company will have its own description and be associated with contacts.
         You can fetch, create, update and list companies.
+      required:
+        - company_id
+        - id
+        - app_id
+        - name
+        - remote_created_at
+        - created_at
+        - updated_at
+        - last_request_at
+        - monthly_spend
+        - session_count
+        - user_count
+        - size
+        - website
+        - industry
       properties:
         type:
           type: string
@@ -12203,6 +12243,34 @@ components:
       - Contacts
       description: Contact are the objects that represent your leads and users in
         Intercom.
+      required:
+        - id
+        - workspace_id
+        - external_id
+        - role
+        - email
+        - phone
+        - name
+        - avatar
+        - owner_id
+        - social_profiles
+        - has_hard_bounced
+        - marked_email_as_spam
+        - unsubscribed_from_emails
+        - created_at
+        - updated_at
+        - signed_up_at
+        - last_seen_at
+        - last_replied_at
+        - last_contacted_at
+        - last_email_opened_at
+        - last_email_clicked_at
+        - language_override
+        - browser
+        - browser_version
+        - browser_language
+        - os
+        - location
       properties:
         type:
           type: string
@@ -12925,6 +12993,23 @@ components:
       description: Conversations are how you can communicate with users in Intercom.
         They are created when a contact replies to an outbound message, or when one
         admin directly sends a message to a single contact.
+      required:
+        - id
+        - created_at 
+        - updated_at
+        - source
+        - contacts
+        - teammates
+        - title
+        - admin_assignee_id
+        - team_assignee_id
+        - custom_attributes
+        - topics
+        - open
+        - state
+        - read
+        - waiting_since
+        - snoozed_until
       properties:
         type:
           type: string
@@ -15148,12 +15233,6 @@ components:
           type: string
           description: The associated conversation_id
           example: '64619700005570'
-      required:
-      - type
-      - id
-      - created_at
-      - body
-      - message_type
     multiple_filter_search_request:
       title: Multiple Filter Search Request
       description: Search using Intercoms Search APIs with more than one filter.
@@ -15650,6 +15729,13 @@ components:
       - Segments
       description: A segment is a group of your contacts defined by the rules that
         you set.
+      required:
+        - type
+        - id
+        - name
+        - created_at
+        - updated_at
+        - person_type
       properties:
         type:
           type: string

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "intercom",
-  "version": "0.42.14"
+  "version": "0.46.1"
 }


### PR DESCRIPTION
The `contact`, `article` and `admin` resources were missing required properties. This PR adds them to the objects so that the generated SDKs are more ergonomic. 