### PR TITLE
Add GET /audiences/{id} to Preview OpenAPI spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -1815,6 +1815,68 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+  "/audiences/{id}":
+    get:
+      summary: Retrieve an audience
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      - name: id
+        in: path
+        required: true
+        description: The unique identifier of the audience to retrieve.
+        example: 123
+        schema:
+          type: integer
+      tags:
+      - Audiences
+      operationId: getAudience
+      description: You can fetch the details of a single audience by ID.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              examples:
+                Successful response:
+                  value:
+                    type: audience
+                    id: '123'
+                    name: VIP Customers
+                    created_at: 1717200000
+                    updated_at: 1717200000
+              schema:
+                "$ref": "#/components/schemas/audience"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                Unauthorized:
+                  value:
+                    type: error.list
+                    request_id: b1939528-98f0-4a63-a442-2cc9203fc8c7
+                    errors:
+                    - code: unauthorized
+                      message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              examples:
+                Not found:
+                  value:
+                    type: error.list
+                    request_id: b1939528-98f0-4a63-a442-2cc9203fc8c7
+                    errors:
+                    - code: not_found
+                      message: Resource Not Found
+              schema:
+                "$ref": "#/components/schemas/error"
   "/export/reporting_data/enqueue":
     post:
       summary: Enqueue a new reporting data export job


### PR DESCRIPTION
### Why?

Adds the show endpoint for the Audiences API to the Preview OpenAPI spec to match the monolith implementation.

### How?

Adds the `GET /audiences/{id}` path entry alongside the existing `GET /audiences` list endpoint. References the existing `audience` schema for the 200 response and documents the `404` response for unknown IDs.

Companion to intercom/intercom#511493

<sub>Generated with Claude Code</sub>