### PR TITLE
Add timing metrics to Calls API schema

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -14732,6 +14732,10 @@ paths:
                     phone: "+15551234567"
                     fin_recording_url: "https://api.intercom.io/calls/124/recording"
                     fin_transcription_url: "https://api.intercom.io/calls/124/transcript"
+                    duration: 90
+                    talk_time: 85
+                    queue_time: 3
+                    hold_time: null
               schema:
                 "$ref": "#/components/schemas/call"
         '404':
@@ -23528,6 +23532,26 @@ components:
           format: uri
           nullable: true
           description: API URL to the AI Agent (Fin) call transcript if available.
+        duration:
+          type: integer
+          nullable: true
+          description: Total call duration in seconds from the caller's perspective. For inbound calls, measured from initiated to ended. For outbound calls, measured from answered to ended.
+          example: 900
+        talk_time:
+          type: integer
+          nullable: true
+          description: Total time in seconds the agent and customer were connected.
+          example: 300
+        queue_time:
+          type: integer
+          nullable: true
+          description: Total time in seconds the caller waited in queue before connecting, when assigned to a team.
+          example: 45
+        hold_time:
+          type: integer
+          nullable: true
+          description: Total time in seconds the caller was placed on hold during the call.
+          example: 60
     call_list:
       title: Calls
       type: object

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -14744,6 +14744,10 @@ paths:
                     phone: "+15551234567"
                     fin_recording_url: "https://api.intercom.io/calls/124/recording"
                     fin_transcription_url: "https://api.intercom.io/calls/124/transcript"
+                    duration: 90
+                    talk_time: 85
+                    queue_time: 3
+                    hold_time: null
               schema:
                 "$ref": "#/components/schemas/call"
         '404':
@@ -23588,6 +23592,26 @@ components:
           format: uri
           nullable: true
           description: API URL to the AI Agent (Fin) call transcript if available.
+        duration:
+          type: integer
+          nullable: true
+          description: Total call duration in seconds from the caller's perspective. For inbound calls, measured from initiated to ended. For outbound calls, measured from answered to ended.
+          example: 900
+        talk_time:
+          type: integer
+          nullable: true
+          description: Total time in seconds the agent and customer were connected.
+          example: 300
+        queue_time:
+          type: integer
+          nullable: true
+          description: Total time in seconds the caller waited in queue before connecting, when assigned to a team.
+          example: 45
+        hold_time:
+          type: integer
+          nullable: true
+          description: Total time in seconds the caller was placed on hold during the call.
+          example: 60
     call_list:
       title: Calls
       type: object


### PR DESCRIPTION
### Why?

The public Calls API now returns call timing metrics, but the OpenAPI specification does not yet include these fields. This causes API documentation and auto-generated client SDKs to be out of sync with the actual API response.

### How?

Add four new nullable integer properties (`duration`, `talk_time`, `queue_time`, `hold_time`) to the `call` schema and its corresponding example response in the `GET /calls/{id}` endpoint.

<sub>Generated with Claude Code</sub>