### PR TITLE
Switch to step security GitHub actions

### DIFF
--- a/.github/workflows/generate_postman_collection.yml
+++ b/.github/workflows/generate_postman_collection.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm install
       - name: Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@v35
+        uses: step-security/changed-files@v45
       - run: node ./scripts/postman/run-postman-collection.js ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
       - name: List all changed files
         run: |


### PR DESCRIPTION
Towards https://github.com/intercom/intercom/issues/389953

Replacing a library for GitHub actions that had a vulnerability with a more secure one