### PR TITLE
Add update_last_request_at to Companies API schema (Unstable)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22396,6 +22396,10 @@ components:
             155.98 will be truncated to 155. Note that this has an upper limit of
             2**31-1 or 2147483647..
           example: 1000
+        update_last_request_at:
+          type: boolean
+          description: Set to true to update the company's last seen time to now.
+          example: true
     create_or_update_custom_object_instance_request:
       description: Payload to create or update a Custom Object instance
       type: object


### PR DESCRIPTION
### Why?

Companion to intercom/intercom#492687 — documents the new `update_last_request_at` boolean parameter on the Companies create/update endpoints.

### How?

Adds `update_last_request_at` to the `create_or_update_company_request` schema in the Unstable OpenAPI spec.

### Companions

- intercom/intercom#492687
- intercom/developer-docs#818

<sub>Generated with Claude Code</sub>