### PR TITLE
Document CX Score attributes in custom_attributes schema

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22889,7 +22889,8 @@ components:
       type: object
       description: An object containing the different custom attributes associated
         to the conversation as key-value pairs. For relationship attributes the value
-        will be a list of custom object instance models.
+        will be a list of custom object instance models. System-defined attributes
+        such as "CX Score rating" and "CX Score explanation" may also be included.
       additionalProperties:
         anyOf:
         - type: string
@@ -22902,6 +22903,9 @@ components:
         team_mates: 9
         start_date_iso8601: "2023-03-04T09:46:14Z"
         end_date_timestamp: 1677923174
+        CX Score rating: 4
+        CX Score explanation: The conversation was resolved quickly and the customer
+          expressed satisfaction with the outcome.
     custom_object_instance:
       title: Custom Object Instance
       type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -16933,7 +16933,8 @@ components:
       type: object
       description: An object containing the different custom attributes associated
         to the conversation as key-value pairs. For relationship attributes the value
-        will be a list of custom object instance models.
+        will be a list of custom object instance models. System-defined attributes
+        such as "CX Score rating" and "CX Score explanation" may also be included.
       additionalProperties:
         anyOf:
         - type: string

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -18593,7 +18593,8 @@ components:
       type: object
       description: An object containing the different custom attributes associated
         to the conversation as key-value pairs. For relationship attributes the value
-        will be a list of custom object instance models.
+        will be a list of custom object instance models. System-defined attributes
+        such as "CX Score rating" and "CX Score explanation" may also be included.
       additionalProperties:
         anyOf:
         - type: string
@@ -18606,6 +18607,9 @@ components:
         team_mates: 9
         start_date_iso8601: "2023-03-04T09:46:14Z"
         end_date_timestamp: 1677923174
+        CX Score rating: 4
+        CX Score explanation: The conversation was resolved quickly and the customer
+          expressed satisfaction with the outcome.
     custom_object_instance:
       title: Custom Object Instance
       type: object

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -19320,7 +19320,8 @@ components:
       type: object
       description: An object containing the different custom attributes associated
         to the conversation as key-value pairs. For relationship attributes the value
-        will be a list of custom object instance models.
+        will be a list of custom object instance models. System-defined attributes
+        such as "CX Score rating" and "CX Score explanation" may also be included.
       additionalProperties:
         anyOf:
         - type: string
@@ -19333,6 +19334,9 @@ components:
         team_mates: 9
         start_date_iso8601: "2023-03-04T09:46:14Z"
         end_date_timestamp: 1677923174
+        CX Score rating: 4
+        CX Score explanation: The conversation was resolved quickly and the customer
+          expressed satisfaction with the outcome.
     custom_object_instance:
       title: Custom Object Instance
       type: object


### PR DESCRIPTION
### Why?

The "CX Score rating" and "CX Score explanation" attributes are already returned in the Conversations API response under `custom_attributes`, but are not mentioned anywhere in the OpenAPI spec. This means both developers and Fin are unaware these fields exist.

- https://github.com/intercom/intercom/issues/433818

### How?

Added a sentence to the `custom_attributes` schema description noting that system-defined attributes like "CX Score rating" and "CX Score explanation" may be included, and added them to the examples. Applied across all versions that have the schema (2.13, 2.14, 2.15, Preview).

Companion to intercom/developer-docs#833

<sub>Generated with Claude Code</sub>