### PR TITLE
Add customer_facing_name_change to activity log event type enum

### DIFF
--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -14481,6 +14481,7 @@ components:
           - conversation_topic_creation
           - conversation_topic_deletion
           - custom_authentication_token_creation
+          - customer_facing_name_change
           - help_center_settings_change
           - inbound_conversations_change
           - inbox_access_change


### PR DESCRIPTION
### Why?

A new `customer_facing_name_change` activity log event type has been added to the platform. This updates the API schema to include it in the `activity_type` enum so it appears correctly in developer documentation and SDK type definitions.

### How?

Added `customer_facing_name_change` in alphabetical order to the `activity_type` enum in the activity log schema.

<sub>Generated with Claude Code</sub>