### PR TITLE
Revert "feat: Add ai_topics schema to conversation response"

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -7748,7 +7748,6 @@ paths:
                         data: []
                         total_count: 0
                         has_more: false
-                      ai_topics:
                       ai_agent:
                       ai_agent_participated: false
               schema:
@@ -7997,7 +7996,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -8174,7 +8172,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -8422,7 +8419,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -8529,7 +8525,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -8867,7 +8862,6 @@ paths:
                         data: []
                         total_count: 0
                         has_more: false
-                      ai_topics:
                       ai_agent:
                       ai_agent_participated: false
               schema:
@@ -8970,7 +8964,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -9047,7 +9040,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -9136,7 +9128,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -9216,7 +9207,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -9417,7 +9407,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -9494,7 +9483,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -9571,7 +9559,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -9648,7 +9635,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -10357,7 +10343,6 @@ paths:
                       data: []
                       total_count: 0
                       has_more: false
-                    ai_topics:
                     ai_agent:
                     ai_agent_participated: false
                     conversation_parts:
@@ -19294,57 +19279,6 @@ components:
           example:
             email: user@example.com
             company.name: Acme Inc
-    ai_subtopic:
-      title: AI Subtopic
-      type: object
-      description: An AI-generated subtopic under a topic.
-      properties:
-        type:
-          type: string
-          description: Always ai_subtopic.
-          example: ai_subtopic
-        name:
-          type: string
-          description: The name of the subtopic.
-          example: Payment Issues
-        id:
-          type: integer
-          description: The ID of the subtopic.
-          example: 42
-    ai_topic:
-      title: AI Topic
-      type: object
-      description: An AI-generated topic assigned to the conversation.
-      properties:
-        type:
-          type: string
-          description: Always ai_topic.
-          example: ai_topic
-        topic_name:
-          type: string
-          description: The name of the AI-generated topic.
-          example: Billing
-        subtopics:
-          type: array
-          description: The subtopics under this topic.
-          items:
-            $ref: '#/components/schemas/ai_subtopic'
-    ai_topics:
-      title: AI Topics
-      type: object
-      x-tags:
-      - AI Topics
-      description: AI-generated topics and subtopics for the conversation.
-      properties:
-        type:
-          type: string
-          description: Always ai_topics.
-          example: ai_topics
-        topics:
-          type: array
-          description: The list of AI-generated topics for this conversation.
-          items:
-            $ref: '#/components/schemas/ai_topic'
     app:
       title: App
       type: object
@@ -22039,8 +21973,6 @@ components:
           "$ref": "#/components/schemas/conversation_parts"
         linked_objects:
           "$ref": "#/components/schemas/linked_object_list"
-        ai_topics:
-          "$ref": "#/components/schemas/ai_topics"
         ai_agent_participated:
           type: boolean
           description: Indicates whether the AI Agent participated in the conversation.


### PR DESCRIPTION
### Why?

Reverting the ai_topics schema addition from the OpenAPI spec.

### How?

Reverts the changes from PR #385, removing the `ai_topics`, `ai_topic`, and `ai_subtopic` component schemas and all references to `ai_topics` in conversation response examples.

<sub>Generated with Claude Code</sub>