### PR TITLE
Add message id to fin_agent_replied_event schema

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -25466,6 +25466,10 @@ components:
           type: object
           description: Fin's answer to the user's query.
           properties:
+            id:
+              type: string
+              description: A unique identifier for this message.
+              example: '98765'
             author:
               type: string
               enum:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -19976,6 +19976,10 @@ components:
           type: object
           description: Fin's answer to the user's query.
           properties:
+            id:
+              type: string
+              description: A unique identifier for this message.
+              example: '98765'
             author:
               type: string
               enum:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -20804,6 +20804,10 @@ components:
           type: object
           description: Fin's answer to the user's query.
           properties:
+            id:
+              type: string
+              description: A unique identifier for this message.
+              example: '98765'
             author:
               type: string
               enum:


### PR DESCRIPTION
### Why?

Fin Agent API consumers need a stable identifier to deduplicate `fin_replied` events across SSE and webhooks.

### How?

Add an `id` field to the `message` object in the `fin_agent_replied_event` schema across versions 0, 2.14, and 2.15.

Companion to:
- https://github.com/intercom/intercom/pull/500501

Towards https://github.com/intercom/intercom/issues/496283

<sub>Generated with Claude Code</sub>