### PR TITLE
Add url_prefix and custom_domain to help center API response examples

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -2163,6 +2163,8 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
+                    url_prefix: https://help.mycompany.com
+                    custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
         '404':
@@ -20390,7 +20392,7 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "https://intercom.help/mycompany"
+          example: "https://help.mycompany.com"
         custom_domain:
           type: string
           nullable: true

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -1235,6 +1235,8 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
+                    url_prefix: https://help.mycompany.com
+                    custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
         '404':
@@ -14870,7 +14872,7 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "https://intercom.help/mycompany"
+          example: "https://help.mycompany.com"
         custom_domain:
           type: string
           nullable: true

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -1263,6 +1263,8 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
+                    url_prefix: https://help.mycompany.com
+                    custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
         '404':
@@ -15887,7 +15889,7 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "https://intercom.help/mycompany"
+          example: "https://help.mycompany.com"
         custom_domain:
           type: string
           nullable: true

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -1817,6 +1817,8 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
+                    url_prefix: https://help.mycompany.com
+                    custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
         '404':
@@ -16157,7 +16159,7 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "https://intercom.help/mycompany"
+          example: "https://help.mycompany.com"
         custom_domain:
           type: string
           nullable: true

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -1847,6 +1847,8 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
+                    url_prefix: https://help.mycompany.com
+                    custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
         '404':
@@ -17872,7 +17874,7 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "https://intercom.help/mycompany"
+          example: "https://help.mycompany.com"
         custom_domain:
           type: string
           nullable: true

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -2163,6 +2163,8 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
+                    url_prefix: https://help.mycompany.com
+                    custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
         '404':
@@ -19362,7 +19364,7 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "https://intercom.help/mycompany"
+          example: "https://help.mycompany.com"
         custom_domain:
           type: string
           nullable: true

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -1134,6 +1134,8 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
+                    url_prefix: https://help.mycompany.com
+                    custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
         '404':
@@ -12862,7 +12864,7 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "https://intercom.help/mycompany"
+          example: "https://help.mycompany.com"
         custom_domain:
           type: string
           nullable: true

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -1134,6 +1134,8 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
+                    url_prefix: https://help.mycompany.com
+                    custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
         '404':
@@ -12886,7 +12888,7 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "https://intercom.help/mycompany"
+          example: "https://help.mycompany.com"
         custom_domain:
           type: string
           nullable: true

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -1134,6 +1134,8 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
+                    url_prefix: https://help.mycompany.com
+                    custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
         '404':
@@ -14225,7 +14227,7 @@ components:
         url_prefix:
           type: string
           description: The URL path prefix for the help center
-          example: "https://intercom.help/mycompany"
+          example: "https://help.mycompany.com"
         custom_domain:
           type: string
           nullable: true


### PR DESCRIPTION
## Summary
- Added missing `url_prefix` and `custom_domain` fields to help center API response examples
- Updated url_prefix example value to use custom domain format for consistency

## Changes
- Updated help center API response examples in all API versions (0, 2.7-2.14)
- Added `url_prefix: https://help.mycompany.com` to response examples
- Added `custom_domain: help.mycompany.com` to response examples
- Changed url_prefix example in schema from `https://intercom.help/mycompany` to `https://help.mycompany.com`

## Technical Details
- These fields were already defined in the schema but missing from the response examples
- Ensures API documentation accurately reflects actual API responses
- Maintains consistency across all API versions

## Testing
- Schema validation should pass
- Examples now match actual API response structure

🤖 Generated with [Claude Code](https://claude.ai/code)