### PR TITLE
update block contact description

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -4756,12 +4756,7 @@ paths:
       tags:
       - Contacts
       operationId: BlockContact
-      description: |-
-        Block a single contact.
-
-        **Note:** conversations of the contact will also be archived during the process.
-
-        More details in [FAQ: How do I block Inbox spam?](https://www.intercom.com/help/en/articles/8838656-inbox-faqs)
+      description: Block a single contact.<br>**Note:** conversations of the contact will also be archived during the process.<br>More details in [FAQ How do I block Inbox spam?](https://www.intercom.com/help/en/articles/8838656-inbox-faqs)
       responses:
         '200':
           description: successful
@@ -5270,7 +5265,7 @@ paths:
                     read: false
                     tags:
                       type: tag.list
-                      tags: 
+                      tags:
                       - type: tag
                         id: '123456'
                         name: Test tag
@@ -5304,7 +5299,7 @@ paths:
                         created_at: 1663597223
                         updated_at: 1663597260
                         notified_at: 1663597260
-                        assigned_to: 
+                        assigned_to:
                           type: contact
                           id: '1a2b3c'
                         author:
@@ -5317,7 +5312,7 @@ paths:
                         redacted: false
                         email_message_metadata: null
                         state: open
-                        tags: 
+                        tags:
                           - type: tag
                             id: '123456'
                             name: Test tag
@@ -5329,7 +5324,7 @@ paths:
                         created_at: 1740141842
                         updated_at: 1740141842
                         notified_at: 1740141842
-                        assigned_to: 
+                        assigned_to:
                         author:
                           type: admin
                           id: '274'
@@ -5351,7 +5346,7 @@ paths:
                         created_at: 1740141851
                         updated_at: 1740141851
                         notified_at: 1740141851
-                        assigned_to: 
+                        assigned_to:
                         author:
                           type: bot
                           id: '278'
@@ -5375,7 +5370,7 @@ paths:
                         created_at: 1740141857
                         updated_at: 1740141857
                         notified_at: 1740141857
-                        assigned_to: 
+                        assigned_to:
                         author:
                           type: admin
                           id: '274'


### PR DESCRIPTION
https://github.com/intercom/intercom/issues/382977

![image](https://github.com/user-attachments/assets/f549a6d4-d64e-47f8-89f0-0d5bf6d22c62)

I think the problem might be the extra `:` in the description (from https://github.com/intercom/Intercom-OpenAPI/pull/202)
