### PR TITLE
Remove assignment from create ticket request

### DIFF
--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -15139,14 +15139,6 @@ components:
           example: 1590000000
         ticket_attributes:
           "$ref": "#/components/schemas/ticket_request_custom_attributes"
-        assignment:
-          type: object
-          properties:
-            assignee_id:
-              type: string
-              description: The ID of the admin to which the ticket is assigned.
-                If not provided, the ticket will be unassigned.
-              example: '123'
       required:
       - ticket_type_id
       - contacts

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -16154,14 +16154,6 @@ components:
           example: 1590000000
         ticket_attributes:
           "$ref": "#/components/schemas/ticket_request_custom_attributes"
-        assignment:
-          type: object
-          properties:
-            assignee_id:
-              type: string
-              description: The ID of the admin to which the ticket is assigned.
-                If not provided, the ticket will be unassigned.
-              example: '123'
       required:
       - ticket_type_id
       - contacts


### PR DESCRIPTION
Towards https://github.com/intercom/intercom/issues/396238 - remove assignment param from `v2.12` & `v2.13` as its only supported in `Unstable`.