### PR TITLE
Update conversation assignee_id fields from null to 0

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -7575,7 +7575,7 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -8006,7 +8006,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -8452,7 +8452,7 @@ paths:
                           id: 6762f14a1bb69f9f2193bbb3
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id: 991267715
+                      admin_assignee_id: 0
                       team_assignee_id: 5017691
                       open: false
                       state: closed
@@ -8556,7 +8556,7 @@ paths:
                       type: conversation
                       url:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -9079,7 +9079,7 @@ paths:
                         id: 6762f1711bb69f9f2193bbc3
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: true
                     state: snoozed
@@ -21402,15 +21402,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         company:
           "$ref": "#/components/schemas/company"
@@ -21523,15 +21521,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         company:
           "$ref": "#/components/schemas/company"

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -4675,7 +4675,7 @@ paths:
                         id: 6657ac966abd0166b52ae26e
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -4945,7 +4945,7 @@ paths:
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
-                      team_assignee_id: 5017691
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -5129,7 +5129,7 @@ paths:
                         id: 6657acab6abd0166b52ae27e
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5482,7 +5482,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: true
                     state: snoozed
                     read: false
@@ -5621,7 +5621,7 @@ paths:
                         id: 6657acc16abd0166b52ae28e
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991268010
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -13002,15 +13002,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -13103,15 +13101,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -4640,7 +4640,7 @@ paths:
                         id: 667d60d88a68186f43bafde1
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -4780,7 +4780,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -5322,7 +5322,7 @@ paths:
                       created_at: 1719492856
                       type: conversation
                       url:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -5653,7 +5653,7 @@ paths:
                         external_id: '74'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: true
@@ -5918,7 +5918,7 @@ paths:
                         id: 667d61108a68186f43bafe09
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -13724,15 +13724,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -13854,15 +13852,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -5155,7 +5155,7 @@ paths:
                         id: 677c55916abd011ad17ff514
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5295,7 +5295,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -5881,7 +5881,7 @@ paths:
                       created_at: 1736201667
                       type: conversation
                       url:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -6209,7 +6209,7 @@ paths:
                         external_id: '74'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: true
@@ -6703,7 +6703,7 @@ paths:
                       created_at: 1736201783
                       type: conversation
                       url:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -14045,15 +14045,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -14153,15 +14151,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -5826,8 +5826,8 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    admin_assignee_id: 0
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -6505,7 +6505,7 @@ paths:
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
-                      team_assignee_id: 5017691
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -7035,7 +7035,7 @@ paths:
                         id: 6762f16e1bb69f9f2193bbc2
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -7690,7 +7690,7 @@ paths:
                       created_at: 1734537722
                       type: conversation
                       url:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -15411,15 +15411,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -15519,15 +15517,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -6409,7 +6409,7 @@ paths:
                           id: 6762f0f31bb69f9f2193bb8b
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id: 991267715
+                      admin_assignee_id: 0
                       team_assignee_id: 5017691
                       open: false
                       state: closed
@@ -6895,7 +6895,7 @@ paths:
                         id: 6762f1301bb69f9f2193bbab
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -7500,7 +7500,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -7942,7 +7942,7 @@ paths:
                         id: 6762f1711bb69f9f2193bbc3
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: true
                     state: snoozed
@@ -8522,7 +8522,7 @@ paths:
                       type: conversation
                       url:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: true
@@ -17141,15 +17141,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -17251,15 +17249,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -6714,7 +6714,7 @@ paths:
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -6967,7 +6967,7 @@ paths:
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: true
@@ -7392,7 +7392,7 @@ paths:
                           id: 6762f14a1bb69f9f2193bbb3
                           external_id: '70'
                       first_contact_reply:
-                      admin_assignee_id: 991267715
+                      admin_assignee_id: 0
                       team_assignee_id: 5017691
                       open: false
                       state: closed
@@ -7495,7 +7495,7 @@ paths:
                       type: conversation
                       url:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: false
@@ -8013,7 +8013,7 @@ paths:
                         id: 6762f1711bb69f9f2193bbc3
                         external_id: '70'
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: true
                     state: snoozed
@@ -17857,15 +17857,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         company:
           "$ref": "#/components/schemas/company"
@@ -17971,15 +17969,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         company:
           "$ref": "#/components/schemas/company"

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -4748,7 +4748,7 @@ paths:
                         id: 6657a8606abd0160d35d1ec6
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -4876,7 +4876,7 @@ paths:
                       - type: contact
                         id: 6657a8676abd0160d35d1eca
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5577,7 +5577,7 @@ paths:
                       - type: contact
                         id: 6657a8866abd0160d35d1ee0
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5704,7 +5704,7 @@ paths:
                         id: 6657a88c6abd0160d35d1ee6
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: true
@@ -5949,7 +5949,7 @@ paths:
                       - type: contact
                         id: 6657a8976abd0160d35d1eee
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -11107,15 +11107,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -11206,15 +11204,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -4748,7 +4748,7 @@ paths:
                         id: 6657a9bb6abd01639cc9e9c7
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: false
                     state: closed
                     read: false
@@ -4876,7 +4876,7 @@ paths:
                       - type: contact
                         id: 6657a9c16abd01639cc9e9cb
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5577,7 +5577,7 @@ paths:
                       - type: contact
                         id: 6657a9df6abd01639cc9e9e1
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5704,7 +5704,7 @@ paths:
                         id: 6657a9e46abd01639cc9e9e7
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: true
                     state: open
                     read: true
@@ -5949,7 +5949,7 @@ paths:
                       - type: contact
                         id: 6657a9f16abd01639cc9e9ef
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -11131,15 +11131,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -11230,15 +11228,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -4878,7 +4878,7 @@ paths:
                       - type: contact
                         id: 6657ab1d6abd0164c24b0d55
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5142,7 +5142,7 @@ paths:
                           id: 6657ab286abd0164c24b0d5c
                       first_contact_reply:
                       admin_assignee_id: 991267715
-                      team_assignee_id: 5017691
+                      team_assignee_id: 0
                       open: false
                       state: closed
                       read: false
@@ -5314,7 +5314,7 @@ paths:
                       - type: contact
                         id: 6657ab326abd0164c24b0d65
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: false
                     state: closed
@@ -5649,7 +5649,7 @@ paths:
                         id: 6657ab3e6abd0164c24b0d6c
                     first_contact_reply:
                     admin_assignee_id: 991267715
-                    team_assignee_id: 5017691
+                    team_assignee_id: 0
                     open: true
                     state: snoozed
                     read: false
@@ -5712,7 +5712,7 @@ paths:
                       - type: contact
                         id: 6657ab426abd0164c24b0d71
                     first_contact_reply:
-                    admin_assignee_id: 991267715
+                    admin_assignee_id: 0
                     team_assignee_id: 5017691
                     open: true
                     state: open
@@ -12311,15 +12311,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"
@@ -12410,15 +12408,13 @@ components:
           example: priority
         admin_assignee_id:
           type: integer
-          nullable: true
           description: The id of the admin assigned to the conversation. If it's not
-            assigned to an admin it will return null.
+            assigned to an admin it will return 0.
           example: 0
         team_assignee_id:
           type: integer
-          nullable: true
           description: The id of the team assigned to the conversation. If it's not
-            assigned to a team it will return null.
+            assigned to a team it will return 0.
           example: 5017691
         tags:
           "$ref": "#/components/schemas/tags"


### PR DESCRIPTION
# Why?

Towards
- https://github.com/intercom/intercom/pull/496758

The API returns `0` (not `null`) for unassigned `admin_assignee_id` and `team_assignee_id` in conversation responses. The docs currently document these fields as `nullable: true` with descriptions saying "return null", which is inaccurate.

# How?

Removes `nullable: true` from conversation schemas, updates descriptions from "return null" to "return 0", and sets a random subset of response examples to `0` so developers see both assigned and unassigned states. Applied across all versions (@2.7–@2.15 + @Preview). Ticket schemas are untouched.


<sub>Generated with Claude Code</sub>