### PR TITLE
Remove activity_description from Preview admin_activity_log_event schema

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -237,8 +237,6 @@ paths:
                         after: after
                       created_at: 1734537253
                       activity_type: app_name_change
-                      activity_description: Ciaran5 Lee changed your app name from
-                        before to after.
                     - id: f48c653b-0185-48ac-a276-23d11006bafb
                       performed_by:
                         type: admin
@@ -253,9 +251,6 @@ paths:
                         after: Eventual message title
                       created_at: 1734537253
                       activity_type: message_state_change
-                      activity_description: Ciaran5 Lee changed your Initial message
-                        title message from Initial message title to Eventual message
-                        title.
               schema:
                 "$ref": "#/components/schemas/activity_log_list"
         '401':
@@ -368,8 +363,6 @@ paths:
                         after: after
                       created_at: 1734537253
                       activity_type: app_name_change
-                      activity_description: Ciaran5 Lee changed your app name
-                        from before to after.
               schema:
                 "$ref": "#/components/schemas/activity_log_list"
         '401':
@@ -18945,10 +18938,6 @@ components:
           - upfront_email_collection_change
           - welcome_message_change
           example: app_name_change
-        activity_description:
-          type: string
-          description: A sentence or two describing the activity.
-          example: Admin updated the app's name to "My App".
     activity_log_event_type_list:
       title: Activity Log Event Types
       type: object


### PR DESCRIPTION
## Summary
Remove the `activity_description` property from the Preview slice of the `admin_activity_log_event` schema. APIs are read by machines — translation belongs in the UI, not in API responses. Numbered version slices (1.x, 2.x) are unchanged.

## Companion PRs
- Parent issue: intercom/intercom#512347
- Closes intercom/intercom#512356
- Monolith PR: intercom/intercom#512388
- developer-docs PR: intercom/developer-docs#914

## Test plan
- [ ] YAML validates against this repo's existing schema/lint tooling
- [ ] Numbered-version (2.x) schemas still include `activity_description`
- [ ] Preview schema does not include `activity_description`

<sub>Generated with Claude Code</sub>