### PR TITLE
Add side_conversations endpoint to OpenAPI spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9430,6 +9430,89 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/error"
+  "/conversations/{id}/side_conversations":
+    get:
+      summary: List side conversations
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      - name: id
+        in: path
+        required: true
+        description: The identifier for the conversation as given by Intercom.
+        example: '123'
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        description: The page number of results to return (starting from 1).
+        schema:
+          type: integer
+          default: 1
+      - name: per_page
+        in: query
+        required: false
+        description: The number of side conversations to return per page (max 50).
+        schema:
+          type: integer
+          default: 25
+          maximum: 50
+      tags:
+      - Conversations
+      operationId: listSideConversations
+      description: |
+        List side conversations for a given conversation. Side conversations are internal threads created by teammates from within a conversation.
+
+        Each side conversation includes its conversation parts (messages). Results are paginated.
+
+        Requires the `read_conversations` OAuth scope.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/side_conversation_list"
+              examples:
+                Successful response:
+                  value:
+                    type: side_conversation.list
+                    side_conversations:
+                    - side_conversation_id: '456'
+                      conversation_parts:
+                      - type: conversation_part
+                        id: '789'
+                        part_type: comment
+                        body: "<p>Internal note about this issue</p>"
+                        author:
+                          type: admin
+                          id: '123'
+                          name: Jane Example
+                          email: jane@example.com
+                        created_at: 1663597223
+                        updated_at: 1663597223
+                      total_count: 1
+                    total_count: 1
+                    pages:
+                      type: pages
+                      page: 1
+                      per_page: 25
+                      total_pages: 1
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error"
+        '404':
+          description: Conversation not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error"
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -25123,6 +25206,65 @@ components:
           description: Array of handling events
           items:
             "$ref": "#/components/schemas/handling_event"
+    side_conversation_summary:
+      title: Side Conversation Summary
+      type: object
+      description: A side conversation with its conversation parts.
+      properties:
+        side_conversation_id:
+          type: string
+          description: The unique identifier for the side conversation.
+          example: '456'
+        conversation_parts:
+          type: array
+          description: The conversation parts (messages) in this side conversation.
+          items:
+            "$ref": "#/components/schemas/conversation_part"
+        total_count:
+          type: integer
+          description: The total number of conversation parts in this side conversation.
+          example: 1
+    side_conversation_list:
+      title: Side Conversation List
+      type: object
+      description: A paginated list of side conversations for a conversation.
+      properties:
+        type:
+          type: string
+          description: The type of the response object.
+          enum:
+          - side_conversation.list
+          example: side_conversation.list
+        side_conversations:
+          type: array
+          description: An array of side conversation objects.
+          items:
+            "$ref": "#/components/schemas/side_conversation_summary"
+        total_count:
+          type: integer
+          description: The total number of side conversations.
+          example: 1
+        pages:
+          type: object
+          description: Pagination metadata.
+          properties:
+            type:
+              type: string
+              enum:
+              - pages
+              example: pages
+            page:
+              type: integer
+              description: The current page number.
+              example: 1
+            per_page:
+              type: integer
+              description: The number of results per page.
+              example: 25
+            total_pages:
+              type: integer
+              description: The total number of pages.
+              example: 1
     help_center:
       title: Help Center
       type: object


### PR DESCRIPTION
### Why?

The monolith PR (`intercom/intercom` branch `busiq/add-side-conversation-threads-api`) adds a new `GET /conversations/{id}/side_conversations` public API endpoint. The OpenAPI spec needs to document this endpoint so it appears in the API reference and generated SDKs.

### How?

Add the path definition and two new schemas (`side_conversation_list`, `side_conversation_summary`) to the Unstable spec, following the existing `handling_events` sub-resource pattern.

### Companion PRs
- **Monolith:** `intercom/intercom` — branch `busiq/add-side-conversation-threads-api`
- **Developer Docs:** `intercom/developer-docs` — branch `busiq/add-side-conversations-endpoint`

<details>
<summary>Implementation Plan</summary>

# Plan: Add Side Conversations API Documentation

## Context

PR `busiq/add-side-conversation-threads-api` introduces a new public API endpoint:
**`GET /conversations/{id}/side_conversations`** — returns paginated side conversation threads
with their conversation parts. The endpoint is in `UnstableVersion`, gated by
`AddSideConversationsEndpoint` version change, and requires `read_conversations` /
`read_extended_conversations` OAuth scopes.

The monolith code is complete. Two companion PRs are needed in external repos to fully ship the API.

## Step 1: OpenAPI Spec — `intercom-openapi`

### 1a. Add path (after `/conversations/{id}/handling_events`)

Insert new path `/conversations/{id}/side_conversations` following the exact pattern of
`handling_events` — same parameter style, same tag (`Conversations`), same error responses.

Key details from the controller/presenter:
- **operationId:** `listSideConversations`
- **Parameters:** `id` (path, required), `page` (query, integer, default 1), `per_page` (query, integer, default 25, max 50), `Intercom-Version` (header)
- **Response:** 200 with `side_conversation_list` schema
- **Errors:** 401 (Unauthorized), 404 (Conversation not found)

### 1b. Add schemas (after `handling_event_list`)

Two new schemas:
- **`side_conversation_summary`** — object with `side_conversation_id` (string), `conversation_parts` (array of `conversation_part` refs), `total_count` (integer)
- **`side_conversation_list`** — object with `type` (enum `side_conversation.list`), `side_conversations` (array of `side_conversation_summary`), `total_count` (integer), `pages` (object with `page`, `per_page`, `total_pages`)

## Step 2: Developer Docs — `developer-docs`

- Copy updated OpenAPI spec into `docs/references/@Unstable/rest-api/`
- Add changelog entry for the new endpoint

</details>

<sub>Generated with Claude Code</sub>