### PR TITLE
Add timezone to contact_location schema

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -5747,6 +5747,7 @@ paths:
                       city:
                       country_code:
                       continent_code:
+                      timezone:
                     android_app_name:
                     android_app_version:
                     android_device:
@@ -5836,6 +5837,7 @@ paths:
                       city:
                       country_code:
                       continent_code:
+                      timezone:
                     android_app_name:
                     android_app_version:
                     android_device:
@@ -6022,6 +6024,7 @@ paths:
                       city:
                       country_code:
                       continent_code:
+                      timezone:
                     android_app_name:
                     android_app_version:
                     android_device:
@@ -6222,6 +6225,7 @@ paths:
                       city:
                       country_code:
                       continent_code:
+                      timezone:
                     android_app_name:
                     android_app_version:
                     android_device:
@@ -6579,6 +6583,7 @@ paths:
                       city:
                       country_code:
                       continent_code:
+                      timezone:
                     android_app_name:
                     android_app_version:
                     android_device:
@@ -6732,6 +6737,7 @@ paths:
                       city:
                       country_code:
                       continent_code:
+                      timezone:
                     android_app_name:
                     android_app_version:
                     android_device:
@@ -18035,6 +18041,7 @@ paths:
                       city:
                       country_code:
                       continent_code:
+                      timezone:
                     android_app_name:
                     android_app_version:
                     android_device:
@@ -21001,6 +21008,11 @@ components:
           nullable: true
           description: The city that the contact is located in
           example: Dublin
+        timezone:
+          type: string
+          nullable: true
+          description: The IANA timezone of the contact based on their IP address location
+          example: Europe/Dublin
     contact_notes:
       title: Contact notes
       type: object


### PR DESCRIPTION
### Why?

Companion to intercom/intercom#507647. The monolith PR exposes `geoip_data.timezone` on the Contact API location object. This PR updates the OpenAPI spec to reflect that new field.

### How?

- Adds the `timezone` property to the `contact_location` schema definition (type: string, nullable: true, with IANA timezone description and example)
- Adds `timezone:` to all 7 inline response examples that include a contact location object

🤖 Generated with [Claude Code](https://claude.com/claude-code)