### PR TITLE
Docs: add missing subject field to create conversation request

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22064,6 +22064,10 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        subject:
+          type: string
+          description: The title of the email. Only applicable if the message type is email.
+          example: Thanks for everything
         attachment_urls:
           type: array
           description: A list of image URLs that will be added as attachments. You

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -13761,6 +13761,10 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        subject:
+          type: string
+          description: The title of the email. Only applicable if the message type is email.
+          example: Thanks for everything
         attachment_urls:
           type: array
           description: A list of image URLs that will be added as attachments. You

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -14570,6 +14570,10 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        subject:
+          type: string
+          description: The title of the email. Only applicable if the message type is email.
+          example: Thanks for everything
         attachment_urls:
           type: array
           description: A list of image URLs that will be added as attachments. You

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -14955,6 +14955,10 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        subject:
+          type: string
+          description: The title of the email. Only applicable if the message type is email.
+          example: Thanks for everything
         attachment_urls:
           type: array
           description: A list of image URLs that will be added as attachments. You

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -16295,6 +16295,10 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        subject:
+          type: string
+          description: The title of the email. Only applicable if the message type is email.
+          example: Thanks for everything
         attachment_urls:
           type: array
           description: A list of image URLs that will be added as attachments. You

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -17743,6 +17743,10 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        subject:
+          type: string
+          description: The title of the email. Only applicable if the message type is email.
+          example: Thanks for everything
         attachment_urls:
           type: array
           description: A list of image URLs that will be added as attachments. You

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -18470,6 +18470,10 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        subject:
+          type: string
+          description: The title of the email. Only applicable if the message type is email.
+          example: Thanks for everything
         attachment_urls:
           type: array
           description: A list of image URLs that will be added as attachments. You

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -11842,6 +11842,10 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        subject:
+          type: string
+          description: The title of the email. Only applicable if the message type is email.
+          example: Thanks for everything
         attachment_urls:
           type: array
           description: A list of image URLs that will be added as attachments. You

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -11866,6 +11866,10 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        subject:
+          type: string
+          description: The title of the email. Only applicable if the message type is email.
+          example: Thanks for everything
         attachment_urls:
           type: array
           description: A list of image URLs that will be added as attachments. You

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -13046,6 +13046,10 @@ components:
           type: string
           description: The content of the message. HTML is not supported.
           example: Hello
+        subject:
+          type: string
+          description: The title of the email. Only applicable if the message type is email.
+          example: Thanks for everything
         attachment_urls:
           type: array
           description: A list of image URLs that will be added as attachments. You


### PR DESCRIPTION
### Why?

The `subject` field has always been accepted by `POST /conversations` (which routes to `MessagesController#create`) but was never documented in the `create_conversation_request` schema. The companion `create_message_request` schema already documents it. A customer reported the discrepancy:

- intercom/intercom#435569

### How?

Adds the `subject` property to `create_conversation_request` across all API versions (2.7–2.15 + Preview), matching the existing definition in `create_message_request`. No API behavior change — this is a documentation correction only.

Companion PR:
- intercom/developer-docs#834

<sub>Generated with Claude Code</sub>