### PR TITLE
Revert "Document list CDA value validation on contact and company writes (#457)"

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22242,10 +22242,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -22738,10 +22735,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -28361,10 +28355,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -10327,30 +10327,54 @@ paths:
                     order_number: ORDER-12345
                     total_amount: 99.99
     get:
-      summary: Get Custom Object Instance by External ID
+      summary: List Custom Object Instances
       parameters:
-      - name: external_id
+      - name: references_contact_id
         in: query
-        style: form
-        required: true
+        required: false
+        description: Return instances associated with the given contact ID.
         schema:
           type: string
-          description: The unique identifier for the instance in the external system
-            it originated from.
-          title: Find by external_id
-          properties:
-            external_id:
-              type: string
-          required:
-          - external_id
+      - name: references_conversation_id
+        in: query
+        required: false
+        description: Return instances associated with the given conversation ID.
+        schema:
+          type: string
+      - name: external_id
+        in: query
+        required: false
+        description: Return the single instance with this external ID. When provided,
+          the response is a single object rather than a list.
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        description: Page number of results to fetch.
+        schema:
+          type: integer
+      - name: per_page
+        in: query
+        required: false
+        description: Number of results per page. Maximum 150.
+        schema:
+          type: integer
+          maximum: 150
       - name: Intercom-Version
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
       tags:
       - Custom Object Instances
-      operationId: getCustomObjectInstancesByExternalId
-      description: Fetch a Custom Object Instance by external_id.
+      operationId: listCustomObjectInstances
+      description: |-
+        List instances of a custom object type. Three modes are supported:
+        - **No filter** — returns all instances for the type.
+        - **`references_contact_id`** — returns instances associated with the given contact.
+        - **`references_conversation_id`** — returns instances associated with the given conversation.
+
+        When **`external_id`** is provided, returns a single matching instance (not a list).
       responses:
         '200':
           description: successful
@@ -10359,22 +10383,40 @@ paths:
               examples:
                 successful:
                   value:
-                    id: '24'
-                    type: Order
-                    custom_attributes:
-                      order_number: ORDER-12345
-                      total_amount: 99.99
-                    external_id: '123'
-                    external_created_at:
-                    external_updated_at:
-                    created_at: 1734537748
-                    updated_at: 1734537748
+                    type: list
+                    pages:
+                      type: pages
+                      page: 1
+                      per_page: 20
+                      total_pages: 1
+                    total_count: 2
+                    data:
+                    - id: '2'
+                      type: Order
+                      custom_attributes:
+                        order_number: ORDER-98765
+                        total_amount: 149.99
+                      external_id: order_002
+                      external_created_at:
+                      external_updated_at:
+                      created_at: 1734537800
+                      updated_at: 1734537800
+                    - id: '1'
+                      type: Order
+                      custom_attributes:
+                        order_number: ORDER-12345
+                        total_amount: 99.99
+                      external_id: order_001
+                      external_created_at: 1734537100
+                      external_updated_at: 1734537100
+                      created_at: 1734537100
+                      updated_at: 1734537100
               schema:
-                "$ref": "#/components/schemas/custom_object_instance"
+                "$ref": "#/components/schemas/custom_object_instances_paginated_list"
         '401':
           $ref: "#/components/responses/Unauthorized"
         '404':
-          $ref: "#/components/responses/ObjectNotFound"
+          $ref: "#/components/responses/TypeNotFound"
     delete:
       summary: Delete a Custom Object Instance by External ID
       parameters:
@@ -23211,6 +23253,31 @@ components:
           type: array
           description: The list of associated custom object instances for a given
             reference attribute on the parent object.
+          items:
+            "$ref": "#/components/schemas/custom_object_instance"
+    custom_object_instances_paginated_list:
+      title: Custom Object Instances
+      type: object
+      x-tags:
+      - Custom Object Instances
+      description: A paginated list of custom object instances.
+      nullable: false
+      properties:
+        type:
+          type: string
+          description: The type of the object - `list`.
+          enum:
+          - list
+          example: list
+        pages:
+          "$ref": "#/components/schemas/pages_link"
+        total_count:
+          type: integer
+          description: A count of the total number of custom object instances.
+          example: 2
+        data:
+          type: array
+          description: An array of Custom Object Instance objects.
           items:
             "$ref": "#/components/schemas/custom_object_instance"
     customer_request:

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -13743,10 +13743,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -14085,10 +14082,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -16880,10 +16874,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -14552,10 +14552,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -14905,10 +14902,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -18732,10 +18726,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -14909,10 +14909,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -15348,10 +15345,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -18379,10 +18373,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -16249,10 +16249,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -16688,10 +16685,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -20109,10 +20103,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -17871,10 +17871,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -18352,10 +18349,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -18403,10 +18397,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -22500,10 +22491,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -18598,10 +18598,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -19079,10 +19076,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -19130,10 +19124,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -23359,10 +23350,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -11824,10 +11824,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -12166,10 +12163,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -14335,10 +14329,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -11848,10 +11848,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -12190,10 +12187,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -14382,10 +14376,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -13028,10 +13028,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -13370,10 +13367,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -16193,10 +16187,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_conversation_request:
       title: Update Conversation Request
       type: object


### PR DESCRIPTION
### Why?

Reverts the OpenAPI spec changes from PR #457 which documented the strict list CDA value validation introduced in intercom/intercom#497043. That code change has been reverted (see intercom/intercom#498426) because it broke documented API behaviour and caused ~40k errors/hour across 60+ workspaces.

Related:
- intercom/intercom#498426 — code revert
- intercom/developer-docs#846 — developer docs revert (companion PR)

### How?

Mechanical `git revert` of the merge commit for #457.

<sub>Generated with Claude Code</sub>