### PR TITLE
Add hide_csat_from_agents_setting_change to activity log event types

### DIFF
--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -14531,6 +14531,7 @@ components:
           - user_voice_notes_setting_change
           - welcome_message_change
           - workspace_deletion_request
+          - hide_csat_from_agents_setting_change
           example: app_name_change
         activity_description:
           type: string

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -14531,7 +14531,6 @@ components:
           - user_voice_notes_setting_change
           - welcome_message_change
           - workspace_deletion_request
-          - hide_csat_from_agents_setting_change
           example: app_name_change
         activity_description:
           type: string

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -15088,6 +15088,7 @@ components:
           - user_voice_notes_setting_change
           - welcome_message_change
           - workspace_deletion_request
+          - hide_csat_from_agents_setting_change
           example: app_name_change
         activity_description:
           type: string


### PR DESCRIPTION
### Why?

The `HideCsatFromAgentsSettingChange` TAL event was added to the intercom monolith (intercom/intercom#512062) but is missing from the public API activity log event types enum.

### How?

Adds `hide_csat_from_agents_setting_change` to the activity log event type enum in the API spec.

<sub>Generated with Claude Code</sub>