### PR TITLE
Add new audience fields to Data Connectors API spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -23472,7 +23472,7 @@ components:
           example: false
         audiences:
           type: array
-          description: The user types this connector is available for.
+          description: The user role types this connector is available for.
           items:
             type: string
             enum:
@@ -23482,6 +23482,13 @@ components:
           example:
           - leads
           - visitors
+        audience_segment_ids:
+          type: array
+          description: IDs of Fin Audience segments to assign to this connector. Replaces any existing segments. Pass an empty array to clear all segments.
+          items:
+            type: string
+          example:
+          - '123'
         headers:
           type: array
           description: HTTP headers to include in the request.
@@ -23598,7 +23605,7 @@ components:
           example: false
         audiences:
           type: array
-          description: The audience types this connector targets.
+          description: The user role types this connector targets. Updating this preserves any existing custom predicate rules.
           items:
             type: string
             enum:
@@ -23608,6 +23615,13 @@ components:
           example:
           - leads
           - users
+        audience_segment_ids:
+          type: array
+          description: IDs of Fin Audience segments to assign. This is a full replacement — the connector will have exactly these segments after the update. Pass an empty array to clear all segments.
+          items:
+            type: string
+          example:
+          - '456'
         headers:
           type: array
           description: HTTP headers to include in the request.
@@ -23826,7 +23840,7 @@ components:
           example: false
         audiences:
           type: array
-          description: The audience types this connector targets.
+          description: The user role types this connector targets.
           items:
             type: string
             enum:
@@ -23836,6 +23850,25 @@ components:
           example:
           - users
           - leads
+        audience_type:
+          type: string
+          description: |
+            The current audience targeting mode. `everyone` targets all users. `custom` means predicate-based rules are configured (edit in the UI). `fin_audience` means Fin Audience segments are assigned.
+          enum:
+          - everyone
+          - custom
+          - fin_audience
+          example: everyone
+        audience_segment_ids:
+          type: array
+          description: IDs of the Fin Audience segments assigned to this connector. Empty when `audience_type` is not `fin_audience`.
+          items:
+            type: string
+          example: []
+        has_custom_predicates:
+          type: boolean
+          description: Whether this connector has custom predicate-based audience rules. When `true`, the rules can only be viewed and edited in the Intercom UI.
+          example: false
         execution_type:
           type: string
           nullable: true

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -23482,9 +23482,9 @@ components:
           example:
           - leads
           - visitors
-        audience_segment_ids:
+        fin_audience_ids:
           type: array
-          description: IDs of Fin Audience segments to assign to this connector. Replaces any existing segments. Pass an empty array to clear all segments.
+          description: IDs of Fin Audiences to assign to this connector.
           items:
             type: string
           example:
@@ -23615,9 +23615,9 @@ components:
           example:
           - leads
           - users
-        audience_segment_ids:
+        fin_audience_ids:
           type: array
-          description: IDs of Fin Audience segments to assign. This is a full replacement — the connector will have exactly these segments after the update. Pass an empty array to clear all segments.
+          description: IDs of Fin Audiences to assign to this connector.
           items:
             type: string
           example:
@@ -23853,21 +23853,21 @@ components:
         audience_type:
           type: string
           description: |
-            The current audience targeting mode. `everyone` targets all users. `custom` means predicate-based rules are configured (edit in the UI). `fin_audience` means Fin Audience segments are assigned.
+            The current audience targeting mode. `everyone` targets all users. `custom` means custom targeting rules are configured. `fin_audiences` means Fin Audiences are assigned.
           enum:
           - everyone
           - custom
-          - fin_audience
+          - fin_audiences
           example: everyone
-        audience_segment_ids:
+        fin_audience_ids:
           type: array
-          description: IDs of the Fin Audience segments assigned to this connector. Empty when `audience_type` is not `fin_audience`.
+          description: IDs of the Fin Audiences assigned to this connector. Empty when `audience_type` is not `fin_audiences`.
           items:
             type: string
           example: []
-        has_custom_predicates:
+        has_custom_targeting_rules:
           type: boolean
-          description: Whether this connector has custom predicate-based audience rules. When `true`, the rules can only be viewed and edited in the Intercom UI.
+          description: Whether this connector has custom targeting rules configured.
           example: false
         execution_type:
           type: string


### PR DESCRIPTION
### Why?

The Data Connectors API now exposes audience targeting information (`audience_type`, `fin_audience_ids`, `has_custom_targeting_rules`) and accepts `fin_audience_ids` for Fin Audience assignment. The OpenAPI spec needs to reflect these new fields.

### How?

Add `audience_type`, `fin_audience_ids`, and `has_custom_targeting_rules` to the `data_connector_detail` response schema. Add `fin_audience_ids` as a writable field in `create_data_connector_request` and `update_data_connector_request` schemas.

### References

- Companion: intercom/intercom#500264
- Companion: intercom/developer-docs#867

<sub>Generated with Claude Code</sub>