### PR TITLE
Document merged contacts behavior in Contacts API

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -5572,7 +5572,12 @@ paths:
       tags:
       - Contacts
       operationId: ShowContact
-      description: You can fetch the details of a single contact.
+      description: |
+        You can fetch the details of a single contact.
+
+        {% admonition type="warning" name="Merged contacts" %}
+          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -5740,8 +5745,17 @@ paths:
       tags:
       - Contacts
       operationId: MergeContact
-      description: You can merge a contact with a `role` of `lead` into a contact
-        with a `role` of `user`.
+      description: |
+        You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.
+
+        {% admonition type="warning" name="Merged contacts are not retrievable via the API" %}
+          Once a merge is completed, the source contact (`from`) is permanently removed from the active contact list. This means:
+          - **GET /contacts/{id}** — Requesting the source contact by its original ID will return a `404 Not Found` error.
+          - **POST /contacts/search** — The source contact will not appear in search results, including queries filtered by `updated_at`.
+          - **GET /contacts** — The source contact will not appear in list results.
+
+          Only the target contact (`into`) remains accessible. If your application stores contact IDs, update them to use the target contact's ID after a merge.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -5895,6 +5909,10 @@ paths:
           pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.
         {% /admonition %}
+        ### Merged Contacts
+
+        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+
         ### Contact Creation Delay
 
         If a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.
@@ -6045,6 +6063,9 @@ paths:
       operationId: ListContacts
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
+        {% admonition type="info" name="Merged contacts" %}
+          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+        {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -5576,7 +5576,7 @@ paths:
         You can fetch the details of a single contact.
 
         {% admonition type="warning" name="Merged contacts" %}
-          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+          If a contact has been merged into another contact via the Merge endpoint (POST /contacts/merge), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
         {% /admonition %}
       responses:
         '200':
@@ -5911,7 +5911,7 @@ paths:
         {% /admonition %}
         ### Merged Contacts
 
-        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+        Contacts that have been merged (via POST /contacts/merge) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
 
         ### Contact Creation Delay
 
@@ -6064,7 +6064,7 @@ paths:
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
         {% admonition type="info" name="Merged contacts" %}
-          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+          Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -3326,7 +3326,7 @@ paths:
         You can fetch the details of a single contact.
 
         {% admonition type="warning" name="Merged contacts" %}
-          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+          If a contact has been merged into another contact via the Merge endpoint (POST /contacts/merge), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
         {% /admonition %}
       responses:
         '200':
@@ -3650,7 +3650,7 @@ paths:
         {% /admonition %}
         ### Merged Contacts
 
-        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+        Contacts that have been merged (via POST /contacts/merge) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
 
         ### Contact Creation Delay
 
@@ -3802,7 +3802,7 @@ paths:
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
         {% admonition type="info" name="Merged contacts" %}
-          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+          Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -3322,7 +3322,12 @@ paths:
       tags:
       - Contacts
       operationId: ShowContact
-      description: You can fetch the details of a single contact.
+      description: |
+        You can fetch the details of a single contact.
+
+        {% admonition type="warning" name="Merged contacts" %}
+          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -3488,8 +3493,17 @@ paths:
       tags:
       - Contacts
       operationId: MergeContact
-      description: You can merge a contact with a `role` of `lead` into a contact
-        with a `role` of `user`.
+      description: |
+        You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.
+
+        {% admonition type="warning" name="Merged contacts are not retrievable via the API" %}
+          Once a merge is completed, the source contact (`from`) is permanently removed from the active contact list. This means:
+          - **GET /contacts/{id}** — Requesting the source contact by its original ID will return a `404 Not Found` error.
+          - **POST /contacts/search** — The source contact will not appear in search results, including queries filtered by `updated_at`.
+          - **GET /contacts** — The source contact will not appear in list results.
+
+          Only the target contact (`into`) remains accessible. If your application stores contact IDs, update them to use the target contact's ID after a merge.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -3634,6 +3648,10 @@ paths:
           pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.
         {% /admonition %}
+        ### Merged Contacts
+
+        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+
         ### Contact Creation Delay
 
         If a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.
@@ -3783,6 +3801,9 @@ paths:
       operationId: ListContacts
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
+        {% admonition type="info" name="Merged contacts" %}
+          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+        {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -3401,7 +3401,12 @@ paths:
       tags:
       - Contacts
       operationId: ShowContact
-      description: You can fetch the details of a single contact.
+      description: |
+        You can fetch the details of a single contact.
+
+        {% admonition type="warning" name="Merged contacts" %}
+          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -3567,8 +3572,17 @@ paths:
       tags:
       - Contacts
       operationId: MergeContact
-      description: You can merge a contact with a `role` of `lead` into a contact
-        with a `role` of `user`.
+      description: |
+        You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.
+
+        {% admonition type="warning" name="Merged contacts are not retrievable via the API" %}
+          Once a merge is completed, the source contact (`from`) is permanently removed from the active contact list. This means:
+          - **GET /contacts/{id}** — Requesting the source contact by its original ID will return a `404 Not Found` error.
+          - **POST /contacts/search** — The source contact will not appear in search results, including queries filtered by `updated_at`.
+          - **GET /contacts** — The source contact will not appear in list results.
+
+          Only the target contact (`into`) remains accessible. If your application stores contact IDs, update them to use the target contact's ID after a merge.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -3713,6 +3727,10 @@ paths:
           pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.
         {% /admonition %}
+        ### Merged Contacts
+
+        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+
         ### Contact Creation Delay
 
         If a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.
@@ -3882,6 +3900,9 @@ paths:
       operationId: ListContacts
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
+        {% admonition type="info" name="Merged contacts" %}
+          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+        {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -3405,7 +3405,7 @@ paths:
         You can fetch the details of a single contact.
 
         {% admonition type="warning" name="Merged contacts" %}
-          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+          If a contact has been merged into another contact via the Merge endpoint (POST /contacts/merge), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
         {% /admonition %}
       responses:
         '200':
@@ -3729,7 +3729,7 @@ paths:
         {% /admonition %}
         ### Merged Contacts
 
-        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+        Contacts that have been merged (via POST /contacts/merge) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
 
         ### Contact Creation Delay
 
@@ -3901,7 +3901,7 @@ paths:
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
         {% admonition type="info" name="Merged contacts" %}
-          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+          Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -3916,7 +3916,7 @@ paths:
         You can fetch the details of a single contact.
 
         {% admonition type="warning" name="Merged contacts" %}
-          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+          If a contact has been merged into another contact via the Merge endpoint (POST /contacts/merge), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
         {% /admonition %}
       responses:
         '200':
@@ -4256,7 +4256,7 @@ paths:
         {% /admonition %}
         ### Merged Contacts
 
-        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+        Contacts that have been merged (via POST /contacts/merge) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
 
         ### Contact Creation Delay
 
@@ -4408,7 +4408,7 @@ paths:
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
         {% admonition type="info" name="Merged contacts" %}
-          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+          Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -3912,7 +3912,12 @@ paths:
       tags:
       - Contacts
       operationId: ShowContact
-      description: You can fetch the details of a single contact.
+      description: |
+        You can fetch the details of a single contact.
+
+        {% admonition type="warning" name="Merged contacts" %}
+          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -4086,8 +4091,17 @@ paths:
       tags:
       - Contacts
       operationId: MergeContact
-      description: You can merge a contact with a `role` of `lead` into a contact
-        with a `role` of `user`.
+      description: |
+        You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.
+
+        {% admonition type="warning" name="Merged contacts are not retrievable via the API" %}
+          Once a merge is completed, the source contact (`from`) is permanently removed from the active contact list. This means:
+          - **GET /contacts/{id}** — Requesting the source contact by its original ID will return a `404 Not Found` error.
+          - **POST /contacts/search** — The source contact will not appear in search results, including queries filtered by `updated_at`.
+          - **GET /contacts** — The source contact will not appear in list results.
+
+          Only the target contact (`into`) remains accessible. If your application stores contact IDs, update them to use the target contact's ID after a merge.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -4240,6 +4254,10 @@ paths:
           pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.
         {% /admonition %}
+        ### Merged Contacts
+
+        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+
         ### Contact Creation Delay
 
         If a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.
@@ -4389,6 +4407,9 @@ paths:
       operationId: ListContacts
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
+        {% admonition type="info" name="Merged contacts" %}
+          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+        {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -4440,7 +4440,12 @@ paths:
       tags:
       - Contacts
       operationId: ShowContact
-      description: You can fetch the details of a single contact.
+      description: |
+        You can fetch the details of a single contact.
+
+        {% admonition type="warning" name="Merged contacts" %}
+          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -4607,8 +4612,17 @@ paths:
       tags:
       - Contacts
       operationId: MergeContact
-      description: You can merge a contact with a `role` of `lead` into a contact
-        with a `role` of `user`.
+      description: |
+        You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.
+
+        {% admonition type="warning" name="Merged contacts are not retrievable via the API" %}
+          Once a merge is completed, the source contact (`from`) is permanently removed from the active contact list. This means:
+          - **GET /contacts/{id}** — Requesting the source contact by its original ID will return a `404 Not Found` error.
+          - **POST /contacts/search** — The source contact will not appear in search results, including queries filtered by `updated_at`.
+          - **GET /contacts** — The source contact will not appear in list results.
+
+          Only the target contact (`into`) remains accessible. If your application stores contact IDs, update them to use the target contact's ID after a merge.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -4761,6 +4775,10 @@ paths:
           pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.
         {% /admonition %}
+        ### Merged Contacts
+
+        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+
         ### Contact Creation Delay
 
         If a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.
@@ -4910,6 +4928,9 @@ paths:
       operationId: ListContacts
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
+        {% admonition type="info" name="Merged contacts" %}
+          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+        {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -4444,7 +4444,7 @@ paths:
         You can fetch the details of a single contact.
 
         {% admonition type="warning" name="Merged contacts" %}
-          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+          If a contact has been merged into another contact via the Merge endpoint (POST /contacts/merge), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
         {% /admonition %}
       responses:
         '200':
@@ -4777,7 +4777,7 @@ paths:
         {% /admonition %}
         ### Merged Contacts
 
-        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+        Contacts that have been merged (via POST /contacts/merge) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
 
         ### Contact Creation Delay
 
@@ -4929,7 +4929,7 @@ paths:
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
         {% admonition type="info" name="Merged contacts" %}
-          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+          Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -4904,7 +4904,7 @@ paths:
         You can fetch the details of a single contact.
 
         {% admonition type="warning" name="Merged contacts" %}
-          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+          If a contact has been merged into another contact via the Merge endpoint (POST /contacts/merge), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
         {% /admonition %}
       responses:
         '200':
@@ -5237,7 +5237,7 @@ paths:
         {% /admonition %}
         ### Merged Contacts
 
-        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+        Contacts that have been merged (via POST /contacts/merge) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
 
         ### Contact Creation Delay
 
@@ -5389,7 +5389,7 @@ paths:
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
         {% admonition type="info" name="Merged contacts" %}
-          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+          Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -4900,7 +4900,12 @@ paths:
       tags:
       - Contacts
       operationId: ShowContact
-      description: You can fetch the details of a single contact.
+      description: |
+        You can fetch the details of a single contact.
+
+        {% admonition type="warning" name="Merged contacts" %}
+          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -5067,8 +5072,17 @@ paths:
       tags:
       - Contacts
       operationId: MergeContact
-      description: You can merge a contact with a `role` of `lead` into a contact
-        with a `role` of `user`.
+      description: |
+        You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.
+
+        {% admonition type="warning" name="Merged contacts are not retrievable via the API" %}
+          Once a merge is completed, the source contact (`from`) is permanently removed from the active contact list. This means:
+          - **GET /contacts/{id}** — Requesting the source contact by its original ID will return a `404 Not Found` error.
+          - **POST /contacts/search** — The source contact will not appear in search results, including queries filtered by `updated_at`.
+          - **GET /contacts** — The source contact will not appear in list results.
+
+          Only the target contact (`into`) remains accessible. If your application stores contact IDs, update them to use the target contact's ID after a merge.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -5221,6 +5235,10 @@ paths:
           pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.
         {% /admonition %}
+        ### Merged Contacts
+
+        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+
         ### Contact Creation Delay
 
         If a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.
@@ -5370,6 +5388,9 @@ paths:
       operationId: ListContacts
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
+        {% admonition type="info" name="Merged contacts" %}
+          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+        {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -4971,7 +4971,12 @@ paths:
       tags:
       - Contacts
       operationId: ShowContact
-      description: You can fetch the details of a single contact.
+      description: |
+        You can fetch the details of a single contact.
+
+        {% admonition type="warning" name="Merged contacts" %}
+          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -5138,8 +5143,17 @@ paths:
       tags:
       - Contacts
       operationId: MergeContact
-      description: You can merge a contact with a `role` of `lead` into a contact
-        with a `role` of `user`.
+      description: |
+        You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.
+
+        {% admonition type="warning" name="Merged contacts are not retrievable via the API" %}
+          Once a merge is completed, the source contact (`from`) is permanently removed from the active contact list. This means:
+          - **GET /contacts/{id}** — Requesting the source contact by its original ID will return a `404 Not Found` error.
+          - **POST /contacts/search** — The source contact will not appear in search results, including queries filtered by `updated_at`.
+          - **GET /contacts** — The source contact will not appear in list results.
+
+          Only the target contact (`into`) remains accessible. If your application stores contact IDs, update them to use the target contact's ID after a merge.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -5292,6 +5306,10 @@ paths:
           pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.
         {% /admonition %}
+        ### Merged Contacts
+
+        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+
         ### Contact Creation Delay
 
         If a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.
@@ -5441,6 +5459,9 @@ paths:
       operationId: ListContacts
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
+        {% admonition type="info" name="Merged contacts" %}
+          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+        {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -4975,7 +4975,7 @@ paths:
         You can fetch the details of a single contact.
 
         {% admonition type="warning" name="Merged contacts" %}
-          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+          If a contact has been merged into another contact via the Merge endpoint (POST /contacts/merge), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
         {% /admonition %}
       responses:
         '200':
@@ -5308,7 +5308,7 @@ paths:
         {% /admonition %}
         ### Merged Contacts
 
-        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+        Contacts that have been merged (via POST /contacts/merge) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
 
         ### Contact Creation Delay
 
@@ -5460,7 +5460,7 @@ paths:
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
         {% admonition type="info" name="Merged contacts" %}
-          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+          Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -3545,7 +3545,7 @@ paths:
         You can fetch the details of a single contact.
 
         {% admonition type="warning" name="Merged contacts" %}
-          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+          If a contact has been merged into another contact via the Merge endpoint (POST /contacts/merge), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
         {% /admonition %}
       responses:
         '200':
@@ -3868,7 +3868,7 @@ paths:
         {% /admonition %}
         ### Merged Contacts
 
-        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+        Contacts that have been merged (via POST /contacts/merge) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
 
         ### Contact Creation Delay
 
@@ -4020,7 +4020,7 @@ paths:
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
         {% admonition type="info" name="Merged contacts" %}
-          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+          Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -3541,7 +3541,12 @@ paths:
       tags:
       - Contacts
       operationId: ShowContact
-      description: You can fetch the details of a single contact.
+      description: |
+        You can fetch the details of a single contact.
+
+        {% admonition type="warning" name="Merged contacts" %}
+          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -3706,8 +3711,17 @@ paths:
       tags:
       - Contacts
       operationId: MergeContact
-      description: You can merge a contact with a `role` of `lead` into a contact
-        with a `role` of `user`.
+      description: |
+        You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.
+
+        {% admonition type="warning" name="Merged contacts are not retrievable via the API" %}
+          Once a merge is completed, the source contact (`from`) is permanently removed from the active contact list. This means:
+          - **GET /contacts/{id}** — Requesting the source contact by its original ID will return a `404 Not Found` error.
+          - **POST /contacts/search** — The source contact will not appear in search results, including queries filtered by `updated_at`.
+          - **GET /contacts** — The source contact will not appear in list results.
+
+          Only the target contact (`into`) remains accessible. If your application stores contact IDs, update them to use the target contact's ID after a merge.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -3852,6 +3866,10 @@ paths:
           pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.
         {% /admonition %}
+        ### Merged Contacts
+
+        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+
         ### Contact Creation Delay
 
         If a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.
@@ -4001,6 +4019,9 @@ paths:
       operationId: ListContacts
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
+        {% admonition type="info" name="Merged contacts" %}
+          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+        {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -3545,7 +3545,7 @@ paths:
         You can fetch the details of a single contact.
 
         {% admonition type="warning" name="Merged contacts" %}
-          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+          If a contact has been merged into another contact via the Merge endpoint (POST /contacts/merge), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
         {% /admonition %}
       responses:
         '200':
@@ -3868,7 +3868,7 @@ paths:
         {% /admonition %}
         ### Merged Contacts
 
-        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+        Contacts that have been merged (via POST /contacts/merge) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
 
         ### Contact Creation Delay
 
@@ -4020,7 +4020,7 @@ paths:
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
         {% admonition type="info" name="Merged contacts" %}
-          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+          Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -3541,7 +3541,12 @@ paths:
       tags:
       - Contacts
       operationId: ShowContact
-      description: You can fetch the details of a single contact.
+      description: |
+        You can fetch the details of a single contact.
+
+        {% admonition type="warning" name="Merged contacts" %}
+          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -3706,8 +3711,17 @@ paths:
       tags:
       - Contacts
       operationId: MergeContact
-      description: You can merge a contact with a `role` of `lead` into a contact
-        with a `role` of `user`.
+      description: |
+        You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.
+
+        {% admonition type="warning" name="Merged contacts are not retrievable via the API" %}
+          Once a merge is completed, the source contact (`from`) is permanently removed from the active contact list. This means:
+          - **GET /contacts/{id}** — Requesting the source contact by its original ID will return a `404 Not Found` error.
+          - **POST /contacts/search** — The source contact will not appear in search results, including queries filtered by `updated_at`.
+          - **GET /contacts** — The source contact will not appear in list results.
+
+          Only the target contact (`into`) remains accessible. If your application stores contact IDs, update them to use the target contact's ID after a merge.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -3852,6 +3866,10 @@ paths:
           pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.
         {% /admonition %}
+        ### Merged Contacts
+
+        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+
         ### Contact Creation Delay
 
         If a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.
@@ -4001,6 +4019,9 @@ paths:
       operationId: ListContacts
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
+        {% admonition type="info" name="Merged contacts" %}
+          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+        {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -3545,7 +3545,7 @@ paths:
         You can fetch the details of a single contact.
 
         {% admonition type="warning" name="Merged contacts" %}
-          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+          If a contact has been merged into another contact via the Merge endpoint (POST /contacts/merge), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
         {% /admonition %}
       responses:
         '200':
@@ -3868,7 +3868,7 @@ paths:
         {% /admonition %}
         ### Merged Contacts
 
-        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+        Contacts that have been merged (via POST /contacts/merge) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
 
         ### Contact Creation Delay
 
@@ -4020,7 +4020,7 @@ paths:
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
         {% admonition type="info" name="Merged contacts" %}
-          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+          Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -3541,7 +3541,12 @@ paths:
       tags:
       - Contacts
       operationId: ShowContact
-      description: You can fetch the details of a single contact.
+      description: |
+        You can fetch the details of a single contact.
+
+        {% admonition type="warning" name="Merged contacts" %}
+          If a contact has been merged into another contact via the [Merge endpoint](/reference/merge-a-lead-and-a-user), requesting it by its original ID will return a `404 Not Found` error. Use the merged-into contact's ID instead.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -3706,8 +3711,17 @@ paths:
       tags:
       - Contacts
       operationId: MergeContact
-      description: You can merge a contact with a `role` of `lead` into a contact
-        with a `role` of `user`.
+      description: |
+        You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.
+
+        {% admonition type="warning" name="Merged contacts are not retrievable via the API" %}
+          Once a merge is completed, the source contact (`from`) is permanently removed from the active contact list. This means:
+          - **GET /contacts/{id}** — Requesting the source contact by its original ID will return a `404 Not Found` error.
+          - **POST /contacts/search** — The source contact will not appear in search results, including queries filtered by `updated_at`.
+          - **GET /contacts** — The source contact will not appear in list results.
+
+          Only the target contact (`into`) remains accessible. If your application stores contact IDs, update them to use the target contact's ID after a merge.
+        {% /admonition %}
       responses:
         '200':
           description: successful
@@ -3852,6 +3866,10 @@ paths:
           pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.
         {% /admonition %}
+        ### Merged Contacts
+
+        Contacts that have been [merged](/reference/merge-a-lead-and-a-user) are excluded from search results. If a contact was recently merged into another, it will no longer appear in queries filtered by `updated_at` or any other field. Only the target contact from the merge remains searchable.
+
         ### Contact Creation Delay
 
         If a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.
@@ -4001,6 +4019,9 @@ paths:
       operationId: ListContacts
       description: |
         You can fetch a list of all contacts (ie. users or leads) in your workspace.
+        {% admonition type="info" name="Merged contacts" %}
+          Contacts that have been [merged](/reference/merge-a-lead-and-a-user) will not appear in list results. Only the target contact from the merge remains accessible.
+        {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `50` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.


### PR DESCRIPTION
### Why?

Customers using the Contacts API encounter unexpected 404 errors when retrieving contacts that have been merged, and merged contacts silently disappear from search and list results. This causes broken sync pipelines and confusion, as reported in:
- https://github.com/intercom/intercom/issues/453610

The behavior is expected (merged contacts are soft-deleted) but was not documented in any of the affected endpoints.

### How?

Add warning/info admonitions to the merge, get, list, and search contacts endpoint descriptions across all API versions (2.7–2.15 + Preview), explaining that merged source contacts return 404, are excluded from search, and don't appear in list results.

Companion to:
- https://github.com/intercom/developer-docs/pull/844

<sub>Generated with Claude Code</sub>