### PR TITLE
added admonition to ticket/search api page mentioning the correct cat…

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -12929,6 +12929,12 @@ paths:
         | snoozed_until                             | Date (UNIX timestamp)                                                                    |
         | ticket_attribute.{id}                     | String or Boolean or Date (UNIX timestamp) or Float or Integer                           |
 
+        {% admonition type="info" name="Searching by Category" %}
+        When searching for tickets by the **`category`** field, specific terms must be used instead of the category names:
+        * For **Customer** category tickets, use the term `request`.
+        * For **Back-office** category tickets, use the term `task`.
+        * For **Tracker** category tickets, use the term `tracker`.
+
         ### Accepted Operators
 
         {% admonition type="info" name="Searching based on `created_at`" %}


### PR DESCRIPTION
added admonition to ticket/search api page mentioning the correct categories to use when searching for a ticket


# Why
Related Issue:
https://github.com/intercom/intercom/issues/400856

It is currently unclear in the documentation that when using the /tickets/search endpoint to search tickets, the category names customer and back-office should not be used as keywords. Instead, customer tickets are searched using the keyword 'request', and back-office tickets are searched using the keyword 'task'. 


# How
It was decided in the issue above that the API should be updated to make this information clearer.
This change adds an admonition to the /tickets/search documentation mentioning the correct category search keywords.


