### PR TITLE
Automatically re-generate the TS SDK when we merge PRs to this repo

### DIFF
--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -4,9 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "The version of the SDKs that you would like to release"
+        description: 'The version of the SDKs that you would like to release'
         required: true
         type: string
+  push:
+    branches:
+      - main
+    paths:
+      - 'fern/**'
 
 jobs:
   release:
@@ -21,9 +26,20 @@ jobs:
       - name: Download Fern
         run: npm install -g fern-api
 
+      - name: Determine version
+        id: bump
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            chmod +x ./scripts/fern/bump.sh
+            VERSION=$(./scripts/fern/bump.sh --from HEAD~1 --group ts-sdk)
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          fi
+
       - name: Release SDKs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           FERN_NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
         run: |
-          fern generate --group ts-sdk --version ${{ inputs.version }} --log-level debug
+          fern generate --group ts-sdk --version ${{ steps.bump.outputs.version }} --log-level debug

--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -42,4 +44,5 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           FERN_NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
         run: |
+          echo "Releasing SDK version: ${{ steps.bump.outputs.version }}"
           fern generate --group ts-sdk --version ${{ steps.bump.outputs.version }} --log-level debug

--- a/scripts/fern/bump.sh
+++ b/scripts/fern/bump.sh
@@ -6,17 +6,26 @@
 # Usage:
 #
 # $ ./scripts/bump.sh --from HEAD~1 --group ts-sdk
+
 set -uo pipefail
 
-# The previous commit to compare against.
 FROM_COMMIT=""
-
-# The group to use for version detection
 GROUP=""
 
 log() {
-    # Logs are written to stderr.
     echo "$@" >&2
+}
+
+ensure_fern_cli() {
+    if ! command -v fern &> /dev/null; then
+        log "Installing Fern CLI..."
+        if ! npm install -g fern-api@latest; then
+            log "Failed to install Fern CLI"
+            exit 1
+        fi
+    else
+        log "Fern CLI is already installed"
+    fi
 }
 
 usage() {
@@ -27,7 +36,6 @@ usage() {
 }
 
 fern() {
-    # Use the version of the fern CLI installed in the user's environment.
     FERN_NO_VERSION_REDIRECTION=true command fern "$@"
 }
 
@@ -37,11 +45,9 @@ get_latest_version() {
 
     case $group in
         ts-sdk)
-            # Get latest version from npm
             version=$(npm view intercom-client version 2>/dev/null)
             ;;
         java-sdk)
-            # Get latest version from maven
             version=$(curl -s "https://repo1.maven.org/maven2/io/intercom/intercom-java/maven-metadata.xml" | grep -oP '<version>\K[^<]+' | sort -V | tail -n1)
             ;;
         *)
@@ -82,65 +88,81 @@ if [[ -z "$FROM_COMMIT" || -z "$GROUP" ]]; then
     usage
 fi
 
-# Get the latest version from the registry
+# Ensure Fern CLI is installed
+ensure_fern_cli
+
+# Get working directory and reset temp dir
+WORK_DIR="$(git rev-parse --show-toplevel)"
+WORKTREE_DIR="$WORK_DIR/.tmp_worktree"
+rm -rf "$WORKTREE_DIR"
+
+# Ensure the FROM_COMMIT exists
+log "Verifying that commit $FROM_COMMIT exists..."
+if ! git rev-parse "$FROM_COMMIT" &>/dev/null; then
+    log "Commit $FROM_COMMIT not found. Did you fetch full history?"
+    exit 1
+fi
+
+# Get the latest version
 FROM_VERSION=$(get_latest_version "$GROUP")
 log "Using current version: $FROM_VERSION"
 
+# Ensure cleanup on exit
 cleanup() {
-    # Remove the temporary worktree, if any.
-    if [[ -n "${WORKTREE_DIR:-}" ]] && [[ -d "$WORKTREE_DIR" ]]; then
+    if [[ -d "$WORKTREE_DIR" ]]; then
         (cd "$WORKTREE_DIR" && git submodule deinit --all --force >/dev/null 2>&1 || true)
         git worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 || true
     fi
-
-    # Remove the from.json and to.json files, if any.
     rm -f "$WORK_DIR/from.json" "$WORK_DIR/to.json" >/dev/null 2>&1
-
-    # Pop back to the user's original directory.
-    popd >/dev/null 2>&1
+    popd >/dev/null 2>&1 || true
 }
-
 trap cleanup EXIT
 
-# Step 0: Navigate to the fern root directory, if not already.
-WORK_DIR="$(git rev-parse --show-toplevel)"
-pushd "$WORK_DIR" >/dev/null 2>&1
+# Navigate to project root
+pushd "$WORK_DIR" >/dev/null
 
-# Step 1: Generate IR from current commit.
+# Generate IR from current commit
 log "Generating IR from current commit..."
 fern ir to.json
 
-# Step 2: Create worktree and generate IR from previous commit.
-WORKTREE_DIR=$(mktemp -d)
-log "Generating IR from previous commit..."
-git worktree add "$WORKTREE_DIR" "$FROM_COMMIT" >/dev/null 2>&1
+# Generate IR from previous commit in worktree
+log "Creating worktree in $WORKTREE_DIR..."
+if ! git worktree add "$WORKTREE_DIR" "$FROM_COMMIT"; then
+    log "Failed to create worktree"
+    exit 1
+fi
+
 (
     cd "$WORKTREE_DIR" || {
         log "Cannot access worktree directory"
         exit 1
     }
 
-    # Initialize and update git submodules, if any.
-    git submodule update --init --recursive >/dev/null 2>&1
+    log "Updating submodules..."
+    git submodule update --init --recursive
 
+    log "Running fern ir for previous commit..."
     fern ir from.json
+
+    if [ ! -f "from.json" ]; then
+        log "from.json was not generated in worktree"
+        exit 1
+    fi
 )
 
-# Step 3: Copy the from.json to the current working directory
+# Copy from.json back to root
+log "Copying from.json to working directory..."
 cp "$WORKTREE_DIR/from.json" "$WORK_DIR/from.json"
 
-# Step 4: Run fern diff.
+# Diff and get next version
 log "Running fern diff..."
 DIFF_OUTPUT=$(fern diff --from from.json --to to.json --from-version "$FROM_VERSION")
-
-# Debug: Print the full diff output
 log "Diff output: $DIFF_OUTPUT"
 
-# Step 5: Extract next version using jq.
 NEXT_VERSION=$(echo "$DIFF_OUTPUT" | jq -r '.nextVersion')
 
-if [[ -z "$NEXT_VERSION" ]]; then
-    log "Could not determine next version from 'fern diff' output: $DIFF_OUTPUT"
+if [[ -z "$NEXT_VERSION" || "$NEXT_VERSION" == "null" ]]; then
+    log "Could not determine next version from fern diff output"
     exit 1
 fi
 

--- a/scripts/fern/bump.sh
+++ b/scripts/fern/bump.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+#
+# Bumps the version of the SDK by comparing the current API
+# against a snapshot of the API from a previous commit.
+#
+# Usage:
+#
+# $ ./scripts/bump.sh --from HEAD~1 --group ts-sdk
+set -uo pipefail
+
+# The previous commit to compare against.
+FROM_COMMIT=""
+
+# The group to use for version detection
+GROUP=""
+
+log() {
+    # Logs are written to stderr.
+    echo "$@" >&2
+}
+
+usage() {
+    echo "Usage: $0 --from <commit> --group <group>"
+    echo "  --from           Previous commit reference (e.g., HEAD~1, 8475a09)"
+    echo "  --group          Group to use for version detection (e.g., ts-sdk, java-sdk)"
+    exit 1
+}
+
+fern() {
+    # Use the version of the fern CLI installed in the user's environment.
+    FERN_NO_VERSION_REDIRECTION=true command fern "$@"
+}
+
+get_latest_version() {
+    local group=$1
+    local version=""
+
+    case $group in
+        ts-sdk)
+            # Get latest version from npm
+            version=$(npm view intercom-client version 2>/dev/null)
+            ;;
+        java-sdk)
+            # Get latest version from maven
+            version=$(curl -s "https://repo1.maven.org/maven2/io/intercom/intercom-java/maven-metadata.xml" | grep -oP '<version>\K[^<]+' | sort -V | tail -n1)
+            ;;
+        *)
+            log "Unknown group: $group"
+            exit 1
+            ;;
+    esac
+
+    if [[ -z "$version" ]]; then
+        log "Could not determine latest version for group $group"
+        exit 1
+    fi
+
+    echo "$version"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --from)
+            FROM_COMMIT="$2"
+            shift 2
+            ;;
+        --group)
+            GROUP="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+if [[ -z "$FROM_COMMIT" || -z "$GROUP" ]]; then
+    usage
+fi
+
+# Get the latest version from the registry
+FROM_VERSION=$(get_latest_version "$GROUP")
+log "Using current version: $FROM_VERSION"
+
+cleanup() {
+    # Remove the temporary worktree, if any.
+    if [[ -n "${WORKTREE_DIR:-}" ]] && [[ -d "$WORKTREE_DIR" ]]; then
+        (cd "$WORKTREE_DIR" && git submodule deinit --all --force >/dev/null 2>&1 || true)
+        git worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 || true
+    fi
+
+    # Remove the from.json and to.json files, if any.
+    rm -f "$WORK_DIR/from.json" "$WORK_DIR/to.json" >/dev/null 2>&1
+
+    # Pop back to the user's original directory.
+    popd >/dev/null 2>&1
+}
+
+trap cleanup EXIT
+
+# Step 0: Navigate to the fern root directory, if not already.
+WORK_DIR="$(git rev-parse --show-toplevel)"
+pushd "$WORK_DIR" >/dev/null 2>&1
+
+# Step 1: Generate IR from current commit.
+log "Generating IR from current commit..."
+fern ir to.json
+
+# Step 2: Create worktree and generate IR from previous commit.
+WORKTREE_DIR=$(mktemp -d)
+log "Generating IR from previous commit..."
+git worktree add "$WORKTREE_DIR" "$FROM_COMMIT" >/dev/null 2>&1
+(
+    cd "$WORKTREE_DIR" || {
+        log "Cannot access worktree directory"
+        exit 1
+    }
+
+    # Initialize and update git submodules, if any.
+    git submodule update --init --recursive >/dev/null 2>&1
+
+    fern ir from.json
+)
+
+# Step 3: Copy the from.json to the current working directory
+cp "$WORKTREE_DIR/from.json" "$WORK_DIR/from.json"
+
+# Step 4: Run fern diff.
+log "Running fern diff..."
+DIFF_OUTPUT=$(fern diff --from from.json --to to.json --from-version "$FROM_VERSION")
+
+# Debug: Print the full diff output
+log "Diff output: $DIFF_OUTPUT"
+
+# Step 5: Extract next version using jq.
+NEXT_VERSION=$(echo "$DIFF_OUTPUT" | jq -r '.nextVersion')
+
+if [[ -z "$NEXT_VERSION" ]]; then
+    log "Could not determine next version from 'fern diff' output: $DIFF_OUTPUT"
+    exit 1
+fi
+
+echo "$NEXT_VERSION"


### PR DESCRIPTION
- Added a script (`bump.sh`) that determines the correct version number to set when we re-deploy the SDK
- Updated `ts-sdk.yml` to automatically re-deploy the TS SDK when PRs get merged to the `fern` folder within this repo
   - Calls `bump.sh` to get the correct version # when we auto re-deploy the SDK
- I'll implement this for the Java SDK once we start publishing to Maven