### PR TITLE
Fix merge conversation 200 example: primary stays open

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -10481,9 +10481,9 @@ paths:
                       url:
                     admin_assignee_id:
                     team_assignee_id:
-                    open: false
-                    state: closed
-                    read: true
+                    open: true
+                    state: open
+                    read: false
                     tags:
                       type: tag.list
                       tags: []


### PR DESCRIPTION
### Why?

The 200 response example for `POST /conversations/{id}/merge` incorrectly showed the primary conversation as `open: false, state: closed`. The endpoint returns the **primary** conversation — which remains open. Only the secondary conversation is closed by the merge.

### How?

Changed `open: false, state: closed, read: true` to `open: true, state: open, read: false` in the 200 response example.

<sub>Generated with Claude Code</sub>