### PR TITLE
Fix fin_reply_chunk status in 2.14 and 2.15 specs

### DIFF
--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -20069,9 +20069,9 @@ components:
         status:
           type: string
           enum:
-          - awaiting_user_reply
-          description: Fin's current status (always 'awaiting_user_reply' for this event).
-          example: awaiting_user_reply
+          - replying
+          description: Fin's current status (always 'replying' for this event).
+          example: replying
         created_at_ms:
           type: string
           format: date-time

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -20897,9 +20897,9 @@ components:
         status:
           type: string
           enum:
-          - awaiting_user_reply
-          description: Fin's current status (always 'awaiting_user_reply' for this event).
-          example: awaiting_user_reply
+          - replying
+          description: Fin's current status (always 'replying' for this event).
+          example: replying
         created_at_ms:
           type: string
           format: date-time


### PR DESCRIPTION
### Why?

The SSE streamer has always hardcoded `"status": "replying"` in every `fin_reply_chunk` event, but the 2.14 and 2.15 OpenAPI specs incorrectly documented the status as `awaiting_user_reply`. The Preview spec (version 0) was already correct, so the older specs were out of sync with both actual behavior and the latest docs.

### How?

Updated the `fin_agent_reply_chunk_event` schema's `status` field in 2.14 and 2.15 specs — changed the enum, description, and example from `awaiting_user_reply` to `replying` to match what the streamer actually sends.

<sub>Generated with Claude Code</sub>