### PR TITLE
Add conversation_to_link_id parameter to ticket creation API

### DIFF
--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -17892,6 +17892,15 @@ components:
               - email
           example:
           - id: '1234'
+        conversation_to_link_id:
+          type: string
+          description: "The ID of the conversation you want to link to the ticket.
+            Here are the valid ways of linking two tickets:\n
+            - conversation | back-office ticket\n
+            - customer tickets | non-shared back-office ticket\n
+            - conversation | tracker ticket\n
+            - customer ticket | tracker ticket"
+          example: '1234'
         company_id:
           type: string
           description: The ID of the company that the ticket is associated with. The


### PR DESCRIPTION
## Summary
- Moved `conversation_to_link_id` parameter from unstable to 2.14 API version
- Added documentation for ticket linking functionality

## Details
The `conversation_to_link_id` parameter allows linking conversations to tickets with the following valid combinations:
- conversation | back-office ticket
- customer tickets | non-shared back-office ticket
- conversation | tracker ticket
- customer ticket | tracker ticket

## Test plan
- [ ] Verify the parameter appears in the 2.14 API documentation
- [ ] Confirm the description accurately reflects the linking capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)