### PR TITLE
Add intercom_conversation_id to Fin Agent API response schemas

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -2054,6 +2054,7 @@ paths:
                 Successful response:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -2061,6 +2062,7 @@ paths:
                 Response with attribute errors:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -2079,6 +2081,10 @@ paths:
                     type: string
                     description: The ID of the conversation.
                     example: ext-123
+                  intercom_conversation_id:
+                    type: string
+                    description: The Intercom conversation ID associated with this Fin conversation.
+                    example: '5678'
                   user_id:
                     type: string
                     description: The ID of the user.
@@ -2245,6 +2251,7 @@ paths:
                 Successful response:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -2252,6 +2259,7 @@ paths:
                 Response with attribute errors:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -2267,6 +2275,10 @@ paths:
                     type: string
                     description: The ID of the conversation.
                     example: ext-123
+                  intercom_conversation_id:
+                    type: string
+                    description: The Intercom conversation ID associated with this Fin conversation.
+                    example: '5678'
                   user_id:
                     type: string
                     description: The ID of the user.

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -1835,6 +1835,7 @@ paths:
                 Successful response:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -1842,6 +1843,7 @@ paths:
                 Response with attribute errors:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -1860,6 +1862,10 @@ paths:
                     type: string
                     description: The ID of the conversation.
                     example: ext-123
+                  intercom_conversation_id:
+                    type: string
+                    description: The Intercom conversation ID associated with this Fin conversation.
+                    example: '5678'
                   user_id:
                     type: string
                     description: The ID of the user.
@@ -2025,6 +2031,7 @@ paths:
                 Successful response:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -2032,6 +2039,7 @@ paths:
                 Response with attribute errors:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -2047,6 +2055,10 @@ paths:
                     type: string
                     description: The ID of the conversation.
                     example: ext-123
+                  intercom_conversation_id:
+                    type: string
+                    description: The Intercom conversation ID associated with this Fin conversation.
+                    example: '5678'
                   user_id:
                     type: string
                     description: The ID of the user.

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -1835,6 +1835,7 @@ paths:
                 Successful response:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -1842,6 +1843,7 @@ paths:
                 Response with attribute errors:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -1860,6 +1862,10 @@ paths:
                     type: string
                     description: The ID of the conversation.
                     example: ext-123
+                  intercom_conversation_id:
+                    type: string
+                    description: The Intercom conversation ID associated with this Fin conversation.
+                    example: '5678'
                   user_id:
                     type: string
                     description: The ID of the user.
@@ -2025,6 +2031,7 @@ paths:
                 Successful response:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -2032,6 +2039,7 @@ paths:
                 Response with attribute errors:
                   value:
                     conversation_id: ext-123
+                    intercom_conversation_id: '5678'
                     user_id: user-456
                     status: thinking
                     created_at_ms: '2025-01-24T10:00:00.123Z'
@@ -2047,6 +2055,10 @@ paths:
                     type: string
                     description: The ID of the conversation.
                     example: ext-123
+                  intercom_conversation_id:
+                    type: string
+                    description: The Intercom conversation ID associated with this Fin conversation.
+                    example: '5678'
                   user_id:
                     type: string
                     description: The ID of the user.


### PR DESCRIPTION
### Why?

The `fin-agent-api-return-intercom-conversation-id` feature flag is now globally enabled in the Intercom monolith, making `intercom_conversation_id` an unconditional field in Fin Agent API responses. The OpenAPI spec needs to reflect this.

Towards https://github.com/intercom/intercom/issues/496451

### How?

Add `intercom_conversation_id` (type: string) to both the response schema properties and response examples for `/fin/start` and `/fin/reply` endpoints in API versions 2.14, 2.15, and Unstable (0).

**Companion PRs:**
- intercom/intercom#498649 — cleans up the feature flag from the Rails codebase
- developer-docs: mirrors these OpenAPI changes in the developer documentation

<sub>Generated with Claude Code</sub>