### PR TITLE
Add new conversation API fields to the developer docs & changelog

### DIFF
--- a/REPO_OWNER
+++ b/REPO_OWNER
@@ -1,1 +1,1 @@
-team-data-interop
+team-data-foundations

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -5689,7 +5689,8 @@ paths:
 
         ### Accepted Fields
 
-        Most keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `"foorbar"`).
+        Most keys listed in the conversation model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `"foorbar"`).
+        The `source.body` field is unique as the search will not be performed against the entire value, but instead against every element of the value separately. For example, when searching for a conversation with a `"I need support"` body - the query should contain a `=` operator with the value `"support"` for such conversation to be returned. A query with a `=` operator and a `"need support"` value will not yield a result.
 
         | Field                                     | Type                                                                                                                                                   |
         | :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -6707,156 +6708,6 @@ paths:
                   type: admin
                   admin_id: 991267717
                   body: Goodbye :)
-  "/conversations/{id}/run_assignment_rules":
-    post:
-      summary: Run Assignment Rules on a conversation
-      parameters:
-      - name: Intercom-Version
-        in: header
-        schema:
-          "$ref": "#/components/schemas/intercom_version"
-      - name: id
-        in: path
-        required: true
-        description: The identifier for the conversation as given by Intercom.
-        example: '123'
-        schema:
-          type: string
-      tags:
-      - Conversations
-      operationId: autoAssignConversation
-      description: |
-        You can let a conversation be automatically assigned following assignment rules.
-        {% admonition type="warning" name="When using workflows" %}
-        It is not possible to use this endpoint with Workflows.
-        {% /admonition %}
-      responses:
-        '200':
-          description: Assign a conversation using assignment rules
-          content:
-            application/json:
-              examples:
-                Assign a conversation using assignment rules:
-                  value:
-                    type: conversation
-                    id: '546'
-                    created_at: 1734537616
-                    updated_at: 1734537617
-                    waiting_since:
-                    snoozed_until:
-                    source:
-                      type: conversation
-                      id: '403918365'
-                      delivered_as: admin_initiated
-                      subject: ''
-                      body: "<p>this is the message body</p>"
-                      author:
-                        type: admin
-                        id: '991267723'
-                        name: Ciaran227 Lee
-                        email: admin227@email.com
-                      attachments: []
-                      url:
-                      redacted: false
-                    contacts:
-                      type: contact.list
-                      contacts:
-                      - type: contact
-                        id: 6762f18f1bb69f9f2193bbd0
-                        external_id: '70'
-                    first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
-                    open: false
-                    state: closed
-                    read: false
-                    tags:
-                      type: tag.list
-                      tags: []
-                    priority: not_priority
-                    sla_applied:
-                    statistics:
-                    conversation_rating:
-                    teammates:
-                    title:
-                    custom_attributes: {}
-                    topics: {}
-                    ticket:
-                    linked_objects:
-                      type: list
-                      data: []
-                      total_count: 0
-                      has_more: false
-                    ai_agent:
-                    ai_agent_participated: false
-                    conversation_parts:
-                      type: conversation_part.list
-                      conversation_parts:
-                      - type: conversation_part
-                        id: '141'
-                        part_type: default_assignment
-                        body:
-                        created_at: 1734537617
-                        updated_at: 1734537617
-                        notified_at: 1734537617
-                        assigned_to:
-                          type: nobody_admin
-                          id:
-                        author:
-                          id: '991267724'
-                          type: bot
-                          name: Fin
-                          email: operator+this_is_an_id402_that_should_be_at_least_@intercom.io
-                        attachments: []
-                        external_id:
-                        redacted: false
-                        metadata: {}
-                        email_message_metadata:
-                      total_count: 1
-              schema:
-                "$ref": "#/components/schemas/conversation"
-        '404':
-          description: Not found
-          content:
-            application/json:
-              examples:
-                Not found:
-                  value:
-                    type: error.list
-                    request_id: b55c4cc0-7511-44cd-965a-2751f3559ba9
-                    errors:
-                    - code: not_found
-                      message: Resource Not Found
-              schema:
-                "$ref": "#/components/schemas/error"
-        '401':
-          description: Unauthorized
-          content:
-            application/json:
-              examples:
-                Unauthorized:
-                  value:
-                    type: error.list
-                    request_id: c9fa3789-8f00-4a85-b15b-c9e968d3edac
-                    errors:
-                    - code: unauthorized
-                      message: Access Token Invalid
-              schema:
-                "$ref": "#/components/schemas/error"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: c1d71d2a-a0fb-43df-82cc-495c051cb1c1
-                    errors:
-                    - code: api_plan_restricted
-                      message: Active subscription needed.
-              schema:
-                "$ref": "#/components/schemas/error"
   "/conversations/{id}/customers":
     post:
       summary: Attach a contact to a conversation
@@ -11929,6 +11780,7 @@ paths:
         ### Accepted Fields
 
         Most keys listed as part of the Ticket model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `"foobar"`).
+        The `source.body` field is unique as the search will not be performed against the entire value, but instead against every element of the value separately. For example, when searching for a conversation with a `"I need support"` body - the query should contain a `=` operator with the value `"support"` for such conversation to be returned. A query with a `=` operator and a `"need support"` value will not yield a result.
 
         | Field                                     | Type                                                                                     |
         | :---------------------------------------- | :--------------------------------------------------------------------------------------- |
@@ -14158,7 +14010,6 @@ components:
           "$ref": "#/components/schemas/contact_location"
         social_profiles:
           "$ref": "#/components/schemas/contact_social_profiles"
-          example: true
     contact_attached_companies:
       title: Contact Attached Companies
       type: object
@@ -14185,9 +14036,13 @@ components:
       title: Contact companies
       type: object
       nullable: false
-      description: An object containing companies meta data about the companies that
-        a contact has. Up to 10 will be displayed here. Use the url to get more.
+      description: An object with metadata about companies attached to a contact . Up to 10 will be displayed here. Use the url to get more.
       properties:
+        data:
+          type: array
+          description: An array of company data objects attached to the contact.
+          items:
+            "$ref": "#/components/schemas/company_data"
         url:
           type: string
           format: uri
@@ -14195,7 +14050,7 @@ components:
           example: "/contacts/5ba682d23d7cf92bef87bfd4/companies"
         total_count:
           type: integer
-          description: Int representing the total number of companyies attached to
+          description: Integer representing the total number of companies attached to
             this contact
           example: 100
         has_more:
@@ -14203,6 +14058,26 @@ components:
           description: Whether there's more Addressable Objects to be viewed. If true,
             use the url to view all
           example: true
+    company_data:
+      title: Company Data
+      type: object
+      description: An object containing data about the companies that a contact is associated with.
+      properties:
+        id:
+          type: string
+          description: The unique identifier for the company which is given by Intercom.
+          example: 5ba682d23d7cf92bef87bfd4
+        type:
+          type: string
+          description: The type of the object. Always company.
+          enum:
+          - company
+          example: company
+        url:
+          type: string
+          format: uri
+          description: The relative URL of the company.
+          example: "/companies/5ba682d23d7cf92bef87bfd4"
     contact_deleted:
       title: Contact Deleted
       description: deleted contact object
@@ -14539,6 +14414,7 @@ components:
         archived:
           type: boolean
           description: Whether the contact is archived or not.
+          example: true
     contact_unarchived:
       title: Contact Unarchived
       description: unarchived contact object
@@ -14551,6 +14427,7 @@ components:
           example: false
     contact_blocked:
       title: Contact Blocked
+      type: object
       description: blocked contact object
       allOf:
       - "$ref": "#/components/schemas/contact_reference"
@@ -14974,6 +14851,23 @@ components:
         email_message_metadata:
           "$ref": "#/components/schemas/email_message_metadata"
           nullable: true
+        state:
+          type: string
+          enum:
+            - open
+            - closed
+            - snoozed
+          description: Indicates the current state of conversation when the conversation part was created.
+          example: open
+        tags:
+          type: array
+          description: A list of tags objects associated with the conversation part.
+          items:
+            "$ref": "#/components/schemas/tag_basic"
+          nullable: true
+        event_details:
+          "$ref": "#/components/schemas/event_details"
+          nullable: true
     conversation_part_author:
       title: Conversation part author
       type: object
@@ -15070,14 +14964,24 @@ components:
     conversation_source:
       title: Conversation source
       type: object
-      description: The Conversation Part that originated this conversation, which
-        can be Contact, Admin, Campaign, Automated or Operator initiated.
+      description: The type of the conversation part that started this conversation. Can be Contact, Admin, Campaign, Automated or Operator initiated.
       properties:
         type:
           type: string
           description: This includes conversation, email, facebook, instagram, phone_call,
             phone_switch, push, sms, twitter and whatsapp.
           example: conversation
+          enum:
+          - conversation
+          - email
+          - facebook
+          - instagram
+          - phone_call
+          - phone_switch
+          - push
+          - sms
+          - twitter
+          - whatsapp
         id:
           type: string
           description: The id representing the message.
@@ -16758,6 +16662,114 @@ components:
           description: A list of an email address headers.
           items:
             "$ref": "#/components/schemas/email_address_header"
+    conversation_attribute_updated_by_workflow:
+      title: Part type - conversation_attribute_updated_by_workflow
+      type: object
+      description: Contains details about the workflow that was triggered and any Custom Data Attributes (CDAs) that were modified during the workflow execution for conversation part type <code>conversation_attribute_updated_by_workflow</code>.
+      properties:
+        workflow:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the workflow
+              example: Workflow 1
+        attribute:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the CDA updated
+              example: flight_category
+        value:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Value of the CDA updated
+              example: vip_status
+    conversation_attribute_updated_by_admin:
+      title: Part type - conversation_attribute_updated_by_admin
+      type: object
+      description: Contains details about Custom Data Attributes (CDAs) that were modified by an admin (operator) for conversation part type <code>conversation_attribute_updated_by_admin</code>.
+      properties:
+        attribute:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the CDA updated
+              example: jira_issue_key
+        value:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Value of the CDA updated
+              example: PROJ-007
+    custom_action_started:
+      title: Part type - custom_action_started
+      type: object
+      description: Contains details about name of the action that was initiated for conversation part type <code>custom_action_started</code>.
+      properties:
+        action:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the action
+              example: Jira Create Issue
+    custom_action_finished:
+      title: Part type - custom_action_finished
+      type: object
+      description: Contains details about final status of the completed action for conversation part type <code>custom_action_finished</code>.
+      properties:
+        action:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the action
+              example: Jira Create Issue
+            result:
+              type: string
+              description: Status of the action
+              enum:
+                - success
+                - failed
+              example: success
+    operator_workflow_event:
+      title: Part type - operator_workflow_event
+      type: object
+      description: Contains details about name of the workflow for conversation part type <code>operator_workflow_event</code>.
+      properties:
+        workflow:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the workflow
+              example: Custom Bot 1
+        event:
+          type: object
+          properties:
+            type:
+              type: string
+              description: Type of the workflow event initiated
+              example: wait_finished
+            result:
+              type: string
+              description: Result of the workflow event
+              example: Finsihed waiting
+    event_details:
+      title: Event details of Workflow & actions
+      type: object
+      anyOf:
+        - "$ref": "#/components/schemas/conversation_attribute_updated_by_workflow"
+        - "$ref": "#/components/schemas/conversation_attribute_updated_by_admin"
+        - "$ref": "#/components/schemas/custom_action_started"
+        - "$ref": "#/components/schemas/custom_action_finished"
+        - "$ref": "#/components/schemas/operator_workflow_event"
     error:
       type: object
       title: Error
@@ -17302,11 +17314,6 @@ components:
       - created_at
       - body
       - message_type
-    multiple_or_single_filter_search_request:
-      title: Multiple or Single Filter Search Request
-      oneOf:
-        - "$ref": "#/components/schemas/multiple_filter_search_request"
-        - "$ref": "#/components/schemas/single_filter_search_request"
     multiple_filter_search_request:
       title: Multiple Filter Search Request
       description: Search using Intercoms Search APIs with more than one filter.
@@ -17320,9 +17327,17 @@ components:
           description: An operator to allow boolean inspection between multiple fields.
           example: AND
         value:
-          type: array
-          items:
-            "$ref": "#/components/schemas/multiple_or_single_filter_search_request"
+          oneOf:
+          - type: array
+            description: Add mutiple filters.
+            title: multiple filter search request
+            items:
+              "$ref": "#/components/schemas/multiple_filter_search_request"
+          - type: array
+            description: Add a single filter field.
+            title: single filter search request
+            items:
+              "$ref": "#/components/schemas/single_filter_search_request"
     news_item:
       title: News Item
       type: object
@@ -17883,10 +17898,9 @@ components:
           - type: integer
           - type: array
             items:
-              type: string
-          - type: array
-            items:
-              type: integer
+              oneOf:
+              - type: string
+              - type: integer
           description: The value that you want to search on.
           example: '73732934'
           nullable: true
@@ -18070,6 +18084,26 @@ components:
           example: 1663597223
         applied_by:
           "$ref": "#/components/schemas/reference"
+    tag_basic:
+      title: Tag
+      type: object
+      x-tags:
+      - Tags
+      description: A tag allows you to label your contacts, companies, and conversations
+        and list them using that tag.
+      properties:
+        type:
+          type: string
+          description: value is "tag"
+          example: tag
+        id:
+          type: string
+          description: The id of the tag
+          example: '123456'
+        name:
+          type: string
+          description: The name of the tag
+          example: Test tag
     tag_company_request:
       description: You can tag a single company or a list of companies.
       type: object


### PR DESCRIPTION
# Why?
Towards: https://github.com/intercom/intercom/issues/379548

# Changes in this PR
- Update repo owner based on new remits
- Update unstable yaml to include new response fields in the docs