### PR TITLE
Update custom_channel_contact schema

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -18049,8 +18049,6 @@ components:
       required:
         - type
         - external_id
-        - name
-        - email
       properties:
         type:
           type: string
@@ -18061,11 +18059,11 @@ components:
           description: External identifier for the contact. Intercom will take care of the mapping of your external_id with our internal ones so you don't have to worry about it.
         name:
           type: string
-          description: Name of the contact.
+          description: Name of the contact. Required for user type.
         email:
           type: string
           format: email
-          description: Email address of the contact.
+          description: Email address of the contact. Required for user type.
     custom_channel_notification_response:
       type: object
       required:


### PR DESCRIPTION
Attributes "email" and "name" should only be required for users and not for leads.