### PR TITLE
docs: clarify Data Export API descriptions

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -12153,7 +12153,12 @@ paths:
       - Data Export
       operationId: createDataExport
       description: "To create your export job, you need to send a `POST` request to
-        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe
+        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThis
+        endpoint exports **message delivery and engagement data** for outbound content
+        (Emails, Posts, Custom Bots, Surveys, Tours, Series, and more). The exported
+        data includes who received each message, when they received it, and how they
+        engaged with it (opens, clicks, replies, completions, dismissals, unsubscribes,
+        and bounces). It does not export raw message or conversation content.\n\nThe
         only parameters you need to provide are the range of dates that you want exported.\n\n>\U0001F6A7
         Limit of one active job\n>\n> You can only have one active job per workspace.
         You will receive a HTTP status code of 429 with the message Exceeded rate
@@ -24333,8 +24338,11 @@ components:
       type: object
       x-tags:
       - Data Export
-      description: The data export api is used to view all message sent & viewed in
-        a given timeframe.
+      description: The data export API is used to export message delivery and engagement
+        statistics for outbound content (Emails, Posts, Custom Bots, Surveys, Tours,
+        Series, and more) sent in a given timeframe. The exported data includes who
+        received each message, when they received it, and how they engaged with it
+        (opens, clicks, replies, completions, dismissals, unsubscribes, and bounces).
       properties:
         job_identfier:
           type: string
@@ -29243,7 +29251,7 @@ tags:
 - name: Data Events
   description: Everything about your Data Events
 - name: Data Export
-  description: Everything about your Data Exports
+  description: Export message delivery and engagement statistics (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content such as Emails, Posts, Custom Bots, Surveys, Tours, and Series.
 - name: Emails
   description: Everything about your Emails
 - name: Fin Agent

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -7207,7 +7207,12 @@ paths:
       - Data Export
       operationId: createDataExport
       description: "To create your export job, you need to send a `POST` request to
-        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe
+        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThis
+        endpoint exports **message delivery and engagement data** for outbound content
+        (Emails, Posts, Custom Bots, Surveys, Tours, Series, and more). The exported
+        data includes who received each message, when they received it, and how they
+        engaged with it (opens, clicks, replies, completions, dismissals, unsubscribes,
+        and bounces). It does not export raw message or conversation content.\n\nThe
         only parameters you need to provide are the range of dates that you want exported.\n\n>\U0001F6A7
         Limit of one active job\n>\n> You can only have one active job per workspace.
         You will receive a HTTP status code of 429 with the message Exceeded rate
@@ -14607,8 +14612,11 @@ components:
       type: object
       x-tags:
       - Data Export
-      description: The data export api is used to view all message sent & viewed in
-        a given timeframe.
+      description: The data export API is used to export message delivery and engagement
+        statistics for outbound content (Emails, Posts, Custom Bots, Surveys, Tours,
+        Series, and more) sent in a given timeframe. The exported data includes who
+        received each message, when they received it, and how they engaged with it
+        (opens, clicks, replies, completions, dismissals, unsubscribes, and bounces).
       properties:
         job_identfier:
           type: string
@@ -17383,7 +17391,7 @@ tags:
 - name: Data Events
   description: Everything about your Data Events
 - name: Data Export
-  description: Everything about your Data Exports
+  description: Export message delivery and engagement statistics (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content such as Emails, Posts, Custom Bots, Surveys, Tours, and Series.
 - name: Help Center
   description: Everything about your Help Center
 - name: Messages

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -7299,7 +7299,12 @@ paths:
       - Data Export
       operationId: createDataExport
       description: "To create your export job, you need to send a `POST` request to
-        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe
+        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThis
+        endpoint exports **message delivery and engagement data** for outbound content
+        (Emails, Posts, Custom Bots, Surveys, Tours, Series, and more). The exported
+        data includes who received each message, when they received it, and how they
+        engaged with it (opens, clicks, replies, completions, dismissals, unsubscribes,
+        and bounces). It does not export raw message or conversation content.\n\nThe
         only parameters you need to provide are the range of dates that you want exported.\n\n>\U0001F6A7
         Limit of one active job\n>\n> You can only have one active job per workspace.
         You will receive a HTTP status code of 429 with the message Exceeded rate
@@ -15465,8 +15470,11 @@ components:
       type: object
       x-tags:
       - Data Export
-      description: The data export api is used to view all message sent & viewed in
-        a given timeframe.
+      description: The data export API is used to export message delivery and engagement
+        statistics for outbound content (Emails, Posts, Custom Bots, Surveys, Tours,
+        Series, and more) sent in a given timeframe. The exported data includes who
+        received each message, when they received it, and how they engaged with it
+        (opens, clicks, replies, completions, dismissals, unsubscribes, and bounces).
       properties:
         job_identifier:
           type: string
@@ -19271,7 +19279,7 @@ tags:
 - name: Data Events
   description: Everything about your Data Events
 - name: Data Export
-  description: Everything about your Data Exports
+  description: Export message delivery and engagement statistics (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content such as Emails, Posts, Custom Bots, Surveys, Tours, and Series.
 - name: Help Center
   description: Everything about your Help Center
 - name: Messages

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -7697,7 +7697,12 @@ paths:
       - Data Export
       operationId: createDataExport
       description: "To create your export job, you need to send a `POST` request to
-        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe
+        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThis
+        endpoint exports **message delivery and engagement data** for outbound content
+        (Emails, Posts, Custom Bots, Surveys, Tours, Series, and more). The exported
+        data includes who received each message, when they received it, and how they
+        engaged with it (opens, clicks, replies, completions, dismissals, unsubscribes,
+        and bounces). It does not export raw message or conversation content.\n\nThe
         only parameters you need to provide are the range of dates that you want exported.\n\n>\U0001F6A7
         Limit of one active job\n>\n> You can only have one active job per workspace.
         You will receive a HTTP status code of 429 with the message Exceeded rate
@@ -15875,8 +15880,11 @@ components:
       type: object
       x-tags:
       - Data Export
-      description: The data export api is used to view all message sent & viewed in
-        a given timeframe.
+      description: The data export API is used to export message delivery and engagement
+        statistics for outbound content (Emails, Posts, Custom Bots, Surveys, Tours,
+        Series, and more) sent in a given timeframe. The exported data includes who
+        received each message, when they received it, and how they engaged with it
+        (opens, clicks, replies, completions, dismissals, unsubscribes, and bounces).
       properties:
         job_identfier:
           type: string
@@ -18983,7 +18991,7 @@ tags:
 - name: Data Events
   description: Everything about your Data Events
 - name: Data Export
-  description: Everything about your Data Exports
+  description: Export message delivery and engagement statistics (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content such as Emails, Posts, Custom Bots, Surveys, Tours, and Series.
 - name: Help Center
   description: Everything about your Help Center
 - name: Messages

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -8927,7 +8927,12 @@ paths:
       - Data Export
       operationId: createDataExport
       description: "To create your export job, you need to send a `POST` request to
-        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe
+        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThis
+        endpoint exports **message delivery and engagement data** for outbound content
+        (Emails, Posts, Custom Bots, Surveys, Tours, Series, and more). The exported
+        data includes who received each message, when they received it, and how they
+        engaged with it (opens, clicks, replies, completions, dismissals, unsubscribes,
+        and bounces). It does not export raw message or conversation content.\n\nThe
         only parameters you need to provide are the range of dates that you want exported.\n\n>\U0001F6A7
         Limit of one active job\n>\n> You can only have one active job per workspace.
         You will receive a HTTP status code of 429 with the message Exceeded rate
@@ -17341,8 +17346,11 @@ components:
       type: object
       x-tags:
       - Data Export
-      description: The data export api is used to view all message sent & viewed in
-        a given timeframe.
+      description: The data export API is used to export message delivery and engagement
+        statistics for outbound content (Emails, Posts, Custom Bots, Surveys, Tours,
+        Series, and more) sent in a given timeframe. The exported data includes who
+        received each message, when they received it, and how they engaged with it
+        (opens, clicks, replies, completions, dismissals, unsubscribes, and bounces).
       properties:
         job_identfier:
           type: string
@@ -20768,7 +20776,7 @@ tags:
 - name: Data Events
   description: Everything about your Data Events
 - name: Data Export
-  description: Everything about your Data Exports
+  description: Export message delivery and engagement statistics (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content such as Emails, Posts, Custom Bots, Surveys, Tours, and Series.
 - name: Help Center
   description: Everything about your Help Center
 - name: Messages

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -9758,7 +9758,12 @@ paths:
       - Data Export
       operationId: createDataExport
       description: "To create your export job, you need to send a `POST` request to
-        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe
+        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThis
+        endpoint exports **message delivery and engagement data** for outbound content
+        (Emails, Posts, Custom Bots, Surveys, Tours, Series, and more). The exported
+        data includes who received each message, when they received it, and how they
+        engaged with it (opens, clicks, replies, completions, dismissals, unsubscribes,
+        and bounces). It does not export raw message or conversation content.\n\nThe
         only parameters you need to provide are the range of dates that you want exported.\n\n>\U0001F6A7
         Limit of one active job\n>\n> You can only have one active job per workspace.
         You will receive a HTTP status code of 429 with the message Exceeded rate
@@ -19186,8 +19191,11 @@ components:
       type: object
       x-tags:
       - Data Export
-      description: The data export api is used to view all message sent & viewed in
-        a given timeframe.
+      description: The data export API is used to export message delivery and engagement
+        statistics for outbound content (Emails, Posts, Custom Bots, Surveys, Tours,
+        Series, and more) sent in a given timeframe. The exported data includes who
+        received each message, when they received it, and how they engaged with it
+        (opens, clicks, replies, completions, dismissals, unsubscribes, and bounces).
       properties:
         job_identifier:
           type: string
@@ -23210,7 +23218,7 @@ tags:
 - name: Data Events
   description: Everything about your Data Events
 - name: Data Export
-  description: Everything about your Data Exports
+  description: Export message delivery and engagement statistics (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content such as Emails, Posts, Custom Bots, Surveys, Tours, and Series.
 - name: Fin Agent
   description: |
     Access Fin programmatically via the Fin Agent API endpoints.

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -9829,7 +9829,12 @@ paths:
       - Data Export
       operationId: createDataExport
       description: "To create your export job, you need to send a `POST` request to
-        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe
+        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThis
+        endpoint exports **message delivery and engagement data** for outbound content
+        (Emails, Posts, Custom Bots, Surveys, Tours, Series, and more). The exported
+        data includes who received each message, when they received it, and how they
+        engaged with it (opens, clicks, replies, completions, dismissals, unsubscribes,
+        and bounces). It does not export raw message or conversation content.\n\nThe
         only parameters you need to provide are the range of dates that you want exported.\n\n>\U0001F6A7
         Limit of one active job\n>\n> You can only have one active job per workspace.
         You will receive a HTTP status code of 429 with the message Exceeded rate
@@ -19913,8 +19918,11 @@ components:
       type: object
       x-tags:
       - Data Export
-      description: The data export api is used to view all message sent & viewed in
-        a given timeframe.
+      description: The data export API is used to export message delivery and engagement
+        statistics for outbound content (Emails, Posts, Custom Bots, Surveys, Tours,
+        Series, and more) sent in a given timeframe. The exported data includes who
+        received each message, when they received it, and how they engaged with it
+        (opens, clicks, replies, completions, dismissals, unsubscribes, and bounces).
       properties:
         job_identifier:
           type: string
@@ -24158,7 +24166,7 @@ tags:
 - name: Data Events
   description: Everything about your Data Events
 - name: Data Export
-  description: Everything about your Data Exports
+  description: Export message delivery and engagement statistics (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content such as Emails, Posts, Custom Bots, Surveys, Tours, and Series.
 - name: Emails
   description: Everything about your Email Settings
 - name: Fin Agent

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -7192,7 +7192,12 @@ paths:
       - Data Export
       operationId: createDataExport
       description: "To create your export job, you need to send a `POST` request to
-        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe
+        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThis
+        endpoint exports **message delivery and engagement data** for outbound content
+        (Emails, Posts, Custom Bots, Surveys, Tours, Series, and more). The exported
+        data includes who received each message, when they received it, and how they
+        engaged with it (opens, clicks, replies, completions, dismissals, unsubscribes,
+        and bounces). It does not export raw message or conversation content.\n\nThe
         only parameters you need to provide are the range of dates that you want exported.\n\n>\U0001F6A7
         Limit of one active job\n>\n> You can only have one active job per workspace.
         You will receive a HTTP status code of 429 with the message Exceeded rate
@@ -12544,8 +12549,11 @@ components:
       type: object
       x-tags:
       - Data Export
-      description: The data export api is used to view all message sent & viewed in
-        a given timeframe.
+      description: The data export API is used to export message delivery and engagement
+        statistics for outbound content (Emails, Posts, Custom Bots, Surveys, Tours,
+        Series, and more) sent in a given timeframe. The exported data includes who
+        received each message, when they received it, and how they engaged with it
+        (opens, clicks, replies, completions, dismissals, unsubscribes, and bounces).
       properties:
         job_identfier:
           type: string
@@ -14713,7 +14721,7 @@ tags:
 - name: Data Events
   description: Everything about your Data Events
 - name: Data Export
-  description: Everything about your Data Exports
+  description: Export message delivery and engagement statistics (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content such as Emails, Posts, Custom Bots, Surveys, Tours, and Series.
 - name: Help Center
   description: Everything about your Help Center
 - name: Messages

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -7192,7 +7192,12 @@ paths:
       - Data Export
       operationId: createDataExport
       description: "To create your export job, you need to send a `POST` request to
-        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe
+        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThis
+        endpoint exports **message delivery and engagement data** for outbound content
+        (Emails, Posts, Custom Bots, Surveys, Tours, Series, and more). The exported
+        data includes who received each message, when they received it, and how they
+        engaged with it (opens, clicks, replies, completions, dismissals, unsubscribes,
+        and bounces). It does not export raw message or conversation content.\n\nThe
         only parameters you need to provide are the range of dates that you want exported.\n\n>\U0001F6A7
         Limit of one active job\n>\n> You can only have one active job per workspace.
         You will receive a HTTP status code of 429 with the message Exceeded rate
@@ -12568,8 +12573,11 @@ components:
       type: object
       x-tags:
       - Data Export
-      description: The data export api is used to view all message sent & viewed in
-        a given timeframe.
+      description: The data export API is used to export message delivery and engagement
+        statistics for outbound content (Emails, Posts, Custom Bots, Surveys, Tours,
+        Series, and more) sent in a given timeframe. The exported data includes who
+        received each message, when they received it, and how they engaged with it
+        (opens, clicks, replies, completions, dismissals, unsubscribes, and bounces).
       properties:
         job_identfier:
           type: string
@@ -14760,7 +14768,7 @@ tags:
 - name: Data Events
   description: Everything about your Data Events
 - name: Data Export
-  description: Everything about your Data Exports
+  description: Export message delivery and engagement statistics (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content such as Emails, Posts, Custom Bots, Surveys, Tours, and Series.
 - name: Help Center
   description: Everything about your Help Center
 - name: Messages

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -7205,7 +7205,12 @@ paths:
       - Data Export
       operationId: createDataExport
       description: "To create your export job, you need to send a `POST` request to
-        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe
+        the export endpoint `https://api.intercom.io/export/content/data`.\n\nThis
+        endpoint exports **message delivery and engagement data** for outbound content
+        (Emails, Posts, Custom Bots, Surveys, Tours, Series, and more). The exported
+        data includes who received each message, when they received it, and how they
+        engaged with it (opens, clicks, replies, completions, dismissals, unsubscribes,
+        and bounces). It does not export raw message or conversation content.\n\nThe
         only parameters you need to provide are the range of dates that you want exported.\n\n>\U0001F6A7
         Limit of one active job\n>\n> You can only have one active job per workspace.
         You will receive a HTTP status code of 429 with the message Exceeded rate
@@ -13919,8 +13924,11 @@ components:
       type: object
       x-tags:
       - Data Export
-      description: The data export api is used to view all message sent & viewed in
-        a given timeframe.
+      description: The data export API is used to export message delivery and engagement
+        statistics for outbound content (Emails, Posts, Custom Bots, Surveys, Tours,
+        Series, and more) sent in a given timeframe. The exported data includes who
+        received each message, when they received it, and how they engaged with it
+        (opens, clicks, replies, completions, dismissals, unsubscribes, and bounces).
       properties:
         job_identfier:
           type: string
@@ -16697,7 +16705,7 @@ tags:
 - name: Data Events
   description: Everything about your Data Events
 - name: Data Export
-  description: Everything about your Data Exports
+  description: Export message delivery and engagement statistics (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content such as Emails, Posts, Custom Bots, Surveys, Tours, and Series.
 - name: Help Center
   description: Everything about your Help Center
 - name: Messages


### PR DESCRIPTION
### Why?

The Data Export API descriptions were vague — saying it "views all messages sent & viewed in a given timeframe" without specifying what data is actually exported. This caused confusion about the endpoint's purpose and output.

### How?

Updated the endpoint description, schema description, and tag description across all spec versions (2.7–2.15 and Preview) to explicitly state that the API exports **message delivery and engagement statistics** (opens, clicks, replies, completions, dismissals, unsubscribes, bounces) for outbound content (Emails, Posts, Custom Bots, Surveys, Tours, Series). Also clarified that it does not export raw message or conversation content.

<sub>Generated with Claude Code</sub>