### PR TITLE
Enhance API documentation for export job data download

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -1758,6 +1758,7 @@ paths:
           required: true
           schema:
             type: string
+            example: application/octet-stream
             enum:
               - application/octet-stream
           description: "Required header for downloading the export file"

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -1741,6 +1741,7 @@ paths:
   "/download/reporting_data/{job_identifier}":
     get:
       summary: Download completed export job data
+      description: |
         Download the data from a completed reporting data export job.
 
         > Octet header required

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -1741,12 +1741,25 @@ paths:
   "/download/reporting_data/{job_identifier}":
     get:
       summary: Download completed export job data
+        Download the data from a completed reporting data export job.
+
+        > Octet header required
+        >
+        > You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.
       tags: [Export]
       parameters:
         - name: Intercom-Version
           in: header
           schema:
             "$ref": "#/components/schemas/intercom_version"
+        - name: Accept
+          in: header
+          required: true
+          schema:
+            type: string
+            enum:
+              - application/octet-stream
+          description: "Required header for downloading the export file"
         - name: app_id
           in: query
           required: true

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -1758,6 +1758,7 @@ paths:
           required: true
           schema:
             type: string
+            example: application/octet-stream
             enum:
               - application/octet-stream
           description: "Required header for downloading the export file"

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -1741,6 +1741,7 @@ paths:
   "/download/reporting_data/{job_identifier}":
     get:
       summary: Download completed export job data
+      description: |
         Download the data from a completed reporting data export job.
 
         > Octet header required

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -1741,12 +1741,25 @@ paths:
   "/download/reporting_data/{job_identifier}":
     get:
       summary: Download completed export job data
+        Download the data from a completed reporting data export job.
+
+        > Octet header required
+        >
+        > You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.
       tags: [Export]
       parameters:
         - name: Intercom-Version
           in: header
           schema:
             "$ref": "#/components/schemas/intercom_version"
+        - name: Accept
+          in: header
+          required: true
+          schema:
+            type: string
+            enum:
+              - application/octet-stream
+          description: "Required header for downloading the export file"
         - name: app_id
           in: query
           required: true

--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -774,6 +774,7 @@ paths:
           required: true
           schema:
             type: string
+            example: application/octet-stream
             enum:
               - application/octet-stream
           description: "Required header for downloading the export file"

--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -769,6 +769,14 @@ paths:
           in: header
           schema:
             "$ref": "#/components/schemas/intercom_version"
+        - name: Accept
+          in: header
+          required: true
+          schema:
+            type: string
+            enum:
+              - application/octet-stream
+          description: "Required header for downloading the export file"
         - name: app_id
           in: query
           required: true

--- a/postman/2.14/intercom-api.postman_collection.json
+++ b/postman/2.14/intercom-api.postman_collection.json
@@ -9320,7 +9320,7 @@
               },
               {
                 "key": "Accept",
-                "value": "application/json"
+                "value": "application/octet-stream"
               }
             ],
             "body": null

--- a/postman/Unstable/intercom-api.postman_collection.json
+++ b/postman/Unstable/intercom-api.postman_collection.json
@@ -9787,7 +9787,7 @@
               },
               {
                 "key": "Accept",
-                "value": "application/json"
+                "value": "application/octet-stream"
               }
             ],
             "body": null


### PR DESCRIPTION
- Update description for the "/download/reporting_data/{job_identifier}" endpoint, specifying the requirement for the Accept header with value `application/octet-stream`.
- Updated parameter definitions to include the Accept header as a required field for downloading export files.