### PR TITLE
Add Calls API endpoints and schemas

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -11151,21 +11151,33 @@ paths:
       - Calls
       operationId: showCallTranscript
       description: |
-        Returns the transcript for the specified call. If no transcript exists, an array with a single empty object is returned: `[{}]`.
+        Returns the transcript for the specified call as a downloadable text file.
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              examples:
-                no_transcript:
-                  value:
-                    - {}
+          headers:
+            Content-Disposition:
+              description: File attachment directive and suggested filename for the transcript
               schema:
-                type: array
-                items:
-                  type: object
-                  additionalProperties: true
+                type: string
+                example: "attachment; filename=transcription_data-2025-07-17.txt"
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Transcript text
+              examples:
+                transcript_txt:
+                  value: |-
+                    [00:00:03] Teammate 1: "Hello, thanks for calling. How can I help today?"
+                    [00:00:09] User: "I need help recovering access to my account."
+                    [00:00:15] Teammate 1: "I can help with that. For security, I’ll ask a few generic verification questions."
+                    [00:00:22] User: "Okay."
+                    [00:00:28] Teammate 1: "Please confirm general details on the account (no sensitive data over this call)."
+                    [00:00:35] User: "I can provide non-sensitive info."
+                    [00:00:41] Teammate 1: "Thank you. I’ll initiate a standard account recovery process and send the next steps."
+                    [00:00:48] User: "Great, thanks."
+                    [00:00:53] Teammate 1: "You should receive a message shortly with instructions to complete recovery."
         '404':
           description: Not Found
           content:


### PR DESCRIPTION
# Add Calls API endpoints and schemas

- Introduces Calls endpoints:
  - GET `/calls` (pagination via `page` and `per_page`, default 25, max 25)
  - GET `/calls/{id}`
  - GET `/calls/{id}/recording` (302 redirect to signed URL; 404 if not available)
  - GET `/calls/{id}/transcript` (returns `[{}]` when no transcript; 404 if call does not exist)
- Adds `call` and `call_list` schemas
  - Fields aligned with `Api::V3::Calls::Presenters::CallResponse` (e.g., `id`, `type=call`, `conversation_id`, `admin_id`, `contact_id`, `state`, timestamps, `recording_url`, `call_type`, `direction`, `ended_reason`, `phone`, `fin_recording_url`, `fin_transcription_url`)
- Tags endpoints under `Calls`
- Example responses aligned with controller behavior in `Api::V3::CallsController` (pagination defaults and limits, 302 redirect for recording, `[{}]` no-transcript behavior)

Generated with Cursor