### PR TITLE
Clarify Tag applied_at/applied_by are only present in tagging operations

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -26652,12 +26652,12 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
           example: 1663597223
         applied_by:
           type: object
           nullable: true
-          description: The admin who applied the tag
+          description: The admin who applied the tag. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           allOf:
             - "$ref": "#/components/schemas/reference"
     tag_basic:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -26652,7 +26652,7 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           example: 1663597223
         applied_by:
           type: object

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -15982,12 +15982,12 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
           example: 1663597223
         applied_by:
           type: object
           nullable: true
-          description: The admin who applied the tag
+          description: The admin who applied the tag. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           allOf:
             - "$ref": "#/components/schemas/reference"
     tag_basic:

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -15982,7 +15982,7 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           example: 1663597223
         applied_by:
           type: object

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -17649,12 +17649,12 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
           example: 1663597223
         applied_by:
           type: object
           nullable: true
-          description: The admin who applied the tag
+          description: The admin who applied the tag. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           allOf:
             - "$ref": "#/components/schemas/reference"
       required:

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -17649,7 +17649,7 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           example: 1663597223
         applied_by:
           type: object

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -17373,12 +17373,12 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
           example: 1663597223
         applied_by:
           type: object
           nullable: true
-          description: The admin who applied the tag
+          description: The admin who applied the tag. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           allOf:
             - "$ref": "#/components/schemas/reference"
     tag_basic:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -17373,7 +17373,7 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           example: 1663597223
         applied_by:
           type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -18984,7 +18984,7 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           example: 1663597223
         applied_by:
           type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -18984,12 +18984,12 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
           example: 1663597223
         applied_by:
           type: object
           nullable: true
-          description: The admin who applied the tag
+          description: The admin who applied the tag. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           allOf:
             - "$ref": "#/components/schemas/reference"
     tag_basic:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -20913,7 +20913,7 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           example: 1663597223
         applied_by:
           type: object

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -20913,12 +20913,12 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
           example: 1663597223
         applied_by:
           type: object
           nullable: true
-          description: The admin who applied the tag
+          description: The admin who applied the tag. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           allOf:
             - "$ref": "#/components/schemas/reference"
     tag_basic:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -21772,12 +21772,12 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
           example: 1663597223
         applied_by:
           type: object
           nullable: true
-          description: The admin who applied the tag
+          description: The admin who applied the tag. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           allOf:
             - "$ref": "#/components/schemas/reference"
     tag_basic:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -21772,7 +21772,7 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           example: 1663597223
         applied_by:
           type: object

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -13981,7 +13981,7 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           example: 1663597223
         applied_by:
           type: object

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -13981,12 +13981,12 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
           example: 1663597223
         applied_by:
           type: object
           nullable: true
-          description: The admin who applied the tag
+          description: The admin who applied the tag. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           allOf:
             - "$ref": "#/components/schemas/reference"
     tag_basic:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -14004,12 +14004,12 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
           example: 1663597223
         applied_by:
           type: object
           nullable: true
-          description: The admin who applied the tag
+          description: The admin who applied the tag. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           allOf:
             - "$ref": "#/components/schemas/reference"
     tag_basic:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -14004,7 +14004,7 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           example: 1663597223
         applied_by:
           type: object

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -15358,12 +15358,12 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
           example: 1663597223
         applied_by:
           type: object
           nullable: true
-          description: The admin who applied the tag
+          description: The admin who applied the tag. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           allOf:
             - "$ref": "#/components/schemas/reference"
     tag_basic:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -15358,7 +15358,7 @@ components:
           type: integer
           format: date-time
           nullable: true
-          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket. Not included in direct tag lookups (GET /tags or GET /tags/{id}).
+          description: The time when the tag was applied to the object. Only present when the tag is returned as part of a tagging operation on a contact, conversation, or ticket.
           example: 1663597223
         applied_by:
           type: object


### PR DESCRIPTION
### Why?

Customers report confusion because the Tag schema on the docs page shows `applied_at` and `applied_by` fields, but these are absent from direct tag lookups (`GET /tags`, `GET /tags/{id}`). These fields are only populated when a tag is returned as part of a tagging operation on a contact, conversation, or ticket — the `tag` schema is used by attach/detach endpoints, while `tag_basic` (without these fields) is used by direct lookups.

- https://github.com/intercom/intercom/issues/283507

### How?

Updates the `applied_at` and `applied_by` descriptions in the `tag` component schema across all API versions to clarify they are context-dependent. No schema structure change — just improved descriptions.

> **Note:** This change needs to be manually synced to `intercom/developer-docs` after merge (the OpenAPI specs are copied manually per the developer-docs README).

<sub>Generated with Claude Code</sub>