### PR TITLE
Add missing examples to create contact request body

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -21830,9 +21830,11 @@ components:
         role:
           type: string
           description: The role of the contact.
+          example: user
         external_id:
           type: string
           description: A unique identifier for the contact which is given to Intercom
+          example: "625e90fc55ab113b6d92175f"
         email:
           type: string
           description: The contacts email
@@ -21888,6 +21890,10 @@ components:
           type: object
           nullable: true
           description: The custom attributes which are set for the contact
+          example:
+            paid_subscriber: true
+            monthly_spend: 155.5
+            team_mates: 1
       anyOf:
       - required:
         - email

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -13650,9 +13650,11 @@ components:
         role:
           type: string
           description: The role of the contact.
+          example: user
         external_id:
           type: string
           description: A unique identifier for the contact which is given to Intercom
+          example: "625e90fc55ab113b6d92175f"
         email:
           type: string
           description: The contacts email
@@ -13700,6 +13702,10 @@ components:
           type: object
           nullable: true
           description: The custom attributes which are set for the contact
+          example:
+            paid_subscriber: true
+            monthly_spend: 155.5
+            team_mates: 1
       anyOf:
       - required:
         - email

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -14459,9 +14459,11 @@ components:
         role:
           type: string
           description: The role of the contact.
+          example: user
         external_id:
           type: string
           description: A unique identifier for the contact which is given to Intercom
+          example: "625e90fc55ab113b6d92175f"
         email:
           type: string
           description: The contacts email
@@ -14509,6 +14511,10 @@ components:
           type: object
           nullable: true
           description: The custom attributes which are set for the contact
+          example:
+            paid_subscriber: true
+            monthly_spend: 155.5
+            team_mates: 1
       anyOf:
       - required:
         - email

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -14721,9 +14721,11 @@ components:
         role:
           type: string
           description: The role of the contact.
+          example: user
         external_id:
           type: string
           description: A unique identifier for the contact which is given to Intercom
+          example: "625e90fc55ab113b6d92175f"
         email:
           type: string
           description: The contacts email
@@ -14771,6 +14773,10 @@ components:
           type: object
           nullable: true
           description: The custom attributes which are set for the contact
+          example:
+            paid_subscriber: true
+            monthly_spend: 155.5
+            team_mates: 1
       anyOf:
       - required:
         - email

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -16156,9 +16156,11 @@ components:
         role:
           type: string
           description: The role of the contact.
+          example: user
         external_id:
           type: string
           description: A unique identifier for the contact which is given to Intercom
+          example: "625e90fc55ab113b6d92175f"
         email:
           type: string
           description: The contacts email
@@ -16206,6 +16208,10 @@ components:
           type: object
           nullable: true
           description: The custom attributes which are set for the contact
+          example:
+            paid_subscriber: true
+            monthly_spend: 155.5
+            team_mates: 1
       anyOf:
       - required:
         - email

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -17604,9 +17604,11 @@ components:
         role:
           type: string
           description: The role of the contact.
+          example: user
         external_id:
           type: string
           description: A unique identifier for the contact which is given to Intercom
+          example: "625e90fc55ab113b6d92175f"
         email:
           type: string
           description: The contacts email
@@ -17654,6 +17656,10 @@ components:
           type: object
           nullable: true
           description: The custom attributes which are set for the contact
+          example:
+            paid_subscriber: true
+            monthly_spend: 155.5
+            team_mates: 1
       anyOf:
       - required:
         - email

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -18331,9 +18331,11 @@ components:
         role:
           type: string
           description: The role of the contact.
+          example: user
         external_id:
           type: string
           description: A unique identifier for the contact which is given to Intercom
+          example: "625e90fc55ab113b6d92175f"
         email:
           type: string
           description: The contacts email
@@ -18381,6 +18383,10 @@ components:
           type: object
           nullable: true
           description: The custom attributes which are set for the contact
+          example:
+            paid_subscriber: true
+            monthly_spend: 155.5
+            team_mates: 1
       anyOf:
       - required:
         - email

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -11744,9 +11744,11 @@ components:
         role:
           type: string
           description: The role of the contact.
+          example: user
         external_id:
           type: string
           description: A unique identifier for the contact which is given to Intercom
+          example: "625e90fc55ab113b6d92175f"
         email:
           type: string
           description: The contacts email
@@ -11794,6 +11796,10 @@ components:
           type: object
           nullable: true
           description: The custom attributes which are set for the contact
+          example:
+            paid_subscriber: true
+            monthly_spend: 155.5
+            team_mates: 1
       anyOf:
       - required:
         - email

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -11768,9 +11768,11 @@ components:
         role:
           type: string
           description: The role of the contact.
+          example: user
         external_id:
           type: string
           description: A unique identifier for the contact which is given to Intercom
+          example: "625e90fc55ab113b6d92175f"
         email:
           type: string
           description: The contacts email
@@ -11818,6 +11820,10 @@ components:
           type: object
           nullable: true
           description: The custom attributes which are set for the contact
+          example:
+            paid_subscriber: true
+            monthly_spend: 155.5
+            team_mates: 1
       anyOf:
       - required:
         - email

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -12948,9 +12948,11 @@ components:
         role:
           type: string
           description: The role of the contact.
+          example: user
         external_id:
           type: string
           description: A unique identifier for the contact which is given to Intercom
+          example: "625e90fc55ab113b6d92175f"
         email:
           type: string
           description: The contacts email
@@ -12998,6 +13000,10 @@ components:
           type: object
           nullable: true
           description: The custom attributes which are set for the contact
+          example:
+            paid_subscriber: true
+            monthly_spend: 155.5
+            team_mates: 1
       anyOf:
       - required:
         - email


### PR DESCRIPTION
https://app.intercom.com/a/inbox/tx2p130c/inbox/team/5826718/conversation/215473742090565?view=List
### Why?

The create contact API request body is missing example values for the `role`, `external_id`, and `custom_attributes` fields. This makes it confusing for customers to understand what can and cannot be added to the request body. Other endpoints like create company already have complete examples on every field.

### How?

Added `example` values to the three fields that were missing them in the `create_contact_request` schema, across all API versions (2.7–2.15 and Unstable).

<sub>Generated with Claude Code</sub>