### PR TITLE
Add display_avatar query param to GET /admins

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -501,6 +501,14 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: display_avatar
+        in: query
+        required: false
+        description: If set to true, the response will include the admin's avatar
+          object containing the image URL. Defaults to false.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Admins
       operationId: listAdmins

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -255,6 +255,14 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: display_avatar
+        in: query
+        required: false
+        description: If set to true, the response will include the admin's avatar
+          object containing the image URL. Defaults to false.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Admins
       operationId: listAdmins

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -255,6 +255,14 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: display_avatar
+        in: query
+        required: false
+        description: If set to true, the response will include the admin's avatar
+          object containing the image URL. Defaults to false.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Admins
       operationId: listAdmins

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -255,6 +255,14 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: display_avatar
+        in: query
+        required: false
+        description: If set to true, the response will include the admin's avatar
+          object containing the image URL. Defaults to false.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Admins
       operationId: listAdmins

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -255,6 +255,14 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: display_avatar
+        in: query
+        required: false
+        description: If set to true, the response will include the admin's avatar
+          object containing the image URL. Defaults to false.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Admins
       operationId: listAdmins

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -280,6 +280,14 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: display_avatar
+        in: query
+        required: false
+        description: If set to true, the response will include the admin's avatar
+          object containing the image URL. Defaults to false.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Admins
       operationId: listAdmins

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -280,6 +280,14 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: display_avatar
+        in: query
+        required: false
+        description: If set to true, the response will include the admin's avatar
+          object containing the image URL. Defaults to false.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Admins
       operationId: listAdmins

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -255,6 +255,14 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: display_avatar
+        in: query
+        required: false
+        description: If set to true, the response will include the admin's avatar
+          object containing the image URL. Defaults to false.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Admins
       operationId: listAdmins

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -255,6 +255,14 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: display_avatar
+        in: query
+        required: false
+        description: If set to true, the response will include the admin's avatar
+          object containing the image URL. Defaults to false.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Admins
       operationId: listAdmins

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -255,6 +255,14 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: display_avatar
+        in: query
+        required: false
+        description: If set to true, the response will include the admin's avatar
+          object containing the image URL. Defaults to false.
+        example: true
+        schema:
+          type: boolean
       tags:
       - Admins
       operationId: listAdmins


### PR DESCRIPTION
### Why?

The `display_avatar=true` query parameter on `GET /admins` has been supported since API version 1.0 but was never documented. This adds it to the OpenAPI spec so API consumers can discover it.

- https://github.com/intercom/intercom/issues/451466

### How?

Added an optional boolean `display_avatar` query parameter to the `GET /admins` operation in every version's spec file (2.7–2.15 and Unstable). When set to `true`, the response includes the avatar object with image URL. Defaults to `false`.

Companion PR:
- https://github.com/intercom/developer-docs/pull/841

<details>
<summary>Implementation Plan</summary>

# Plan: Add `display_avatar` Query Parameter to GET /admins — All Versions

## Context
The GET /admins (list admins) endpoint supports a `display_avatar` boolean query parameter. When set to `true`, the response includes the admin's avatar. This parameter is **not version-gated** and must be documented across **all** API versions in both the Intercom-OpenAPI spec and the developer-docs site.

## Summary: 32 files across 2 repos

| Repo | Format | Versions | File count |
|------|--------|----------|------------|
| Intercom-OpenAPI | YAML | 2.7–2.15, 0 (Unstable) | 10 |
| developer-docs | YAML | @2.7–@2.15, @Unstable | 9 |
| developer-docs | Markdown | @1.0–@2.6 | 13 |

## YAML files
All YAML files get the same parameter block inserted into the `parameters` array of `GET /admins`, after the existing `Intercom-Version` header param.

## Markdown files (developer-docs only)
- **v1.0–v1.4**: Replace `None.` under `### Request Parameters` with parameter table
- **v2.0–v2.5**: Add `### Request Query Parameters` section before `### Response`
- **v2.6**: Same as v2.0–v2.5, different filename (`list-all-admins.md`)

</details>

<sub>Generated with Claude Code</sub>