### PR TITLE
Convert Contact.owner_id to string in unstable API

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -20271,11 +20271,11 @@ components:
           description: The contacts name.
           example: John Doe
         owner_id:
-          type: integer
+          type: string
           nullable: true
           description: The id of an admin that has been assigned account ownership
             of the contact.
-          example: 123
+          example: '123'
         has_hard_bounced:
           type: boolean
           description: Whether the contact has had an email sent to them hard bounce.

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22227,11 +22227,11 @@ components:
             Messenger was installed or when specified manually)
           example: 1571672154
         owner_id:
-          type: integer
+          type: string
           nullable: true
           description: The id of an admin that has been assigned account ownership
             of the contact
-          example: 123
+          example: '123'
         unsubscribed_from_emails:
           type: boolean
           nullable: true
@@ -28353,11 +28353,11 @@ components:
             Messenger was installed or when specified manually)
           example: 1571672154
         owner_id:
-          type: integer
+          type: string
           nullable: true
           description: The id of an admin that has been assigned account ownership
             of the contact
-          example: 123
+          example: '123'
         unsubscribed_from_emails:
           type: boolean
           nullable: true


### PR DESCRIPTION
### Why?

Aligns the `Contact.owner_id` field type with `Admin.id` in the unstable API version. Both are now strings, improving type consistency across the API.

### How?

Updated the Preview specification to reflect the unstable API's new string type for `Contact.owner_id`, while existing public versions (2.11–2.15) maintain integer type through versioning transformations.

<sub>Generated with Claude Code</sub>