### PR TITLE
Update REPO_OWNER: team-data-foundations → team-integration-capabilities

### DIFF
--- a/REPO_OWNER
+++ b/REPO_OWNER
@@ -1,1 +1,1 @@
-team-data-foundations
+team-integration-capabilities


### PR DESCRIPTION
## Why?
As part of the team-data-foundations split into three teams (Integration Capabilities, Integration Apps, Conversations), repo ownership labels need updating. OpenAPI schemas and API reference docs fall under team-integration-capabilities per the [team split proposal](https://docs.google.com/document/d/1caWmxHaPJaeMEvn9ewTUHJDR6S3eMfTHrKyAKbwip_M/edit).

## How?
Updates `REPO_OWNER` from `team-data-foundations` to `team-integration-capabilities`. This changes which team label `event-management-system` applies to auto-created issues (Dependabot, security alerts, etc.) for this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)