### PR TITLE
add away_status_reason_id to admins away endpoint

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -89,6 +89,7 @@ paths:
                     away_mode_enabled: true
                     away_mode_reassign: true
                     has_inbox_seat: true
+                    away_status_reason_id: '12345'
                     team_ids: []
               schema:
                 "$ref": "#/components/schemas/admin"
@@ -106,6 +107,25 @@ paths:
                       message: Admin for admin_id not found
               schema:
                 "$ref": "#/components/schemas/error"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              examples:
+                parameter_invalid:
+                  summary: "Example of an invalid away_status_reason_id"
+                  value:
+                    type: error.list
+                    errors:
+                      - code: parameter_invalid
+                        message: "Away status reason is deleted"
+                away_status_reason_mandatory:
+                  summary: "Example of a missing away_status_reason_id when away reasons are mandatory"
+                  value:
+                    type: error.list
+                    errors:
+                      - code: away_status_reason_mandatory
+                        message: "Away status reason is mandatory"
         '401':
           description: Unauthorized
           content:
@@ -141,12 +161,17 @@ paths:
                     to your default inbox.
                   example: false
                   default: false
+                away_status_reason_id:
+                  type: integer
+                  description: The unique identifier of the away status reason
+                  example: 12345
             examples:
               successful_response:
                 summary: Successful response
                 value:
                   away_mode_enabled: true
                   away_mode_reassign: true
+                  away_status_reason_id: 12345
               admin_not_found:
                 summary: Admin not found
                 value:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -352,6 +352,7 @@ paths:
                     away_mode_enabled: false
                     away_mode_reassign: false
                     has_inbox_seat: true
+                    away_status_reason_id: null
                     team_ids: []
               schema:
                 "$ref": "#/components/schemas/admin"
@@ -13027,6 +13028,11 @@ components:
           description: Identifies if this admin is set to automatically reassign new
             conversations to the apps default inbox.
           example: false
+        away_status_reason_id:
+          type: integer
+          nullable: true
+          description: The unique identifier of the away status reason
+          example: 12345
         has_inbox_seat:
           type: boolean
           description: Identifies if this admin has a paid inbox seat to restrict/allow


### PR DESCRIPTION
Follow up: [Updating endpoint - set admin as away](https://github.com/intercom/intercom/issues/393911)