### PR TITLE
Document channel.{initial,current} on Conversations API (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -7366,6 +7366,9 @@ paths:
                       ai_topics:
                       ai_agent:
                       ai_agent_participated: false
+                      channel:
+                        initial: messenger
+                        current: messenger
               schema:
                 "$ref": "#/components/schemas/conversation_list"
         '401':
@@ -7615,6 +7618,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -7792,6 +7798,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -8040,6 +8049,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -8147,6 +8159,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts: []
@@ -8485,6 +8500,9 @@ paths:
                       ai_topics:
                       ai_agent:
                       ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
               schema:
                 "$ref": "#/components/schemas/conversation_list"
       requestBody:
@@ -8588,6 +8606,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -8665,6 +8686,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -8754,6 +8778,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -8834,6 +8861,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -9035,6 +9065,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -9112,6 +9145,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -9189,6 +9225,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -9266,6 +9305,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -9975,6 +10017,9 @@ paths:
                     ai_topics:
                     ai_agent:
                     ai_agent_participated: false
+                    channel:
+                      initial: messenger
+                      current: messenger
                     conversation_parts:
                       type: conversation_part.list
                       conversation_parts:
@@ -21300,6 +21345,10 @@ components:
         sales_agent:
           "$ref": "#/components/schemas/sales_agent"
           nullable: true
+        channel:
+          "$ref": "#/components/schemas/conversation_channel"
+          nullable: true
+          description: The channel through which the conversation was initiated and its current channel. Available on the Preview API version only.
     conversation:
       title: Conversation
       type: object
@@ -21423,6 +21472,10 @@ components:
         sales_agent:
           "$ref": "#/components/schemas/sales_agent"
           nullable: true
+        channel:
+          "$ref": "#/components/schemas/conversation_channel"
+          nullable: true
+          description: The channel through which the conversation was initiated and its current channel. Available on the Preview API version only.
     conversation_attachment_files:
       title: Conversation attachment files
       type: object
@@ -21440,6 +21493,21 @@ components:
           type: string
           description: The name of the file.
           example: test.json
+    conversation_channel:
+      title: Conversation Channel
+      type: object
+      description: The channel through which a conversation was originally initiated and its current channel. Available on the Preview API version only.
+      properties:
+        initial:
+          type: string
+          nullable: true
+          description: The channel through which the conversation was originally initiated. Possible values include `messenger`, `zendesk_sunshine`, `zendesk_ticket`, `twitter`, `email`. Returns `null` if channel data is unavailable.
+          example: messenger
+        current:
+          type: string
+          nullable: true
+          description: The current channel of the conversation. May differ from `initial` if the conversation was migrated between channels. Returns `null` if channel data is unavailable.
+          example: messenger
     conversation_contacts:
       title: Contacts
       type: object

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -21348,7 +21348,7 @@ components:
         channel:
           "$ref": "#/components/schemas/conversation_channel"
           nullable: true
-          description: The channel through which the conversation was initiated and its current channel. Available on the Preview API version only.
+          description: The channel through which the conversation was initiated and its current channel.
     conversation:
       title: Conversation
       type: object
@@ -21475,7 +21475,7 @@ components:
         channel:
           "$ref": "#/components/schemas/conversation_channel"
           nullable: true
-          description: The channel through which the conversation was initiated and its current channel. Available on the Preview API version only.
+          description: The channel through which the conversation was initiated and its current channel.
     conversation_attachment_files:
       title: Conversation attachment files
       type: object
@@ -21496,7 +21496,7 @@ components:
     conversation_channel:
       title: Conversation Channel
       type: object
-      description: The channel through which a conversation was originally initiated and its current channel. Available on the Preview API version only.
+      description: The channel through which a conversation was originally initiated and its current channel.
       properties:
         initial:
           type: string


### PR DESCRIPTION
### Why?

The Conversations API response now includes a `channel` object that exposes both the channel through which a conversation was originally started (`initial`) and its current channel (`current`). This documents that addition in the OpenAPI specification for the Preview API version.

### How?

Adds a new `conversation_channel` schema and the `channel` field to both `conversation` and `conversation_list_item` response schemas. Updates all 15 inline response examples to include example `channel` values.

<sub>Generated with Claude Code</sub>