### PR TITLE
Add created_at field to create conversation request body for v2.11+

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -15539,6 +15539,11 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        created_at:
+          type: integer
+          format: date-time
+          description: The time the conversation was created as a UTC Unix timestamp. If not provided, the current time will be used. This field is only recommneded for migrating past conversations from another source into Intercom.
+          example: 1671028894
       required:
       - from
       - body

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -14381,6 +14381,11 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        created_at:
+          type: integer
+          format: date-time
+          description: The time the conversation was created as a UTC Unix timestamp. If not provided, the current time will be used. This field is only recommneded for migrating past conversations from another source into Intercom.
+          example: 1671028894
       required:
       - from
       - body

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -14681,6 +14681,11 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        created_at:
+          type: integer
+          format: date-time
+          description: The time the conversation was created as a UTC Unix timestamp. If not provided, the current time will be used. This field is only recommneded for migrating past conversations from another source into Intercom.
+          example: 1671028894
       required:
       - from
       - body


### PR DESCRIPTION
Closes https://github.com/intercom/intercom/issues/386886

Related to escalation request: https://app.intercom.com/a/apps/tx2p130c/conversations/40658072881

This functionality has been available since version 2.11 of the API when it was added in this PR https://github.com/intercom/intercom/pull/302855 to enable it for ticket migrations from Zendesk. However, it was never documented publicly.