### PR TITLE
Update Custom Channel Event API customer ID

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -7549,7 +7549,7 @@ paths:
                 summary: Example request
                 value:
                   event_id: "evt_12345"
-                  conversation_id: "conv_67890"
+                  external_conversation_id: "conv_67890"
                   contact:
                     type: "user"
                     external_id: "user_001"
@@ -7600,7 +7600,7 @@ paths:
                 summary: Example request
                 value:
                   event_id: "evt_54321"
-                  conversation_id: "conv_98765"
+                  external_conversation_id: "conv_98765"
                   contact:
                     type: "user"
                     external_id: "user_002"
@@ -7652,7 +7652,7 @@ paths:
                 summary: Example request
                 value:
                   event_id: "evt_67890"
-                  conversation_id: "conv_13579"
+                  external_conversation_id: "conv_13579"
                   contact:
                     type: "user"
                     external_id: "user_003"
@@ -7703,7 +7703,7 @@ paths:
                 summary: Example request
                 value:
                   event_id: "evt_24680"
-                  conversation_id: "conv_11223"
+                  external_conversation_id: "conv_11223"
                   contact:
                     type: "user"
                     external_id: "user_004"
@@ -17734,14 +17734,14 @@ components:
         event_id:
           type: string
           description: Unique identifier for the event.
-        conversation_id:
+        external_conversation_id:
           type: string
-          description: Identifier for the conversation in your system.
+          description: Identifier for the conversation in your application.
         contact:
           $ref: '#/components/schemas/custom_channel_contact'
       required:
         - event_id
-        - conversation_id
+        - external_conversation_id
         - contact
     custom_channel_contact:
       title: Custom Channel - Simplified Contact


### PR DESCRIPTION
Update contract from `customer_id` to `external_customer_id`, to. make it explicit that this is not the same as Intercom's conversation ID.