### PR TITLE
Help center OpenAPI update

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -20055,6 +20055,15 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
+        url_prefix:
+          type: string
+          description: The URL path prefix for the help center
+          example: "/help"
+        custom_domain:
+          type: string
+          nullable: true
+          description: Custom domain configured for the help center
+          example: "help.company.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -20058,12 +20058,12 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "/help"
+          example: "https://intercom.help/mycompany"
         custom_domain:
           type: string
           nullable: true
           description: Custom domain configured for the help center
-          example: "help.company.com"
+          example: "help.mycompany.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -14870,12 +14870,12 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "/help"
+          example: "https://intercom.help/mycompany"
         custom_domain:
           type: string
           nullable: true
           description: Custom domain configured for the help center
-          example: "help.company.com"
+          example: "help.mycompany.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -14867,6 +14867,15 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
+        url_prefix:
+          type: string
+          description: The URL path prefix for the help center
+          example: "/help"
+        custom_domain:
+          type: string
+          nullable: true
+          description: Custom domain configured for the help center
+          example: "help.company.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -15887,12 +15887,12 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "/help"
+          example: "https://intercom.help/mycompany"
         custom_domain:
           type: string
           nullable: true
           description: Custom domain configured for the help center
-          example: "help.company.com"
+          example: "help.mycompany.com"
       required:
         - id
         - workspace_id

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -15884,6 +15884,15 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
+        url_prefix:
+          type: string
+          description: The URL path prefix for the help center
+          example: "/help"
+        custom_domain:
+          type: string
+          nullable: true
+          description: Custom domain configured for the help center
+          example: "help.company.com"
       required:
         - id
         - workspace_id

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -16157,12 +16157,12 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "/help"
+          example: "https://intercom.help/mycompany"
         custom_domain:
           type: string
           nullable: true
           description: Custom domain configured for the help center
-          example: "help.company.com"
+          example: "help.mycompany.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -16154,6 +16154,15 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
+        url_prefix:
+          type: string
+          description: The URL path prefix for the help center
+          example: "/help"
+        custom_domain:
+          type: string
+          nullable: true
+          description: Custom domain configured for the help center
+          example: "help.company.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -17872,12 +17872,12 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "/help"
+          example: "https://intercom.help/mycompany"
         custom_domain:
           type: string
           nullable: true
           description: Custom domain configured for the help center
-          example: "help.company.com"
+          example: "help.mycompany.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -17869,6 +17869,15 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
+        url_prefix:
+          type: string
+          description: The URL path prefix for the help center
+          example: "/help"
+        custom_domain:
+          type: string
+          nullable: true
+          description: Custom domain configured for the help center
+          example: "help.company.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -19359,6 +19359,15 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
+        url_prefix:
+          type: string
+          description: The URL path prefix for the help center
+          example: "/help"
+        custom_domain:
+          type: string
+          nullable: true
+          description: Custom domain configured for the help center
+          example: "help.company.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -19362,12 +19362,12 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "/help"
+          example: "https://intercom.help/mycompany"
         custom_domain:
           type: string
           nullable: true
           description: Custom domain configured for the help center
-          example: "help.company.com"
+          example: "help.mycompany.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -12859,6 +12859,15 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
+        url_prefix:
+          type: string
+          description: The URL path prefix for the help center
+          example: "/help"
+        custom_domain:
+          type: string
+          nullable: true
+          description: Custom domain configured for the help center
+          example: "help.company.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -12862,12 +12862,12 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "/help"
+          example: "https://intercom.help/mycompany"
         custom_domain:
           type: string
           nullable: true
           description: Custom domain configured for the help center
-          example: "help.company.com"
+          example: "help.mycompany.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -12886,12 +12886,12 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "/help"
+          example: "https://intercom.help/mycompany"
         custom_domain:
           type: string
           nullable: true
           description: Custom domain configured for the help center
-          example: "help.company.com"
+          example: "help.mycompany.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -12883,6 +12883,15 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
+        url_prefix:
+          type: string
+          description: The URL path prefix for the help center
+          example: "/help"
+        custom_domain:
+          type: string
+          nullable: true
+          description: Custom domain configured for the help center
+          example: "help.company.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -14225,12 +14225,12 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "/help"
+          example: "https://intercom.help/mycompany"
         custom_domain:
           type: string
           nullable: true
           description: Custom domain configured for the help center
-          example: "help.company.com"
+          example: "help.mycompany.com"
     help_center_list:
       title: Help Centers
       type: object

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -14222,6 +14222,15 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
+        url_prefix:
+          type: string
+          description: The URL path prefix for the help center
+          example: "/help"
+        custom_domain:
+          type: string
+          nullable: true
+          description: Custom domain configured for the help center
+          example: "help.company.com"
     help_center_list:
       title: Help Centers
       type: object


### PR DESCRIPTION
## Context
- Doing this as a part of https://github.com/intercom/intercom/issues/421822
- PR: https://github.com/intercom/intercom/pull/418380
## Summary
Added url_prefix field to help_center schema for URL path prefix 
Added custom_domain field to help_center schema for custom domain configuration (nullable)
Updated all API versions (0, 2.7-2.14) since Help Center endpoints are not version-gated
