### PR TITLE
Fix spec issues from merged PRs #405 and #406

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -8496,6 +8496,10 @@ paths:
         {% admonition type="warning" name="Experimental" %}
           This is an experimental endpoint. It requires a valid HMAC secret for authentication in addition to the standard bearer token.
         {% /admonition %}
+
+        {% admonition type="info" name="Ticket Conversations" %}
+          For ticket conversations, the `write_tickets` OAuth scope is required. Requests without this scope will receive a 401 Unauthorized response.
+        {% /admonition %}
       responses:
         '200':
           description: Conversation part updated
@@ -8551,8 +8555,8 @@ paths:
                     type: error.list
                     request_id: a3e5b8e2-1234-5678-9abc-def012345678
                     errors:
-                    - code: unauthorized
-                      message: Access Token Invalid
+                    - code: token_unauthorized
+                      message: Not authorized to access resource
               schema:
                 "$ref": "#/components/schemas/error"
         '403':
@@ -11999,9 +12003,11 @@ paths:
               examples:
                 missing message_id:
                   value:
-                    type: error
-                    request_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-                    message: "message_id is required"
+                    type: error.list
+                    request_id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                    errors:
+                    - code: parameter_not_found
+                      message: message_id is required
               schema:
                 "$ref": "#/components/schemas/error"
         '401':
@@ -23890,6 +23896,11 @@ components:
     whatsapp_message_status:
       type: object
       description: The delivery status of a specific WhatsApp message.
+      required:
+        - conversation_id
+        - status
+        - type
+        - message_id
       properties:
         conversation_id:
           type: string
@@ -23902,8 +23913,14 @@ components:
           example: delivered
         type:
           type: string
-          description: Event type
+          description: The type of WhatsApp message.
           example: broadcast_outbound
+          enum:
+            - broadcast_outbound
+            - inbox_outbound
+            - inbound
+            - admin_reply
+            - admin_reply_with_template
         created_at:
           type: integer
           description: Creation timestamp


### PR DESCRIPTION
### Why?

PRs #405 and #406 documented two new endpoints in the Unstable spec but introduced several discrepancies between the spec and actual backend behavior. An [audit](https://docs.google.com/document/d/1ga7HJTmM_y6zhWzs9mH2Ym-3piGwG6bbgvjDKvp-7iA) identified 5 issues — wrong error formats, missing enums, incorrect error codes, and undocumented auth requirements.

### How?

Five targeted fixes to `descriptions/0/api.intercom.io.yaml`, each verified against backend source code.

### Decisions

Kept all fixes in a single PR since they're all corrections to the same spec file from the same audit pass.

---

### Backend evidence for each fix

#### Fix 1: 400 error format on GET /messages/whatsapp/status
**Was:** flat `{type: error, request_id, message}` — **Should be:** `{type: "error.list", errors: [{code, message}]}`

Backend proof: All `ApiCodedError` exceptions go through [`error_handler.rb`](https://github.com/intercom/intercom/blob/main/app/lib/api/v3/error_handler.rb) → `render_error` → `render_errors`, which always wraps in the `error.list` format. The 404 example in the same endpoint already used the correct format — this was an inconsistency within the same PR.

#### Fix 2: `type` enum missing on whatsapp_message_status
**Was:** no enum, just `example: broadcast_outbound` — **Should be:** 5 values

Backend proof: [`whatsapp_event.rb:14-19`](https://github.com/intercom/intercom/blob/main/app/services/channels/whatsapp/models/whatsapp_event.rb) defines the enum:
```ruby
enum :type, {
  broadcast_outbound: 'broadcast_outbound',
  inbox_outbound: 'inbox_outbound',
  inbound: 'inbound',
  admin_reply: 'admin_reply',
  admin_reply_with_template: 'admin_reply_with_template',
}
```

#### Fix 3: required properties on whatsapp_message_status
**Was:** no `required` array — **Should be:** `[conversation_id, status, type, message_id]`

Backend proof: [`messages_controller.rb`](https://github.com/intercom/intercom/blob/main/app/controllers/api/v3/messages_controller.rb) `whatsapp_status` action always builds the response hash with `conversation_id`, `status`, `type`, and `message_id` from non-nullable DB columns.

#### Fix 4: 401 error code on PUT conversation_parts
**Was:** `code: unauthorized`, `message: Access Token Invalid` — **Should be:** `code: token_unauthorized`, `message: Not authorized to access resource`

Backend proof: [`code.rb:44`](https://github.com/intercom/intercom/blob/main/app/lib/api/v3/errors/code.rb) defines `TOKEN_UNAUTHORIZED = 'token_unauthorized'`. The controller's [`unauthorized_api_error`](https://github.com/intercom/intercom/blob/main/app/controllers/api/v3/conversation_parts_controller.rb) method returns `message: 'Not authorized to access resource'`.

#### Fix 5: WRITE_TICKETS scope undocumented on PUT conversation_parts
**Was:** no mention of ticket scope — **Should be:** documented

Backend proof: [`conversation_parts_controller.rb:58-61`](https://github.com/intercom/intercom/blob/main/app/controllers/api/v3/conversation_parts_controller.rb) checks `unauthorized_ticket_write?` which verifies `@token.scope.include?(WRITE_TICKETS)` for ticket conversations.

<details>
<summary>Implementation Plan</summary>

# Fix PRs #405 and #406 — OpenAPI Spec Issues

## Context

PRs #405 and #406 documented two previously-undocumented endpoints in the Unstable spec. Both merged. An audit found multiple discrepancies between spec and backend. Single PR to fix all 5 issues.

## File to modify

`descriptions/0/api.intercom.io.yaml` — only file

## Fixes

### From PR #405 — GET /messages/whatsapp/status

**Fix 1 (HIGH): 400 error example — wrong format**

Spec has flat `{type: error, request_id, message}`. Backend always renders `{type: "error.list", errors: [{code, message}]}` via `error_handler.rb` → `render_errors`. The 404 in the same endpoint is already correct.

**Fix 2 (HIGH): type field missing enum**

`whatsapp_event.rb:14-19` defines 5 values. Spec has none.

**Fix 3 (MEDIUM): No required properties**

Controller always returns `conversation_id`, `status`, `type`, `message_id`.

### From PR #406 — PUT /conversations/{conversation_id}/conversation_parts/{id}

**Fix 4 (HIGH): 401 error code and message wrong**

Spec: `code: unauthorized`, `message: Access Token Invalid`
Backend: `code: token_unauthorized`, `message: Not authorized to access resource`

**Fix 5 (MEDIUM): WRITE_TICKETS scope undocumented**

Controller checks `unauthorized_ticket_write?` verifying WRITE_TICKETS scope for ticket conversations.

## Verification

1. `fern check` — 0 errors, 290 warnings (same as main)
2. Each fix verified against backend source files

</details>

<sub>Generated with Claude Code</sub>