### PR TITLE
Remove include_request_url opt-in from execution results

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -11707,15 +11707,6 @@ paths:
           enum:
           - 'true'
           - 'false'
-      - name: include_request_url
-        in: query
-        required: false
-        description: Include the request URL in the response (default false).
-        schema:
-          type: string
-          enum:
-          - 'true'
-          - 'false'
       tags:
       - Data Connectors
       operationId: listDataConnectorExecutionResults
@@ -11723,9 +11714,7 @@ paths:
         Retrieve paginated execution logs for a specific data connector.
         Results from the last hour are returned by default. Use `start_ts` and `end_ts` to customize the time range.
 
-        Request/response bodies and request URL are excluded by default.
-        Use `include_bodies=true` to include bodies.
-        Use `include_request_url=true` to include the sanitised request URL.
+        Request/response bodies are excluded by default. Use `include_bodies=true` to include them.
       responses:
         '200':
           description: successful
@@ -11742,6 +11731,7 @@ paths:
                       success: true
                       http_status: 200
                       http_method: post
+                      request_url: https://api.vendor.com/webhook
                       execution_time_ms: 150
                       source_type: workflow
                       source_id: '5001'


### PR DESCRIPTION
### Why?

The monolith now always includes the sanitized `request_url` in execution result responses. The opt-in query parameter is no longer needed.

### How?

Remove the `include_request_url` parameter definition, update the endpoint description, and add `request_url` to the example response.

Companion to:
- intercom/intercom#498344
- intercom/developer-docs#854

<sub>Generated with Claude Code</sub>