### PR TITLE
docs: fix custom_attributes example in company response

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -3601,7 +3601,7 @@ paths:
                       has_more: false
                     plan: {}
                     custom_attributes:
-                      creation_source: api
+                      industry: manufacturing
               schema:
                 "$ref": "#/components/schemas/company"
         '400':

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -1361,7 +1361,7 @@ paths:
                       segments: []
                     plan: {}
                     custom_attributes:
-                      creation_source: api
+                      industry: manufacturing
               schema:
                 "$ref": "#/components/schemas/company"
         '400':

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -1403,7 +1403,7 @@ paths:
                       segments: []
                     plan: {}
                     custom_attributes:
-                      creation_source: api
+                      industry: manufacturing
               schema:
                 "$ref": "#/components/schemas/company"
         '400':

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -1943,7 +1943,7 @@ paths:
                       segments: []
                     plan: {}
                     custom_attributes:
-                      creation_source: api
+                      industry: manufacturing
               schema:
                 "$ref": "#/components/schemas/company"
         '400':

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -2356,7 +2356,7 @@ paths:
                       segments: []
                     plan: {}
                     custom_attributes:
-                      creation_source: api
+                      industry: manufacturing
               schema:
                 "$ref": "#/components/schemas/company"
         '400':

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -3156,7 +3156,7 @@ paths:
                       segments: []
                     plan: {}
                     custom_attributes:
-                      creation_source: api
+                      industry: manufacturing
               schema:
                 "$ref": "#/components/schemas/company"
         '400':

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -3156,7 +3156,7 @@ paths:
                       segments: []
                     plan: {}
                     custom_attributes:
-                      creation_source: api
+                      industry: manufacturing
               schema:
                 "$ref": "#/components/schemas/company"
         '400':

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -16,7 +16,7 @@ paths:
       summary: Identify an admin
       parameters:
       - name: Intercom-Version
-        in: header 
+        in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
       tags:
@@ -1580,7 +1580,7 @@ paths:
                       segments: []
                     plan: {}
                     custom_attributes:
-                      creation_source: api
+                      industry: manufacturing
               schema:
                 "$ref": "#/components/schemas/company"
         '400':

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -1580,7 +1580,7 @@ paths:
                       segments: []
                     plan: {}
                     custom_attributes:
-                      creation_source: api
+                      industry: manufacturing
               schema:
                 "$ref": "#/components/schemas/company"
         '400':

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -1580,7 +1580,7 @@ paths:
                       segments: []
                     plan: {}
                     custom_attributes:
-                      creation_source: api
+                      industry: manufacturing
               schema:
                 "$ref": "#/components/schemas/company"
         '400':


### PR DESCRIPTION
### Why?

Clean up inaccurate API response examples across all spec versions.

### How?

Updated the `custom_attributes` example in the Create/Update Company response to use a more representative value. Minor whitespace cleanup in v2.7.

<sub>Generated with Claude Code</sub>