### PR TITLE
Document list CDA value validation on contact and company writes

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22400,7 +22400,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -22893,7 +22896,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -28558,7 +28564,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -13743,7 +13743,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -14082,7 +14085,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -16874,7 +16880,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -14552,7 +14552,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -14902,7 +14905,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -18726,7 +18732,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -14909,7 +14909,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -15345,7 +15348,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -18373,7 +18379,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -16249,7 +16249,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -16685,7 +16688,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -20103,7 +20109,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -18047,7 +18047,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -18525,7 +18528,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -18573,7 +18579,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -22737,7 +22746,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -18774,7 +18774,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -19252,7 +19255,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -19300,7 +19306,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -23596,7 +23605,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -11824,7 +11824,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -12163,7 +12166,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -14329,7 +14335,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -11848,7 +11848,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -12187,7 +12190,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -14376,7 +14382,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -13028,7 +13028,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -13367,7 +13370,10 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store.
+            company you want Intercom to store. For list-type attributes, the
+            value must be one of the attribute's predefined allowed values.
+            Setting a value not in the allowed list will return a 400 Bad
+            Request error.
           additionalProperties:
             type: string
           example:
@@ -16187,7 +16193,10 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact
+          description: The custom attributes which are set for the contact.
+            For list-type attributes, the value must be one of the attribute's
+            predefined allowed values. Setting a value not in the allowed list
+            will return a 400 Bad Request error.
     update_conversation_request:
       title: Update Conversation Request
       type: object


### PR DESCRIPTION
### Why?

The API now validates list-type custom data attribute values on contact and company writes, rejecting values not in the attribute's allowed list with a 400 Bad Request. The spec descriptions need to reflect this so SDK consumers and API users are aware of the validation.

### How?

Updated the `custom_attributes` field descriptions in the `create_contact_request`, `update_contact_request`, `create_or_update_company_request`, and `update_company_request` schemas across all API version specs (0, 2.7–2.15) to document the list-type validation behaviour.

- intercom/intercom#497043

<sub>Generated with Claude Code</sub>