### PR TITLE
Clarify deleteCompany archive semantics across all spec versions

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -3980,7 +3980,16 @@ paths:
       tags:
       - Companies
       operationId: deleteCompany
-      description: You can delete a single company.
+      description: |
+        Delete a single company.
+
+        This endpoint does not permanently remove the company. It archives the company record and detaches any contacts attached to it; the contacts themselves are not deleted. A `company.deleted` webhook is sent once archival completes.
+
+        The endpoint returns `200` with `"deleted": true` as soon as the request is accepted — archival is processed asynchronously.
+
+        {% admonition type="warning" %}
+        Third-party integrations that sync companies into Intercom (for example, Salesforce or Chargebee) will recreate any company deleted through this endpoint on their next sync. To prevent recreation, remove or filter the company at the source integration before deleting it via the API.
+        {% /admonition %}
       responses:
         '200':
           description: Successful

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -1711,7 +1711,16 @@ paths:
       tags:
       - Companies
       operationId: deleteCompany
-      description: You can delete a single company.
+      description: |
+        Delete a single company.
+
+        This endpoint does not permanently remove the company. It archives the company record and detaches any contacts attached to it; the contacts themselves are not deleted. A `company.deleted` webhook is sent once archival completes.
+
+        The endpoint returns `200` with `"deleted": true` as soon as the request is accepted — archival is processed asynchronously.
+
+        {% admonition type="warning" %}
+        Third-party integrations that sync companies into Intercom (for example, Salesforce or Chargebee) will recreate any company deleted through this endpoint on their next sync. To prevent recreation, remove or filter the company at the source integration before deleting it via the API.
+        {% /admonition %}
       responses:
         '200':
           description: Successful

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -1753,7 +1753,16 @@ paths:
       tags:
       - Companies
       operationId: deleteCompany
-      description: You can delete a single company.
+      description: |
+        Delete a single company.
+
+        This endpoint does not permanently remove the company. It archives the company record and detaches any contacts attached to it; the contacts themselves are not deleted. A `company.deleted` webhook is sent once archival completes.
+
+        The endpoint returns `200` with `"deleted": true` as soon as the request is accepted — archival is processed asynchronously.
+
+        {% admonition type="warning" %}
+        Third-party integrations that sync companies into Intercom (for example, Salesforce or Chargebee) will recreate any company deleted through this endpoint on their next sync. To prevent recreation, remove or filter the company at the source integration before deleting it via the API.
+        {% /admonition %}
       responses:
         '200':
           description: Successful

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -2293,7 +2293,16 @@ paths:
       tags:
       - Companies
       operationId: deleteCompany
-      description: You can delete a single company.
+      description: |
+        Delete a single company.
+
+        This endpoint does not permanently remove the company. It archives the company record and detaches any contacts attached to it; the contacts themselves are not deleted. A `company.deleted` webhook is sent once archival completes.
+
+        The endpoint returns `200` with `"deleted": true` as soon as the request is accepted — archival is processed asynchronously.
+
+        {% admonition type="warning" %}
+        Third-party integrations that sync companies into Intercom (for example, Salesforce or Chargebee) will recreate any company deleted through this endpoint on their next sync. To prevent recreation, remove or filter the company at the source integration before deleting it via the API.
+        {% /admonition %}
       responses:
         '200':
           description: Successful

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -2706,7 +2706,16 @@ paths:
       tags:
       - Companies
       operationId: deleteCompany
-      description: You can delete a single company.
+      description: |
+        Delete a single company.
+
+        This endpoint does not permanently remove the company. It archives the company record and detaches any contacts attached to it; the contacts themselves are not deleted. A `company.deleted` webhook is sent once archival completes.
+
+        The endpoint returns `200` with `"deleted": true` as soon as the request is accepted — archival is processed asynchronously.
+
+        {% admonition type="warning" %}
+        Third-party integrations that sync companies into Intercom (for example, Salesforce or Chargebee) will recreate any company deleted through this endpoint on their next sync. To prevent recreation, remove or filter the company at the source integration before deleting it via the API.
+        {% /admonition %}
       responses:
         '200':
           description: Successful

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -3521,7 +3521,16 @@ paths:
       tags:
       - Companies
       operationId: deleteCompany
-      description: You can delete a single company.
+      description: |
+        Delete a single company.
+
+        This endpoint does not permanently remove the company. It archives the company record and detaches any contacts attached to it; the contacts themselves are not deleted. A `company.deleted` webhook is sent once archival completes.
+
+        The endpoint returns `200` with `"deleted": true` as soon as the request is accepted — archival is processed asynchronously.
+
+        {% admonition type="warning" %}
+        Third-party integrations that sync companies into Intercom (for example, Salesforce or Chargebee) will recreate any company deleted through this endpoint on their next sync. To prevent recreation, remove or filter the company at the source integration before deleting it via the API.
+        {% /admonition %}
       responses:
         '200':
           description: Successful

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -3521,7 +3521,16 @@ paths:
       tags:
       - Companies
       operationId: deleteCompany
-      description: You can delete a single company.
+      description: |
+        Delete a single company.
+
+        This endpoint does not permanently remove the company. It archives the company record and detaches any contacts attached to it; the contacts themselves are not deleted. A `company.deleted` webhook is sent once archival completes.
+
+        The endpoint returns `200` with `"deleted": true` as soon as the request is accepted — archival is processed asynchronously.
+
+        {% admonition type="warning" %}
+        Third-party integrations that sync companies into Intercom (for example, Salesforce or Chargebee) will recreate any company deleted through this endpoint on their next sync. To prevent recreation, remove or filter the company at the source integration before deleting it via the API.
+        {% /admonition %}
       responses:
         '200':
           description: Successful

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -1930,7 +1930,16 @@ paths:
       tags:
       - Companies
       operationId: deleteCompany
-      description: You can delete a single company.
+      description: |
+        Delete a single company.
+
+        This endpoint does not permanently remove the company. It archives the company record and detaches any contacts attached to it; the contacts themselves are not deleted. A `company.deleted` webhook is sent once archival completes.
+
+        The endpoint returns `200` with `"deleted": true` as soon as the request is accepted — archival is processed asynchronously.
+
+        {% admonition type="warning" %}
+        Third-party integrations that sync companies into Intercom (for example, Salesforce or Chargebee) will recreate any company deleted through this endpoint on their next sync. To prevent recreation, remove or filter the company at the source integration before deleting it via the API.
+        {% /admonition %}
       responses:
         '200':
           description: Successful

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -1930,7 +1930,16 @@ paths:
       tags:
       - Companies
       operationId: deleteCompany
-      description: You can delete a single company.
+      description: |
+        Delete a single company.
+
+        This endpoint does not permanently remove the company. It archives the company record and detaches any contacts attached to it; the contacts themselves are not deleted. A `company.deleted` webhook is sent once archival completes.
+
+        The endpoint returns `200` with `"deleted": true` as soon as the request is accepted — archival is processed asynchronously.
+
+        {% admonition type="warning" %}
+        Third-party integrations that sync companies into Intercom (for example, Salesforce or Chargebee) will recreate any company deleted through this endpoint on their next sync. To prevent recreation, remove or filter the company at the source integration before deleting it via the API.
+        {% /admonition %}
       responses:
         '200':
           description: Successful

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -1930,7 +1930,16 @@ paths:
       tags:
       - Companies
       operationId: deleteCompany
-      description: You can delete a single company.
+      description: |
+        Delete a single company.
+
+        This endpoint does not permanently remove the company. It archives the company record and detaches any contacts attached to it; the contacts themselves are not deleted. A `company.deleted` webhook is sent once archival completes.
+
+        The endpoint returns `200` with `"deleted": true` as soon as the request is accepted — archival is processed asynchronously.
+
+        {% admonition type="warning" %}
+        Third-party integrations that sync companies into Intercom (for example, Salesforce or Chargebee) will recreate any company deleted through this endpoint on their next sync. To prevent recreation, remove or filter the company at the source integration before deleting it via the API.
+        {% /admonition %}
       responses:
         '200':
           description: Successful


### PR DESCRIPTION
### Why?
https://app.intercom.com/a/inbox/tx2p130c/inbox/team/5826718/conversation/215474096115205?source=Slack-2eabce44676d45859573b33b6641fee7&view=List

The current `deleteCompany` description ("You can delete a single company.") doesn't communicate that the endpoint archives the company asynchronously and detaches contacts rather than performing a permanent delete. Developers integrating with the API have read it as a hard delete and been surprised when third-party integrations (CRM/billing syncs such as Salesforce or Chargebee) recreate the company on their next sync.

### How?

Expand the operation description across all 10 spec versions to call out archive + detach semantics, the async 200 response, and a warning admonition about third-party sync recreation.

<sub>Generated with Claude Code</sub>