### PR TITLE
Update API documentation to reflect changes in conversation attributes

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -1516,7 +1516,7 @@ paths:
                   type: array
                   items:
                     type: string
-                  example: [conversation.id, conversation.first_user_conversation_part_created_at]
+                  example: [conversation_id, conversation_started_at]
                 start_time:
                   type: integer
                   format: int64
@@ -1726,7 +1726,7 @@ paths:
                           example: "Conversation-level details: status, channel, assignee."
                         default_time_attribute_id:
                           type: string
-                          example: conversation.first_user_conversation_part_created_at
+                          example: conversation_started_at
                         attributes:
                           type: array
                           items:
@@ -1734,7 +1734,7 @@ paths:
                             properties:
                               id:
                                 type: string
-                                example: conversation.id
+                                example: conversation_id
                               name:
                                 type: string
                                 example: Conversation ID

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -1516,7 +1516,7 @@ paths:
                   type: array
                   items:
                     type: string
-                  example: [conversation.id, conversation.first_user_conversation_part_created_at]
+                  example: [conversation_id, conversation_started_at]
                 start_time:
                   type: integer
                   format: int64
@@ -1726,7 +1726,7 @@ paths:
                           example: "Conversation-level details: status, channel, assignee."
                         default_time_attribute_id:
                           type: string
-                          example: conversation.first_user_conversation_part_created_at
+                          example: conversation_started_at
                         attributes:
                           type: array
                           items:
@@ -1734,7 +1734,7 @@ paths:
                             properties:
                               id:
                                 type: string
-                                example: conversation.id
+                                example: conversation_id
                               name:
                                 type: string
                                 example: Conversation ID

--- a/postman/Unstable/intercom-api.postman_collection.json
+++ b/postman/Unstable/intercom-api.postman_collection.json
@@ -9226,7 +9226,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"dataset_id\": \"conversation\",\n  \"attribute_ids\": [\n    \"conversation.id\",\n    \"conversation.first_user_conversation_part_created_at\"\n  ],\n  \"start_time\": 1717490000,\n  \"end_time\": 1717510000\n}",
+              "raw": "{\n  \"dataset_id\": \"conversation\",\n  \"attribute_ids\": [\n    \"conversation_id\",\n    \"conversation_started_at\"\n  ],\n  \"start_time\": 1717490000,\n  \"end_time\": 1717510000\n}",
               "urlencoded": [],
               "formdata": []
             }


### PR DESCRIPTION
Modified examples in the API specification to use updated attribute names:
- Changed `conversation.id` to `conversation_id`
- Changed `conversation.first_user_conversation_part_created_at` to `conversation_started_at`