### PR TITLE
Resolve spec typing bugs detailed in FER 4816

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -121,6 +121,15 @@ paths:
         - companies
       x-fern-sdk-method-name: retrieve
       x-fern-request-name: RetrieveCompanyRequest
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                "$ref": null
+                oneOf:
+                  - $ref: "#/components/schemas/company"
+                  - $ref: "#/components/schemas/company_list"
     post:
       x-fern-sdk-group-name:
         - companies
@@ -1419,6 +1428,10 @@ components:
         type:
           enum:
             - tag
+    ticket_custom_attributes:
+      x-fern-type: map<string, unknown>
+    ticket_request_custom_attributes:
+      x-fern-type: map<string, unknown>
     ticket_type_attribute:
       properties:
         data_type:


### PR DESCRIPTION
Check FER 4816 for details. Basically there's several type issues/inconsistencies in the OpenAPI spec.

Some notes on each of the issues:

1-3 had been resolved before I started the task, possibly fixed over the course of adding overrides while making it work for TS SDK generation. 

1. "avatar" attribute was already overridden to be the correct type (string).
2. Parameters were already added to the OpenAPI spec, the so issue shouldn't be present anymore. Also double-checked by checking that the parameters exist on the generated SDK.
3. Consistency has already been reinforced via override for company_list as well as for several other types that used to use "cursor_pages" - now all use offset_pages as the type for pages. 
4. Repro'd via curl by calling API that this issue was present. Resolved by overriding type to the response to oneOf to capture the possible divergence in return type.
5. Difficult to debug as we don't know what generator this user is using, so fixes are speculative. The first two are very likely due to an error in the OpenAPI spec, as item types for the array option in the ticket related schemas are missing. Resolved by overriding the type to any. The error with snooze_conversation_request.required is too vague to properly diagnose, so no action was taken for it.