### PR TITLE
Add DELETE /content_snippets/{id} to Preview spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -7063,6 +7063,54 @@ paths:
                       message: The language is not currently supported for Fin
               schema:
                 "$ref": "#/components/schemas/error"
+    delete:
+      summary: Delete a content snippet
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      - name: id
+        in: path
+        required: true
+        description: The unique identifier for the content snippet.
+        schema:
+          type: string
+          example: '123'
+      tags:
+      - Content Snippets
+      operationId: deleteContentSnippet
+      description: You can delete a single content snippet by its id.
+      responses:
+        '204':
+          description: Content snippet deleted
+        '404':
+          description: Content snippet not found
+          content:
+            application/json:
+              examples:
+                Content snippet not found:
+                  value:
+                    type: error.list
+                    errors:
+                    - code: not_found
+                      message: Content snippet not found
+              schema:
+                "$ref": "#/components/schemas/error"
+        '422':
+          description: Content snippet has procedure dependencies
+          content:
+            application/json:
+              examples:
+                Content snippet has procedure dependencies:
+                  value:
+                    type: error.list
+                    errors:
+                    - code: content_has_procedure_dependencies
+                      message: Content snippet has dependent procedures and cannot
+                        be deleted
+              schema:
+                "$ref": "#/components/schemas/error"
   "/conversations/{conversation_id}/tags":
     post:
       summary: Add tag to a conversation


### PR DESCRIPTION
### Why?

The content snippets public API now supports deletion (shipped in intercom/intercom#501696). The OpenAPI spec needs to document this endpoint so SDKs and developer docs reflect the full CRUD surface.

### How?

Adds a `delete` operation under `/content_snippets/{id}` in the Preview (`0/`) spec, following the same pattern as the existing `deleteTag` operation. Includes 204 success, 404 not found, and 422 procedure dependency error responses.

Related:
- https://github.com/intercom/intercom/issues/501685
- https://github.com/intercom/intercom/pull/501696

<sub>Generated with Claude Code</sub>