### PR TITLE
Rename url_prefix field to url in help center API response

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -2163,7 +2163,7 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
-                    url_prefix: https://help.mycompany.com
+                    url: https://help.mycompany.com
                     custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
@@ -20391,9 +20391,9 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
-        url_prefix:
+        url:
           type: string
-          description: The URL path prefix for the help center
+          description: The URL for the help center
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -20393,7 +20393,7 @@ components:
           example: Intercom Help Center
         url:
           type: string
-          description: The URL for the help center
+          description: The URL for the help center, if you have a custom domain then this will show the URL using the custom domain.
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -23349,10 +23349,10 @@ tags:
     You can then iterate through the content from that source via its API and POST it to the External Pages endpoint. That endpoint has an *external_id* parameter which allows you to specify the identifier from the source. The endpoint will then either create a new External Page or update an existing one as appropriate.",
 - name: Articles
   description: Everything about your Articles
-- name: Brands
-  description: Everything about your Brands
 - name: Away Status Reasons
   description: Everything about your Away Status Reasons
+- name: Brands
+  description: Everything about your Brands
 - name: Companies
   description: Everything about your Companies
 - name: Contacts

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -14871,7 +14871,7 @@ components:
           example: Intercom Help Center
         url:
           type: string
-          description: The URL for the help center
+          description: The URL for the help center, if you have a custom domain then this will show the URL using the custom domain.
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -1235,7 +1235,7 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
-                    url_prefix: https://help.mycompany.com
+                    url: https://help.mycompany.com
                     custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
@@ -14869,9 +14869,9 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
-        url_prefix:
+        url:
           type: string
-          description: The URL path prefix for the help center
+          description: The URL for the help center
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -15888,7 +15888,7 @@ components:
           example: Intercom Help Center
         url:
           type: string
-          description: The URL for the help center
+          description: The URL for the help center, if you have a custom domain then this will show the URL using the custom domain.
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -1263,7 +1263,7 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
-                    url_prefix: https://help.mycompany.com
+                    url: https://help.mycompany.com
                     custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
@@ -15886,9 +15886,9 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
-        url_prefix:
+        url:
           type: string
-          description: The URL path prefix for the help center
+          description: The URL for the help center
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -1817,7 +1817,7 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
-                    url_prefix: https://help.mycompany.com
+                    url: https://help.mycompany.com
                     custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
@@ -16156,9 +16156,9 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
-        url_prefix:
+        url:
           type: string
-          description: The URL path prefix for the help center
+          description: The URL for the help center
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -16158,7 +16158,7 @@ components:
           example: Intercom Help Center
         url:
           type: string
-          description: The URL for the help center
+          description: The URL for the help center, if you have a custom domain then this will show the URL using the custom domain.
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -1847,7 +1847,7 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
-                    url_prefix: https://help.mycompany.com
+                    url: https://help.mycompany.com
                     custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
@@ -17871,9 +17871,9 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
-        url_prefix:
+        url:
           type: string
-          description: The URL path prefix for the help center
+          description: The URL for the help center
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -17873,7 +17873,7 @@ components:
           example: Intercom Help Center
         url:
           type: string
-          description: The URL for the help center
+          description: The URL for the help center, if you have a custom domain then this will show the URL using the custom domain.
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -19363,7 +19363,7 @@ components:
           example: Intercom Help Center
         url:
           type: string
-          description: The URL for the help center
+          description: The URL for the help center, if you have a custom domain then this will show the URL using the custom domain.
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -2163,7 +2163,7 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
-                    url_prefix: https://help.mycompany.com
+                    url: https://help.mycompany.com
                     custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
@@ -19361,9 +19361,9 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
-        url_prefix:
+        url:
           type: string
-          description: The URL path prefix for the help center
+          description: The URL for the help center
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -12863,7 +12863,7 @@ components:
           example: Intercom Help Center
         url:
           type: string
-          description: The URL for the help center
+          description: The URL for the help center, if you have a custom domain then this will show the URL using the custom domain.
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -1134,7 +1134,7 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
-                    url_prefix: https://help.mycompany.com
+                    url: https://help.mycompany.com
                     custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
@@ -12861,9 +12861,9 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
-        url_prefix:
+        url:
           type: string
-          description: The URL path prefix for the help center
+          description: The URL for the help center
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -1134,7 +1134,7 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
-                    url_prefix: https://help.mycompany.com
+                    url: https://help.mycompany.com
                     custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
@@ -12885,9 +12885,9 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
-        url_prefix:
+        url:
           type: string
-          description: The URL path prefix for the help center
+          description: The URL for the help center
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -12887,7 +12887,7 @@ components:
           example: Intercom Help Center
         url:
           type: string
-          description: The URL for the help center
+          description: The URL for the help center, if you have a custom domain then this will show the URL using the custom domain.
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -14226,7 +14226,7 @@ components:
           example: Intercom Help Center
         url:
           type: string
-          description: The URL for the help center
+          description: The URL for the help center, if you have a custom domain then this will show the URL using the custom domain.
           example: "https://help.mycompany.com"
         custom_domain:
           type: string

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -1134,7 +1134,7 @@ paths:
                     identifier: help-center-1
                     website_turned_on: false
                     display_name: Intercom Help Center
-                    url_prefix: https://help.mycompany.com
+                    url: https://help.mycompany.com
                     custom_domain: help.mycompany.com
               schema:
                 "$ref": "#/components/schemas/help_center"
@@ -14224,9 +14224,9 @@ components:
           type: string
           description: The display name of the Help Center only seen by teammates.
           example: Intercom Help Center
-        url_prefix:
+        url:
           type: string
-          description: The URL path prefix for the help center
+          description: The URL for the help center
           example: "https://help.mycompany.com"
         custom_domain:
           type: string


### PR DESCRIPTION
## Context
- https://github.com/intercom/intercom/issues/421822

## Changes
- Renamed `url_prefix` field to `url` to better reflect that it contains the full URL
- Improved url description ( added a sentence for custom domain behavior
- Fixed brand tag ordering and improved brand documentation