### PR TITLE
Revert "Document list CDA value validation on contact and company writes (#457)"

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22244,10 +22244,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -22740,10 +22737,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -28363,10 +28357,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -13743,10 +13743,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -14085,10 +14082,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -16880,10 +16874,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -14552,10 +14552,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -14905,10 +14902,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -18732,10 +18726,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -14909,10 +14909,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -15348,10 +15345,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -18379,10 +18373,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -16249,10 +16249,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -16688,10 +16685,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -20109,10 +20103,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -17871,10 +17871,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -18352,10 +18349,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -18403,10 +18397,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -22500,10 +22491,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -18598,10 +18598,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -19079,10 +19076,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -19130,10 +19124,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -23359,10 +23350,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_content_import_source_request:
       title: Create Content Import Source Payload
       type: object

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -11824,10 +11824,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -12166,10 +12163,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -14335,10 +14329,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -11848,10 +11848,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -12190,10 +12187,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -14382,10 +14376,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_conversation_request:
       title: Update Conversation Request
       type: object

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -13028,10 +13028,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
           example:
             paid_subscriber: true
             monthly_spend: 155.5
@@ -13370,10 +13367,7 @@ components:
         custom_attributes:
           type: object
           description: A hash of key/value pairs containing any other data about the
-            company you want Intercom to store. For list-type attributes, the
-            value must be one of the attribute's predefined allowed values.
-            Setting a value not in the allowed list will return a 400 Bad
-            Request error.
+            company you want Intercom to store.
           additionalProperties:
             type: string
           example:
@@ -16193,10 +16187,7 @@ components:
         custom_attributes:
           type: object
           nullable: true
-          description: The custom attributes which are set for the contact.
-            For list-type attributes, the value must be one of the attribute's
-            predefined allowed values. Setting a value not in the allowed list
-            will return a 400 Bad Request error.
+          description: The custom attributes which are set for the contact
     update_conversation_request:
       title: Update Conversation Request
       type: object


### PR DESCRIPTION
### Why?

Reverts the OpenAPI spec changes from PR #457 which documented the strict list CDA value validation introduced in intercom/intercom#497043. That code change has been reverted (see intercom/intercom#498426) because it broke documented API behaviour and caused ~40k errors/hour across 60+ workspaces.

Related:
- intercom/intercom#498426 — code revert
- intercom/developer-docs#846 — developer docs revert (companion PR)

### How?

Cherry-pick of the revert commit onto latest main (clean, no unrelated changes).

<sub>Generated with Claude Code</sub>