### PR TITLE
remove two duplicates

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -1350,10 +1350,6 @@ components:
               type: string
               description: A unique identified for the visitor which is given by you.
               example: "123"
-            user_id:
-              type: string
-              description: A unique identified for the visitor which is given by you.
-              example: "123"
             name:
               type: string
               description: The visitor's name.
@@ -1436,6 +1432,8 @@ components:
             - section
     visitor:
       properties:
+        custom_attributes:
+          additionalProperties: true
         type:
           enum:
             - visitor
@@ -1463,10 +1461,6 @@ components:
         custom_attributes:
           additionalProperties: true
     create_or_update_company_request:
-      properties:
-        custom_attributes:
-          additionalProperties: true
-    visitor:
       properties:
         custom_attributes:
           additionalProperties: true


### PR DESCRIPTION
just gets rid of a basic 'tag cannot be listed twice' error in the overrides file