### PR TITLE
add title param in update conversation endpoint spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ node_modules/
 compiled/
 
 .DS_Store
+
+# Rubymine
+.idea

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -5682,6 +5682,7 @@ paths:
                 summary: conversation found
                 value:
                   read: true
+                  title: new conversation title
                   custom_attributes:
                     issue_type: Billing
                     priority: High
@@ -5696,6 +5697,7 @@ paths:
                 summary: Not found
                 value:
                   read: true
+                  title: new conversation title
                   custom_attributes:
                     issue_type: Billing
                     priority: High
@@ -19265,6 +19267,10 @@ components:
           type: boolean
           description: Mark a conversation as read within Intercom.
           example: true
+        title:
+          type: string
+          description: The title given to the conversation
+          example: Conversation Title
         custom_attributes:
           "$ref": "#/components/schemas/custom_attributes"
     update_data_attribute_request:


### PR DESCRIPTION
Follow up to https://github.com/intercom/intercom/pull/387414

Adding the spec for the new title param in the update conversation endpoint in Conversation API

(also expanding the gitignore for rubymine users 😬)