### PR TITLE
Fix: Remove conversation_to_link_id from 2.14 version documentation

### DIFF
--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -17887,15 +17887,6 @@ components:
               - email
           example:
           - id: '1234'
-        conversation_to_link_id:
-          type: string
-          description: "The ID of the conversation you want to link to the ticket.
-            Here are the valid ways of linking two tickets:\n
-            - conversation | back-office ticket\n
-            - customer tickets | non-shared back-office ticket\n
-            - conversation | tracker ticket\n
-            - customer ticket | tracker ticket"
-          example: '1234'
         company_id:
           type: string
           description: The ID of the company that the ticket is associated with. The


### PR DESCRIPTION
## Summary
- Removed `conversation_to_link_id` field from 2.14 API specification
- Fixed version inconsistency where this field was incorrectly documented in stable version (2.14)
- Verified the field remains properly documented in Unstable version only

## Problem
The `conversation_to_link_id` feature for linking tickets to conversations is only available in the [Unstable API version](https://developers.intercom.com/docs/references/unstable/changelog#added-ability-to-link-to-an-existing-ticket-when-creating-a-ticket). However, it was incorrectly documented in the 2.14 version, causing confusion for customers trying to use this feature in the stable version. There has been same [confusion](https://github.com/intercom/developer-docs/pull/587) previously as well.

## Solution
Removed the `conversation_to_link_id` field definition from:
- `docs/references/@2.14/rest-api/api.intercom.io.yaml` (lines 17902-17910)

🤖 Generated with [Claude Code](https://claude.ai/code)