### PR TITLE
Fix conversation model assignee ID types to match API responses

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -6958,8 +6958,8 @@ paths:
                           id: 6762f0f31bb69f9f2193bb8b
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -7200,8 +7200,8 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -7377,8 +7377,8 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -7630,8 +7630,8 @@ paths:
                         id: 6762f1301bb69f9f2193bbab
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: true
@@ -7728,8 +7728,8 @@ paths:
                         id: 6762f1341bb69f9f2193bbac
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -7976,8 +7976,8 @@ paths:
         | source.url                                | String                                                                                                                                                 |
         | contact_ids                               | String                                                                                                                                                 |
         | teammate_ids                              | String                                                                                                                                                 |
-        | admin_assignee_id                         | String                                                                                                                                                 |
-        | team_assignee_id                          | String                                                                                                                                                 |
+        | admin_assignee_id                         | Integer                                                                                                                                                |
+        | team_assignee_id                          | Integer                                                                                                                                                |
         | channel_initiated                         | String                                                                                                                                                 |
         | open                                      | Boolean                                                                                                                                                |
         | read                                      | Boolean                                                                                                                                                |
@@ -8077,8 +8077,8 @@ paths:
                           id: 6762f14a1bb69f9f2193bbb3
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -8180,8 +8180,8 @@ paths:
                       created_at: 1734537561
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -8257,8 +8257,8 @@ paths:
                         id: 6762f15b1bb69f9f2193bbbc
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -8346,8 +8346,8 @@ paths:
                         id: 6762f15e1bb69f9f2193bbbd
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -8426,8 +8426,8 @@ paths:
                       created_at: 1734537572
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -8627,8 +8627,8 @@ paths:
                         id: 6762f16e1bb69f9f2193bbc2
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -8704,8 +8704,8 @@ paths:
                         id: 6762f1711bb69f9f2193bbc3
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: snoozed
                     read: false
@@ -8781,8 +8781,8 @@ paths:
                         id: 6762f1781bb69f9f2193bbc8
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: true
@@ -8859,7 +8859,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id:
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -9567,8 +9567,8 @@ paths:
                       created_at: 1734537722
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -20992,16 +20992,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         company:
           "$ref": "#/components/schemas/company"
           nullable: true
@@ -21106,16 +21104,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         company:
           "$ref": "#/components/schemas/company"
           nullable: true

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -6959,7 +6959,7 @@ paths:
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
-                      team_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -7200,7 +7200,7 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -7378,7 +7378,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -7630,7 +7630,7 @@ paths:
                         id: 6762f1301bb69f9f2193bbab
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -7729,7 +7729,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -8077,7 +8077,7 @@ paths:
                           id: 6762f14a1bb69f9f2193bbb3
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id: 0
+                      admin_assignee_id: 991267715
                       team_assignee_id: 5017691
                       open: false
                       state: closed
@@ -8181,7 +8181,7 @@ paths:
                       type: conversation
                       url:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -8257,7 +8257,7 @@ paths:
                         id: 6762f15b1bb69f9f2193bbbc
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -8347,7 +8347,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -8426,7 +8426,7 @@ paths:
                       created_at: 1734537572
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -8628,7 +8628,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -8704,7 +8704,7 @@ paths:
                         id: 6762f1711bb69f9f2193bbc3
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: snoozed
@@ -8782,7 +8782,7 @@ paths:
                         external_id: '74'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -8859,7 +8859,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -9567,7 +9567,7 @@ paths:
                       created_at: 1734537722
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -20992,13 +20992,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         company:
           "$ref": "#/components/schemas/company"
@@ -21104,13 +21106,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         company:
           "$ref": "#/components/schemas/company"

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -4294,8 +4294,8 @@ paths:
                           id: 6657ac736abd0166b52ae24e
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id: 991268010
-                      team_assignee_id: 0
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -4518,7 +4518,7 @@ paths:
                         id: 6657ac916abd0166b52ae26a
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -4654,8 +4654,8 @@ paths:
                         id: 6657ac966abd0166b52ae26e
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991268010
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: true
@@ -4923,7 +4923,7 @@ paths:
                           id: 6657aca16abd0166b52ae275
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id: 0
+                      admin_assignee_id: 991267715
                       team_assignee_id: 5017691
                       open: false
                       state: closed
@@ -5022,8 +5022,8 @@ paths:
                       created_at: 1717021866
                       type: conversation
                       url:
-                    admin_assignee_id: 991268010
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5108,7 +5108,7 @@ paths:
                         id: 6657acab6abd0166b52ae27e
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5193,8 +5193,8 @@ paths:
                       created_at: 1717021872
                       type: conversation
                       url:
-                    admin_assignee_id: 991268010
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5390,7 +5390,7 @@ paths:
                         id: 6657acb66abd0166b52ae284
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5460,8 +5460,8 @@ paths:
                         id: 6657acb86abd0166b52ae285
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991268010
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: snoozed
                     read: false
@@ -5530,7 +5530,7 @@ paths:
                         id: 6657acbb6abd0166b52ae28a
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -5601,7 +5601,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991268010
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5790,8 +5790,8 @@ paths:
                         id: 6657acc76abd0166b52ae292
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991268010
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6169,7 +6169,7 @@ paths:
                       created_at: 1717021953
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -12981,13 +12981,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -13080,13 +13082,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -4294,8 +4294,8 @@ paths:
                           id: 6657ac736abd0166b52ae24e
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991268010
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -4518,8 +4518,8 @@ paths:
                         id: 6657ac916abd0166b52ae26a
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -4654,8 +4654,8 @@ paths:
                         id: 6657ac966abd0166b52ae26e
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991268010
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -4822,8 +4822,8 @@ paths:
         | source.url                                | String                                                                                                                                                 |
         | contact_ids                               | String                                                                                                                                                 |
         | teammate_ids                              | String                                                                                                                                                 |
-        | admin_assignee_id                         | String                                                                                                                                                 |
-        | team_assignee_id                          | String                                                                                                                                                 |
+        | admin_assignee_id                         | Integer                                                                                                                                                |
+        | team_assignee_id                          | Integer                                                                                                                                                |
         | channel_initiated                         | String                                                                                                                                                 |
         | open                                      | Boolean                                                                                                                                                |
         | read                                      | Boolean                                                                                                                                                |
@@ -4923,8 +4923,8 @@ paths:
                           id: 6657aca16abd0166b52ae275
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -5022,8 +5022,8 @@ paths:
                       created_at: 1717021866
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991268010
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5108,8 +5108,8 @@ paths:
                         id: 6657acab6abd0166b52ae27e
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5193,8 +5193,8 @@ paths:
                       created_at: 1717021872
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991268010
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5390,8 +5390,8 @@ paths:
                         id: 6657acb66abd0166b52ae284
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5460,8 +5460,8 @@ paths:
                         id: 6657acb86abd0166b52ae285
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991268010
+                    team_assignee_id: 0
                     open: true
                     state: snoozed
                     read: false
@@ -5530,8 +5530,8 @@ paths:
                         id: 6657acbb6abd0166b52ae28a
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -5601,7 +5601,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991268010
-                    team_assignee_id:
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5790,8 +5790,8 @@ paths:
                         id: 6657acc76abd0166b52ae292
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991268010
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -6169,8 +6169,8 @@ paths:
                       created_at: 1717021953
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -12981,16 +12981,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:
@@ -13082,16 +13080,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -4392,8 +4392,8 @@ paths:
                           id: 667d60bb8a68186f43bafdc5
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id: 991267615
-                      team_assignee_id: 0
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -4619,7 +4619,7 @@ paths:
                         id: 667d60d88a68186f43bafde1
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -4758,8 +4758,8 @@ paths:
                         id: 667d60e08a68186f43bafde5
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267615
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: true
@@ -5038,7 +5038,7 @@ paths:
                           id: 667d60ea8a68186f43bafdec
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id: 0
+                      admin_assignee_id: 991267715
                       team_assignee_id: 5017691
                       open: false
                       state: closed
@@ -5140,8 +5140,8 @@ paths:
                       created_at: 1719492850
                       type: conversation
                       url:
-                    admin_assignee_id: 991267615
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5213,7 +5213,7 @@ paths:
                         id: 667d60f38a68186f43bafdf5
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5301,8 +5301,8 @@ paths:
                       created_at: 1719492856
                       type: conversation
                       url:
-                    admin_assignee_id: 991267615
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5485,7 +5485,7 @@ paths:
                         id: 667d60fd8a68186f43bafdfb
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5558,8 +5558,8 @@ paths:
                         id: 667d60ff8a68186f43bafdfc
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267615
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: snoozed
                     read: false
@@ -5631,7 +5631,7 @@ paths:
                         id: 667d61038a68186f43bafe01
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -5705,7 +5705,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267615
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5897,8 +5897,8 @@ paths:
                         id: 667d61108a68186f43bafe09
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267615
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6279,7 +6279,7 @@ paths:
                       created_at: 1719492939
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -13703,13 +13703,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -13831,13 +13833,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -4392,8 +4392,8 @@ paths:
                           id: 667d60bb8a68186f43bafdc5
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991267615
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -4619,8 +4619,8 @@ paths:
                         id: 667d60d88a68186f43bafde1
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -4758,8 +4758,8 @@ paths:
                         id: 667d60e08a68186f43bafde5
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267615
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -4937,8 +4937,8 @@ paths:
         | source.url                                | String                                                                                                                                                 |
         | contact_ids                               | String                                                                                                                                                 |
         | teammate_ids                              | String                                                                                                                                                 |
-        | admin_assignee_id                         | String                                                                                                                                                 |
-        | team_assignee_id                          | String                                                                                                                                                 |
+        | admin_assignee_id                         | Integer                                                                                                                                                |
+        | team_assignee_id                          | Integer                                                                                                                                                |
         | channel_initiated                         | String                                                                                                                                                 |
         | open                                      | Boolean                                                                                                                                                |
         | read                                      | Boolean                                                                                                                                                |
@@ -5038,8 +5038,8 @@ paths:
                           id: 667d60ea8a68186f43bafdec
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -5140,8 +5140,8 @@ paths:
                       created_at: 1719492850
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267615
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5213,8 +5213,8 @@ paths:
                         id: 667d60f38a68186f43bafdf5
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5301,8 +5301,8 @@ paths:
                       created_at: 1719492856
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267615
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5485,8 +5485,8 @@ paths:
                         id: 667d60fd8a68186f43bafdfb
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5558,8 +5558,8 @@ paths:
                         id: 667d60ff8a68186f43bafdfc
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267615
+                    team_assignee_id: 0
                     open: true
                     state: snoozed
                     read: false
@@ -5631,8 +5631,8 @@ paths:
                         id: 667d61038a68186f43bafe01
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -5705,7 +5705,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267615
-                    team_assignee_id:
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5897,8 +5897,8 @@ paths:
                         id: 667d61108a68186f43bafe09
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267615
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -6279,8 +6279,8 @@ paths:
                       created_at: 1719492939
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -13703,16 +13703,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:
@@ -13833,16 +13831,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -4908,8 +4908,8 @@ paths:
                           id: 677c55676abd011ad17ff4f8
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991266468
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -5134,8 +5134,8 @@ paths:
                         id: 677c55916abd011ad17ff514
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5273,8 +5273,8 @@ paths:
                         id: 677c559a6abd011ad17ff518
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266468
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -5361,8 +5361,8 @@ paths:
                         id: 677c559d6abd011ad17ff519
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5499,8 +5499,8 @@ paths:
         | source.url                                | String                                                                                                                                                 |
         | contact_ids                               | String                                                                                                                                                 |
         | teammate_ids                              | String                                                                                                                                                 |
-        | admin_assignee_id                         | String                                                                                                                                                 |
-        | team_assignee_id                          | String                                                                                                                                                 |
+        | admin_assignee_id                         | Integer                                                                                                                                                |
+        | team_assignee_id                          | Integer                                                                                                                                                |
         | channel_initiated                         | String                                                                                                                                                 |
         | open                                      | Boolean                                                                                                                                                |
         | read                                      | Boolean                                                                                                                                                |
@@ -5600,8 +5600,8 @@ paths:
                           id: 677c55ae6abd011ad17ff520
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991266468
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -5701,8 +5701,8 @@ paths:
                       created_at: 1736201658
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5773,8 +5773,8 @@ paths:
                         id: 677c55bc6abd011ad17ff529
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266468
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -5860,8 +5860,8 @@ paths:
                       created_at: 1736201667
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -6043,8 +6043,8 @@ paths:
                         id: 677c55cb6abd011ad17ff52f
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266468
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -6115,8 +6115,8 @@ paths:
                         id: 677c55ce6abd011ad17ff530
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: snoozed
                     read: false
@@ -6187,8 +6187,8 @@ paths:
                         id: 677c55d56abd011ad17ff535
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266468
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: true
@@ -6260,7 +6260,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991266468
-                    team_assignee_id:
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -6682,8 +6682,8 @@ paths:
                       created_at: 1736201783
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -14024,16 +14024,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:
@@ -14132,16 +14130,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -4908,8 +4908,8 @@ paths:
                           id: 677c55676abd011ad17ff4f8
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id: 991266468
-                      team_assignee_id: 0
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -5134,7 +5134,7 @@ paths:
                         id: 677c55916abd011ad17ff514
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5273,8 +5273,8 @@ paths:
                         id: 677c559a6abd011ad17ff518
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991266468
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: true
@@ -5361,7 +5361,7 @@ paths:
                         id: 677c559d6abd011ad17ff519
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5600,8 +5600,8 @@ paths:
                           id: 677c55ae6abd011ad17ff520
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id: 991266468
-                      team_assignee_id: 0
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -5701,7 +5701,7 @@ paths:
                       created_at: 1736201658
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -5773,8 +5773,8 @@ paths:
                         id: 677c55bc6abd011ad17ff529
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991266468
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5860,7 +5860,7 @@ paths:
                       created_at: 1736201667
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -6043,8 +6043,8 @@ paths:
                         id: 677c55cb6abd011ad17ff52f
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991266468
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6115,7 +6115,7 @@ paths:
                         id: 677c55ce6abd011ad17ff530
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: snoozed
@@ -6187,8 +6187,8 @@ paths:
                         id: 677c55d56abd011ad17ff535
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id: 991266468
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -6260,7 +6260,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991266468
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -6682,7 +6682,7 @@ paths:
                       created_at: 1736201783
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -14024,13 +14024,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -14130,13 +14132,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -5579,8 +5579,8 @@ paths:
                           id: 677c55676abd011ad17ff4f8
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -5805,8 +5805,8 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6057,8 +6057,8 @@ paths:
                         id: 6762f1301bb69f9f2193bbab
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -6154,8 +6154,8 @@ paths:
                         id: 6762f1341bb69f9f2193bbac
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6382,8 +6382,8 @@ paths:
         | source.url                                | String                                                                                                                                                 |
         | contact_ids                               | String                                                                                                                                                 |
         | teammate_ids                              | String                                                                                                                                                 |
-        | admin_assignee_id                         | String                                                                                                                                                 |
-        | team_assignee_id                          | String                                                                                                                                                 |
+        | admin_assignee_id                         | Integer                                                                                                                                                |
+        | team_assignee_id                          | Integer                                                                                                                                                |
         | channel_initiated                         | String                                                                                                                                                 |
         | open                                      | Boolean                                                                                                                                                |
         | read                                      | Boolean                                                                                                                                                |
@@ -6483,8 +6483,8 @@ paths:
                           id: 677c55ae6abd011ad17ff520
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -6584,8 +6584,8 @@ paths:
                       created_at: 1734537561
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -6660,8 +6660,8 @@ paths:
                         id: 6762f15b1bb69f9f2193bbbc
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -6748,8 +6748,8 @@ paths:
                         id: 6762f15e1bb69f9f2193bbbd
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6827,8 +6827,8 @@ paths:
                       created_at: 1734537572
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -7014,8 +7014,8 @@ paths:
                         id: 6762f16e1bb69f9f2193bbc2
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -7090,8 +7090,8 @@ paths:
                         id: 6762f1711bb69f9f2193bbc3
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: snoozed
                     read: false
@@ -7166,8 +7166,8 @@ paths:
                         id: 6762f1781bb69f9f2193bbc8
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -7243,7 +7243,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id:
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -7669,8 +7669,8 @@ paths:
                       created_at: 1734537722
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: true
@@ -15390,16 +15390,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:
@@ -15498,16 +15496,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -5580,7 +5580,7 @@ paths:
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
-                      team_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -5805,7 +5805,7 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -6058,7 +6058,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: true
@@ -6154,7 +6154,7 @@ paths:
                         id: 6762f1341bb69f9f2193bbac
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -6484,7 +6484,7 @@ paths:
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
-                      team_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -6584,7 +6584,7 @@ paths:
                       created_at: 1734537561
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -6661,7 +6661,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6748,7 +6748,7 @@ paths:
                         id: 6762f15e1bb69f9f2193bbbd
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -6828,7 +6828,7 @@ paths:
                       type: conversation
                       url:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -7014,7 +7014,7 @@ paths:
                         id: 6762f16e1bb69f9f2193bbc2
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -7091,7 +7091,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: snoozed
                     read: false
@@ -7166,7 +7166,7 @@ paths:
                         id: 6762f1781bb69f9f2193bbc8
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -7243,7 +7243,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -7670,7 +7670,7 @@ paths:
                       type: conversation
                       url:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -15390,13 +15390,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -15496,13 +15498,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -6039,7 +6039,7 @@ paths:
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
-                      team_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -6272,7 +6272,7 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -6525,7 +6525,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: true
@@ -6621,7 +6621,7 @@ paths:
                         id: 6762f1341bb69f9f2193bbac
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -6951,7 +6951,7 @@ paths:
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
-                      team_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -7052,7 +7052,7 @@ paths:
                       created_at: 1734537561
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -7129,7 +7129,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -7216,7 +7216,7 @@ paths:
                         id: 6762f15e1bb69f9f2193bbbd
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -7296,7 +7296,7 @@ paths:
                       type: conversation
                       url:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -7495,7 +7495,7 @@ paths:
                         id: 6762f16e1bb69f9f2193bbc2
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -7572,7 +7572,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: snoozed
                     read: false
@@ -7647,7 +7647,7 @@ paths:
                         id: 6762f1781bb69f9f2193bbc8
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -7724,7 +7724,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -8151,7 +8151,7 @@ paths:
                       type: conversation
                       url:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -16770,13 +16770,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -16878,13 +16880,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -6038,8 +6038,8 @@ paths:
                           id: 6762f0f31bb69f9f2193bb8b
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -6272,8 +6272,8 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6524,8 +6524,8 @@ paths:
                         id: 6762f1301bb69f9f2193bbab
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -6621,8 +6621,8 @@ paths:
                         id: 6762f1341bb69f9f2193bbac
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6849,8 +6849,8 @@ paths:
         | source.url                                | String                                                                                                                                                 |
         | contact_ids                               | String                                                                                                                                                 |
         | teammate_ids                              | String                                                                                                                                                 |
-        | admin_assignee_id                         | String                                                                                                                                                 |
-        | team_assignee_id                          | String                                                                                                                                                 |
+        | admin_assignee_id                         | Integer                                                                                                                                                |
+        | team_assignee_id                          | Integer                                                                                                                                                |
         | channel_initiated                         | String                                                                                                                                                 |
         | open                                      | Boolean                                                                                                                                                |
         | read                                      | Boolean                                                                                                                                                |
@@ -6950,8 +6950,8 @@ paths:
                           id: 6762f14a1bb69f9f2193bbb3
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -7052,8 +7052,8 @@ paths:
                       created_at: 1734537561
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -7128,8 +7128,8 @@ paths:
                         id: 6762f15b1bb69f9f2193bbbc
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -7216,8 +7216,8 @@ paths:
                         id: 6762f15e1bb69f9f2193bbbd
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -7295,8 +7295,8 @@ paths:
                       created_at: 1734537572
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -7495,8 +7495,8 @@ paths:
                         id: 6762f16e1bb69f9f2193bbc2
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -7571,8 +7571,8 @@ paths:
                         id: 6762f1711bb69f9f2193bbc3
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: snoozed
                     read: false
@@ -7647,8 +7647,8 @@ paths:
                         id: 6762f1781bb69f9f2193bbc8
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -7724,7 +7724,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id:
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -8150,8 +8150,8 @@ paths:
                       created_at: 1734537722
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: true
@@ -16770,16 +16770,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:
@@ -16880,16 +16878,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -6110,7 +6110,7 @@ paths:
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
-                      team_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -6343,7 +6343,7 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -6596,7 +6596,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: true
@@ -6692,7 +6692,7 @@ paths:
                         id: 6762f1341bb69f9f2193bbac
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -7022,7 +7022,7 @@ paths:
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
-                      team_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -7123,7 +7123,7 @@ paths:
                       created_at: 1734537561
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -7200,7 +7200,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -7287,7 +7287,7 @@ paths:
                         id: 6762f15e1bb69f9f2193bbbd
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -7367,7 +7367,7 @@ paths:
                       type: conversation
                       url:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -7566,7 +7566,7 @@ paths:
                         id: 6762f16e1bb69f9f2193bbc2
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -7643,7 +7643,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: snoozed
                     read: false
@@ -7718,7 +7718,7 @@ paths:
                         id: 6762f1781bb69f9f2193bbc8
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -7795,7 +7795,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -8222,7 +8222,7 @@ paths:
                       type: conversation
                       url:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -17486,13 +17486,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         company:
           "$ref": "#/components/schemas/company"
@@ -17598,13 +17600,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         company:
           "$ref": "#/components/schemas/company"

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -6109,8 +6109,8 @@ paths:
                           id: 6762f0f31bb69f9f2193bb8b
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -6343,8 +6343,8 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6595,8 +6595,8 @@ paths:
                         id: 6762f1301bb69f9f2193bbab
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -6692,8 +6692,8 @@ paths:
                         id: 6762f1341bb69f9f2193bbac
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6920,8 +6920,8 @@ paths:
         | source.url                                | String                                                                                                                                                 |
         | contact_ids                               | String                                                                                                                                                 |
         | teammate_ids                              | String                                                                                                                                                 |
-        | admin_assignee_id                         | String                                                                                                                                                 |
-        | team_assignee_id                          | String                                                                                                                                                 |
+        | admin_assignee_id                         | Integer                                                                                                                                                |
+        | team_assignee_id                          | Integer                                                                                                                                                |
         | channel_initiated                         | String                                                                                                                                                 |
         | open                                      | Boolean                                                                                                                                                |
         | read                                      | Boolean                                                                                                                                                |
@@ -7021,8 +7021,8 @@ paths:
                           id: 6762f14a1bb69f9f2193bbb3
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -7123,8 +7123,8 @@ paths:
                       created_at: 1734537561
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -7199,8 +7199,8 @@ paths:
                         id: 6762f15b1bb69f9f2193bbbc
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -7287,8 +7287,8 @@ paths:
                         id: 6762f15e1bb69f9f2193bbbd
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -7366,8 +7366,8 @@ paths:
                       created_at: 1734537572
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -7566,8 +7566,8 @@ paths:
                         id: 6762f16e1bb69f9f2193bbc2
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -7642,8 +7642,8 @@ paths:
                         id: 6762f1711bb69f9f2193bbc3
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: snoozed
                     read: false
@@ -7718,8 +7718,8 @@ paths:
                         id: 6762f1781bb69f9f2193bbc8
                         external_id: '74'
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -7795,7 +7795,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id:
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -8221,8 +8221,8 @@ paths:
                       created_at: 1734537722
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: true
@@ -17486,16 +17486,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         company:
           "$ref": "#/components/schemas/company"
           nullable: true
@@ -17600,16 +17598,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         company:
           "$ref": "#/components/schemas/company"
           nullable: true

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -4509,8 +4509,8 @@ paths:
                         - type: contact
                           id: 6657a8436abd0160d35d1eaa
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991266448
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -4726,8 +4726,8 @@ paths:
                       - type: contact
                         id: 6657a8606abd0160d35d1ec6
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -4855,8 +4855,8 @@ paths:
                       - type: contact
                         id: 6657a8676abd0160d35d1eca
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266448
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -5017,8 +5017,8 @@ paths:
         | source.url                                | String                                                                                                                                                 |
         | contact_ids                               | String                                                                                                                                                 |
         | teammate_ids                              | String                                                                                                                                                 |
-        | admin_assignee_id                         | String                                                                                                                                                 |
-        | team_assignee_id                          | String                                                                                                                                                 |
+        | admin_assignee_id                         | Integer                                                                                                                                                |
+        | team_assignee_id                          | Integer                                                                                                                                                |
         | channel_initiated                         | String                                                                                                                                                 |
         | open                                      | Boolean                                                                                                                                                |
         | read                                      | Boolean                                                                                                                                                |
@@ -5117,8 +5117,8 @@ paths:
                         - type: contact
                           id: 6657a8716abd0160d35d1ed1
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -5209,8 +5209,8 @@ paths:
                       created_at: 1717020794
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266448
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5288,8 +5288,8 @@ paths:
                       - type: contact
                         id: 6657a87b6abd0160d35d1eda
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5366,8 +5366,8 @@ paths:
                       created_at: 1717020800
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266448
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5556,8 +5556,8 @@ paths:
                       - type: contact
                         id: 6657a8866abd0160d35d1ee0
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5619,8 +5619,8 @@ paths:
                       - type: contact
                         id: 6657a8876abd0160d35d1ee1
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266448
+                    team_assignee_id: 0
                     open: true
                     state: snoozed
                     read: false
@@ -5682,8 +5682,8 @@ paths:
                       - type: contact
                         id: 6657a88c6abd0160d35d1ee6
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -5746,7 +5746,7 @@ paths:
                         id: 6657a8916abd0160d35d1eea
                     first_contact_reply:
                     admin_assignee_id: 991266448
-                    team_assignee_id:
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5928,8 +5928,8 @@ paths:
                       - type: contact
                         id: 6657a8976abd0160d35d1eee
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266448
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -6300,8 +6300,8 @@ paths:
                       created_at: 1717020881
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -11086,16 +11086,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:
@@ -11185,16 +11183,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -4509,8 +4509,8 @@ paths:
                         - type: contact
                           id: 6657a8436abd0160d35d1eaa
                       first_contact_reply:
-                      admin_assignee_id: 991266448
-                      team_assignee_id: 0
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -4726,7 +4726,7 @@ paths:
                       - type: contact
                         id: 6657a8606abd0160d35d1ec6
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -4855,8 +4855,8 @@ paths:
                       - type: contact
                         id: 6657a8676abd0160d35d1eca
                     first_contact_reply:
-                    admin_assignee_id: 991266448
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: true
@@ -5117,7 +5117,7 @@ paths:
                         - type: contact
                           id: 6657a8716abd0160d35d1ed1
                       first_contact_reply:
-                      admin_assignee_id: 0
+                      admin_assignee_id: 991267715
                       team_assignee_id: 5017691
                       open: false
                       state: closed
@@ -5209,8 +5209,8 @@ paths:
                       created_at: 1717020794
                       type: conversation
                       url:
-                    admin_assignee_id: 991266448
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5288,7 +5288,7 @@ paths:
                       - type: contact
                         id: 6657a87b6abd0160d35d1eda
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5366,8 +5366,8 @@ paths:
                       created_at: 1717020800
                       type: conversation
                       url:
-                    admin_assignee_id: 991266448
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5556,7 +5556,7 @@ paths:
                       - type: contact
                         id: 6657a8866abd0160d35d1ee0
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5619,8 +5619,8 @@ paths:
                       - type: contact
                         id: 6657a8876abd0160d35d1ee1
                     first_contact_reply:
-                    admin_assignee_id: 991266448
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: snoozed
                     read: false
@@ -5682,7 +5682,7 @@ paths:
                       - type: contact
                         id: 6657a88c6abd0160d35d1ee6
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -5746,7 +5746,7 @@ paths:
                         id: 6657a8916abd0160d35d1eea
                     first_contact_reply:
                     admin_assignee_id: 991266448
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5928,8 +5928,8 @@ paths:
                       - type: contact
                         id: 6657a8976abd0160d35d1eee
                     first_contact_reply:
-                    admin_assignee_id: 991266448
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6300,7 +6300,7 @@ paths:
                       created_at: 1717020881
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -11086,13 +11086,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -11183,13 +11185,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -4509,8 +4509,8 @@ paths:
                         - type: contact
                           id: 6657a99e6abd01639cc9e9ab
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991266962
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -4726,8 +4726,8 @@ paths:
                       - type: contact
                         id: 6657a9bb6abd01639cc9e9c7
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -4855,8 +4855,8 @@ paths:
                       - type: contact
                         id: 6657a9c16abd01639cc9e9cb
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266962
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -5017,8 +5017,8 @@ paths:
         | source.url                                | String                                                                                                                                                 |
         | contact_ids                               | String                                                                                                                                                 |
         | teammate_ids                              | String                                                                                                                                                 |
-        | admin_assignee_id                         | String                                                                                                                                                 |
-        | team_assignee_id                          | String                                                                                                                                                 |
+        | admin_assignee_id                         | Integer                                                                                                                                                |
+        | team_assignee_id                          | Integer                                                                                                                                                |
         | channel_initiated                         | String                                                                                                                                                 |
         | open                                      | Boolean                                                                                                                                                |
         | read                                      | Boolean                                                                                                                                                |
@@ -5117,8 +5117,8 @@ paths:
                         - type: contact
                           id: 6657a9cc6abd01639cc9e9d2
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -5209,8 +5209,8 @@ paths:
                       created_at: 1717021140
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266962
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5288,8 +5288,8 @@ paths:
                       - type: contact
                         id: 6657a9d66abd01639cc9e9db
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5366,8 +5366,8 @@ paths:
                       created_at: 1717021146
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266962
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5556,8 +5556,8 @@ paths:
                       - type: contact
                         id: 6657a9df6abd01639cc9e9e1
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5619,8 +5619,8 @@ paths:
                       - type: contact
                         id: 6657a9e16abd01639cc9e9e2
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266962
+                    team_assignee_id: 0
                     open: true
                     state: snoozed
                     read: false
@@ -5682,8 +5682,8 @@ paths:
                       - type: contact
                         id: 6657a9e46abd01639cc9e9e7
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -5746,7 +5746,7 @@ paths:
                         id: 6657a9eb6abd01639cc9e9eb
                     first_contact_reply:
                     admin_assignee_id: 991266962
-                    team_assignee_id:
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5928,8 +5928,8 @@ paths:
                       - type: contact
                         id: 6657a9f16abd01639cc9e9ef
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991266962
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -6300,8 +6300,8 @@ paths:
                       created_at: 1717021225
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -11110,16 +11110,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:
@@ -11209,16 +11207,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -4509,8 +4509,8 @@ paths:
                         - type: contact
                           id: 6657a99e6abd01639cc9e9ab
                       first_contact_reply:
-                      admin_assignee_id: 991266962
-                      team_assignee_id: 0
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -4726,7 +4726,7 @@ paths:
                       - type: contact
                         id: 6657a9bb6abd01639cc9e9c7
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -4855,8 +4855,8 @@ paths:
                       - type: contact
                         id: 6657a9c16abd01639cc9e9cb
                     first_contact_reply:
-                    admin_assignee_id: 991266962
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: true
@@ -5117,7 +5117,7 @@ paths:
                         - type: contact
                           id: 6657a9cc6abd01639cc9e9d2
                       first_contact_reply:
-                      admin_assignee_id: 0
+                      admin_assignee_id: 991267715
                       team_assignee_id: 5017691
                       open: false
                       state: closed
@@ -5209,8 +5209,8 @@ paths:
                       created_at: 1717021140
                       type: conversation
                       url:
-                    admin_assignee_id: 991266962
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5288,7 +5288,7 @@ paths:
                       - type: contact
                         id: 6657a9d66abd01639cc9e9db
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5366,8 +5366,8 @@ paths:
                       created_at: 1717021146
                       type: conversation
                       url:
-                    admin_assignee_id: 991266962
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5556,7 +5556,7 @@ paths:
                       - type: contact
                         id: 6657a9df6abd01639cc9e9e1
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5619,8 +5619,8 @@ paths:
                       - type: contact
                         id: 6657a9e16abd01639cc9e9e2
                     first_contact_reply:
-                    admin_assignee_id: 991266962
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: snoozed
                     read: false
@@ -5682,7 +5682,7 @@ paths:
                       - type: contact
                         id: 6657a9e46abd01639cc9e9e7
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -5746,7 +5746,7 @@ paths:
                         id: 6657a9eb6abd01639cc9e9eb
                     first_contact_reply:
                     admin_assignee_id: 991266962
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5928,8 +5928,8 @@ paths:
                       - type: contact
                         id: 6657a9f16abd01639cc9e9ef
                     first_contact_reply:
-                    admin_assignee_id: 991266962
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6300,7 +6300,7 @@ paths:
                       created_at: 1717021225
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -11110,13 +11110,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -11207,13 +11209,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -4509,8 +4509,8 @@ paths:
                         - type: contact
                           id: 6657aafb6abd0164c24b0d35
                       first_contact_reply:
-                      admin_assignee_id: 991267476
-                      team_assignee_id: 0
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -4727,7 +4727,7 @@ paths:
                       - type: contact
                         id: 6657ab176abd0164c24b0d51
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -4857,8 +4857,8 @@ paths:
                       - type: contact
                         id: 6657ab1d6abd0164c24b0d55
                     first_contact_reply:
-                    admin_assignee_id: 991267476
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: true
@@ -5120,7 +5120,7 @@ paths:
                         - type: contact
                           id: 6657ab286abd0164c24b0d5c
                       first_contact_reply:
-                      admin_assignee_id: 0
+                      admin_assignee_id: 991267715
                       team_assignee_id: 5017691
                       open: false
                       state: closed
@@ -5213,8 +5213,8 @@ paths:
                       created_at: 1717021488
                       type: conversation
                       url:
-                    admin_assignee_id: 991267476
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5293,7 +5293,7 @@ paths:
                       - type: contact
                         id: 6657ab326abd0164c24b0d65
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5372,8 +5372,8 @@ paths:
                       created_at: 1717021494
                       type: conversation
                       url:
-                    admin_assignee_id: 991267476
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5563,7 +5563,7 @@ paths:
                       - type: contact
                         id: 6657ab3c6abd0164c24b0d6b
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5627,8 +5627,8 @@ paths:
                       - type: contact
                         id: 6657ab3e6abd0164c24b0d6c
                     first_contact_reply:
-                    admin_assignee_id: 991267476
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: true
                     state: snoozed
                     read: false
@@ -5691,7 +5691,7 @@ paths:
                       - type: contact
                         id: 6657ab426abd0164c24b0d71
                     first_contact_reply:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -5756,7 +5756,7 @@ paths:
                         id: 6657ab496abd0164c24b0d75
                     first_contact_reply:
                     admin_assignee_id: 991267476
-                    team_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: false
@@ -5939,8 +5939,8 @@ paths:
                       - type: contact
                         id: 6657ab4f6abd0164c24b0d79
                     first_contact_reply:
-                    admin_assignee_id: 991267476
-                    team_assignee_id: 0
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -6312,7 +6312,7 @@ paths:
                       created_at: 1717021580
                       type: conversation
                       url:
-                    admin_assignee_id: 0
+                    admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -12290,13 +12290,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -12387,13 +12389,15 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
+          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return 0.
+            assigned to an admin it will return null.
           example: 0
         team_assignee_id:
           type: integer
+          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return 0.
+            assigned to a team it will return null.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -4509,8 +4509,8 @@ paths:
                         - type: contact
                           id: 6657aafb6abd0164c24b0d35
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 991267476
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -4727,8 +4727,8 @@ paths:
                       - type: contact
                         id: 6657ab176abd0164c24b0d51
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -4857,8 +4857,8 @@ paths:
                       - type: contact
                         id: 6657ab1d6abd0164c24b0d55
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267476
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -5020,8 +5020,8 @@ paths:
         | source.url                                | String                                                                                                                                                 |
         | contact_ids                               | String                                                                                                                                                 |
         | teammate_ids                              | String                                                                                                                                                 |
-        | admin_assignee_id                         | String                                                                                                                                                 |
-        | team_assignee_id                          | String                                                                                                                                                 |
+        | admin_assignee_id                         | Integer                                                                                                                                                |
+        | team_assignee_id                          | Integer                                                                                                                                                |
         | channel_initiated                         | String                                                                                                                                                 |
         | open                                      | Boolean                                                                                                                                                |
         | read                                      | Boolean                                                                                                                                                |
@@ -5120,8 +5120,8 @@ paths:
                         - type: contact
                           id: 6657ab286abd0164c24b0d5c
                       first_contact_reply:
-                      admin_assignee_id:
-                      team_assignee_id:
+                      admin_assignee_id: 0
+                      team_assignee_id: 5017691
                       open: false
                       state: closed
                       read: false
@@ -5213,8 +5213,8 @@ paths:
                       created_at: 1717021488
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267476
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5293,8 +5293,8 @@ paths:
                       - type: contact
                         id: 6657ab326abd0164c24b0d65
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5372,8 +5372,8 @@ paths:
                       created_at: 1717021494
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267476
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5563,8 +5563,8 @@ paths:
                       - type: contact
                         id: 6657ab3c6abd0164c24b0d6b
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: false
                     state: closed
                     read: false
@@ -5627,8 +5627,8 @@ paths:
                       - type: contact
                         id: 6657ab3e6abd0164c24b0d6c
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267476
+                    team_assignee_id: 0
                     open: true
                     state: snoozed
                     read: false
@@ -5691,8 +5691,8 @@ paths:
                       - type: contact
                         id: 6657ab426abd0164c24b0d71
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -5756,7 +5756,7 @@ paths:
                         id: 6657ab496abd0164c24b0d75
                     first_contact_reply:
                     admin_assignee_id: 991267476
-                    team_assignee_id:
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -5939,8 +5939,8 @@ paths:
                       - type: contact
                         id: 6657ab4f6abd0164c24b0d79
                     first_contact_reply:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 991267476
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -6312,8 +6312,8 @@ paths:
                       created_at: 1717021580
                       type: conversation
                       url:
-                    admin_assignee_id:
-                    team_assignee_id:
+                    admin_assignee_id: 0
+                    team_assignee_id: 5017691
                     open: true
                     state: open
                     read: true
@@ -12290,16 +12290,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:
@@ -12389,16 +12387,14 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
-          type: string
-          nullable: true
+          type: integer
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
-          example: '5017691'
+            assigned to a team it will return 0.
+          example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
         conversation_rating:


### PR DESCRIPTION
# Why?

[Towards Dev Rel PQ](https://app.intercom.com/a/inbox/tx2p130c/inbox/team/5826718/conversation/215473886392040?view=List) 

The conversations API (GET /:id, GET /all, POST /search) returns `admin_assignee_id` and `team_assignee_id` as integers. However, the docs had `team_assignee_id` typed as `string` and search tables listing both as `String`. The tickets API correctly returns these as strings and its docs are accurate, this PR consolidates the conversation model to match the actual API behavior.

# How?

- Updated `team_assignee_id` to `integer` type
- fixed search table types from `String` to `Integer`, and 
- added alternating integer/zero example values in response examples — all scoped to the conversation model across every version (@2.7 through @Preview). Ticket model is intentionally unchanged.


Mirrors intercom/developer-docs#842.

<sub>Generated with Claude Code</sub>