### PR TITLE
Add include_translations parameter to GET conversation endpoint

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -5655,6 +5655,13 @@ paths:
         example: plaintext
         schema:
           type: string
+      - name: include_translations
+        in: query
+        required: false
+        description: If set to true, conversation parts will be translated to the detected language of the conversation.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Conversations
       operationId: retrieveConversation


### PR DESCRIPTION
Follow up to https://github.com/intercom/intercom/pull/422640
Towards https://github.com/intercom/intercom/issues/420115

## Summary
- Added `include_translations` query parameter to the GET `/conversations/{id}` endpoint in the unstable API version
- Parameter allows conversation parts to be translated to the detected language of the conversation
- Positioned after the `display_as` parameter as requested

🤖 Generated with [Claude Code](https://claude.ai/code)