### PR TITLE
Add ticket_state_id to convert endpoint (Unstable)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -21639,6 +21639,10 @@ components:
           description: The ID of the type of ticket you want to convert the conversation
             to
           example: '1234'
+        ticket_state_id:
+          type: string
+          description: The ID of the ticket state associated with the ticket type.
+          example: '123'
         attributes:
           "$ref": "#/components/schemas/ticket_request_custom_attributes"
       required:


### PR DESCRIPTION
### Why?

The public API convert endpoint now supports an optional `ticket_state_id` parameter to set the initial ticket state during conversion, gated to the Unstable API version.

### How?

Adds `ticket_state_id` (string, optional) to the `convert_conversation_to_ticket_request` schema in the Unstable spec only, matching the existing pattern from `update_ticket_request`.

Related:
- https://github.com/intercom/intercom/pull/491405
- https://github.com/intercom/intercom/pull/492855
- https://github.com/intercom/developer-docs/pull/819

<sub>Generated with Claude Code</sub>