### PR TITLE
docs: clarify listSubscriptionsForAContact only returns explicitly-configured subscriptions

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -5123,6 +5123,8 @@ paths:
 
           1.Opt-out subscription types that the user has opted-out from.
           2.Opt-in subscription types that the user has opted-in to receiving.
+
+        **Note:** This endpoint only returns subscriptions where the contact has explicitly configured their preference. Subscriptions that are in the default state — where the contact has not made an explicit opt-in or opt-out choice — are not included in the response.
       responses:
         '200':
           description: Successful


### PR DESCRIPTION
### Why?

Developers were confused by the `GET /contacts/{contact_id}/subscriptions` endpoint — the existing description didn't make it clear that it only returns subscriptions where the contact has actively opted in or out. Subscriptions sitting in the default state (no explicit user action) are silently excluded, which led to unexpected gaps in the response.

Reported via internal CS ticket: https://intercomrades.intercom.com/a/inbox/tx2p130c/inbox/team/5826718/conversation/215473965478005

### How?

Added a **Note** paragraph to the `listSubscriptionsForAContact` description in the Preview spec clarifying the default-state exclusion.

Companion: intercom/developer-docs (PR to follow)

<sub>Generated with Claude Code</sub>