### PR TITLE
Document cross_post param on Reply to a Ticket endpoint

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -15816,6 +15816,14 @@ paths:
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
                     \  </body> </html>"
+              admin_note_cross_post_reply:
+                summary: Admin note reply with cross-post to linked conversations
+                value:
+                  message_type: note
+                  type: admin
+                  admin_id: 991267943
+                  body: This note will be cross-posted to all linked conversations.
+                  cross_post: true
               admin_quick_reply_reply:
                 summary: Admin quick_reply reply
                 value:
@@ -18417,6 +18425,11 @@ components:
             type: string
             format: uri
           maxItems: 10
+        cross_post:
+          type: boolean
+          description: If set to true, the note will be cross-posted to all linked
+            conversations. Only applicable to note message types on back-office tickets.
+          example: true
       required:
       - message_type
       - type

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -9499,6 +9499,14 @@ paths:
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
                     \  </body> </html>"
+              admin_note_cross_post_reply:
+                summary: Admin note reply with cross-post to linked conversations
+                value:
+                  message_type: note
+                  type: admin
+                  admin_id: 991268224
+                  body: This note will be cross-posted to all linked conversations.
+                  cross_post: true
               admin_quick_reply_reply:
                 summary: Admin quick_reply reply
                 value:
@@ -11224,6 +11232,11 @@ components:
             type: string
             format: uri
           maxItems: 10
+        cross_post:
+          type: boolean
+          description: If set to true, the note will be cross-posted to all linked
+            conversations. Only applicable to note message types on back-office tickets.
+          example: true
       required:
       - message_type
       - type

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -9586,6 +9586,14 @@ paths:
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
                     \  </body> </html>"
+              admin_note_cross_post_reply:
+                summary: Admin note reply with cross-post to linked conversations
+                value:
+                  message_type: note
+                  type: admin
+                  admin_id: 991267829
+                  body: This note will be cross-posted to all linked conversations.
+                  cross_post: true
               admin_quick_reply_reply:
                 summary: Admin quick_reply reply
                 value:
@@ -11345,6 +11353,11 @@ components:
             type: string
             format: uri
           maxItems: 10
+        cross_post:
+          type: boolean
+          description: If set to true, the note will be cross-posted to all linked
+            conversations. Only applicable to note message types on back-office tickets.
+          example: true
       required:
       - message_type
       - type

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -10292,6 +10292,14 @@ paths:
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
                     \  </body> </html>"
+              admin_note_cross_post_reply:
+                summary: Admin note reply with cross-post to linked conversations
+                value:
+                  message_type: note
+                  type: admin
+                  admin_id: 991266696
+                  body: This note will be cross-posted to all linked conversations.
+                  cross_post: true
               admin_quick_reply_reply:
                 summary: Admin quick_reply reply
                 value:
@@ -12054,6 +12062,11 @@ components:
             type: string
             format: uri
           maxItems: 10
+        cross_post:
+          type: boolean
+          description: If set to true, the note will be cross-posted to all linked
+            conversations. Only applicable to note message types on back-office tickets.
+          example: true
       required:
       - message_type
       - type

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -11529,6 +11529,14 @@ paths:
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
                     \  </body> </html>"
+              admin_note_cross_post_reply:
+                summary: Admin note reply with cross-post to linked conversations
+                value:
+                  message_type: note
+                  type: admin
+                  admin_id: 991266696
+                  body: This note will be cross-posted to all linked conversations.
+                  cross_post: true
               admin_quick_reply_reply:
                 summary: Admin quick_reply reply
                 value:
@@ -13382,6 +13390,11 @@ components:
             type: string
             format: uri
           maxItems: 10
+        cross_post:
+          type: boolean
+          description: If set to true, the note will be cross-posted to all linked
+            conversations. Only applicable to note message types on back-office tickets.
+          example: true
       required:
       - message_type
       - type

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -12611,6 +12611,14 @@ paths:
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
                     \  </body> </html>"
+              admin_note_cross_post_reply:
+                summary: Admin note reply with cross-post to linked conversations
+                value:
+                  message_type: note
+                  type: admin
+                  admin_id: 991267943
+                  body: This note will be cross-posted to all linked conversations.
+                  cross_post: true
               admin_quick_reply_reply:
                 summary: Admin quick_reply reply
                 value:
@@ -14671,6 +14679,11 @@ components:
             type: string
             format: uri
           maxItems: 10
+        cross_post:
+          type: boolean
+          description: If set to true, the note will be cross-posted to all linked
+            conversations. Only applicable to note message types on back-office tickets.
+          example: true
       required:
       - message_type
       - type

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -12682,6 +12682,14 @@ paths:
                     \  <li>Tea</li>   <li>Milk</li> </ul>    <h2>An Ordered HTML List</h2>
                     \ <ol>   <li>Coffee</li>   <li>Tea</li>   <li>Milk</li> </ol>
                     \  </body> </html>"
+              admin_note_cross_post_reply:
+                summary: Admin note reply with cross-post to linked conversations
+                value:
+                  message_type: note
+                  type: admin
+                  admin_id: 991267943
+                  body: This note will be cross-posted to all linked conversations.
+                  cross_post: true
               admin_quick_reply_reply:
                 summary: Admin quick_reply reply
                 value:
@@ -15237,6 +15245,11 @@ components:
             type: string
             format: uri
           maxItems: 10
+        cross_post:
+          type: boolean
+          description: If set to true, the note will be cross-posted to all linked
+            conversations. Only applicable to note message types on back-office tickets.
+          example: true
       required:
       - message_type
       - type


### PR DESCRIPTION
### Why?

The Reply to a Ticket endpoint supports a `cross_post` boolean parameter that cross-posts notes to all linked conversations on back-office tickets, but this was never documented in the API spec. Reported by the Knowledge team and confirmed via codebase investigation.

- https://github.com/intercom/intercom/issues/432971

### How?

Added the `cross_post` boolean property to the `admin_reply_ticket_request` schema and a corresponding request body example across all API versions that have the ticket reply endpoint (2.10–2.15 and Unstable).

<sub>Generated with Claude Code</sub>