### PR TITLE
Add overrides to get Pydantic validation to pass

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -1428,6 +1428,11 @@ components:
         type:
           enum:
             - tag
+      # The spec incorrectly labels applied_at and applied_by as required
+      required:
+        - type
+        - id
+        - name
     ticket_custom_attributes:
       x-fern-type: map<string, unknown>
     ticket_request_custom_attributes:
@@ -1479,6 +1484,17 @@ components:
       properties:
         custom_attributes:
           additionalProperties: true
+      # The spec incorrectly labels last_request_at, remote_created_at, size, website, and industry as required
+      required:
+        - company_id
+        - id
+        - app_id
+        - name
+        - created_at
+        - updated_at
+        - monthly_spend
+        - session_count
+        - user_count
     create_or_update_company_request:
       properties:
         custom_attributes:
@@ -1527,7 +1543,65 @@ components:
     note_list:
       properties:
         pages:
-          "$ref": "#/components/schemas/offset_pages"
+    # The spec incorrectly labels job_title as required
+    admin:
+      required:
+        - id
+        - name
+        - email
+        - away_mode_enabled
+        - away_mode_reassign
+        - has_inbox_seat
+        - team_ids
+    # The spec incorrectly labels default_locale and translated_content as required
+    article_list_item:
+      required:
+        - id
+        - workspace_id
+        - title
+        - description
+        - body
+        - author_id
+        - state
+        - created_at
+        - updated_at
+        - url
+        - parent_id
+        - parent_type
+        - statistics
+
+    # The spec incorrectly labels conversions as required
+    article_statistics:
+      required:
+        - type
+        - views
+        - reactions
+        - happy_reaction_percentage
+        - neutral_reaction_percentage
+        - sad_reaction_percentage
+
+    # The spec incorrectly labels description as required
+    data_attribute:
+      required:
+        - type
+        - name
+        - full_name
+        - label
+        - data_type
+
+    # The spec incorrectly labels type, email, intercom_user_id, and user_id as required
+    data_event_summary:
+      required:
+        - events
+
+    # The spec incorrectly labels default_locale as required
+    collection:
+      required:
+        - id
+        - workspace_id
+        - name
+        - created_at
+        - order
 
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
Intercom's server returns responses without certain fields that are marked as `required` in the spec. This isn't an issue in Typescript or Java, but Pydantic (in the Python SDK) throws an error if required fields are missing in an object. This PR provides overrides for a few schemas to mark the missing fields as optional.