### PR TITLE
Add ai_*_availability boolean fields to Content Snippets API (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -6848,6 +6848,9 @@ paths:
                       body_markdown: "# How to reset your password\n\nNavigate to Settings > Security > Reset password.\n"
                       chatbot_availability: 1
                       copilot_availability: 1
+                      ai_chatbot_availability: true
+                      ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       created_at: 1663597223
                       updated_at: 1663597223
                     total_count: 1
@@ -6899,6 +6902,9 @@ paths:
                     body_markdown: "# How to reset your password\n\nNavigate to Settings > Security > Reset password.\n"
                     chatbot_availability: 1
                     copilot_availability: 1
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     created_at: 1663597223
                     updated_at: 1663597223
               schema:
@@ -6953,6 +6959,9 @@ paths:
                     body_markdown: "# How to reset your password\n\nNavigate to Settings > Security > Reset password.\n"
                     chatbot_availability: 1
                     copilot_availability: 1
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     created_at: 1663597223
                     updated_at: 1663597223
               schema:
@@ -7019,6 +7028,9 @@ paths:
                     body_markdown: "# How to reset your password (updated)\n\nGo to Settings > Security > Reset password and follow the steps.\n"
                     chatbot_availability: 1
                     copilot_availability: 1
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     created_at: 1663597223
                     updated_at: 1663597300
               schema:
@@ -22273,6 +22285,18 @@ components:
           description: Whether this snippet is available for Copilot (1 = on, 0 =
             off).
           example: 1
+        ai_chatbot_availability:
+          type: boolean
+          description: Whether this snippet is available for AI Chatbot.
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether this snippet is available for AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether this snippet is available for AI Sales Agent.
+          example: true
         created_at:
           type: integer
           description: The time the snippet was created as a UNIX timestamp.


### PR DESCRIPTION
### Why?

The Content Snippets API needed boolean availability fields so API consumers can determine whether a snippet is surfaced by AI Chatbot, AI Copilot, and AI Sales Agent independently. The existing integer fields used an inconsistent encoding compared to the rest of the API.

### How?

Adds `ai_chatbot_availability`, `ai_copilot_availability`, and `ai_sales_agent_availability` boolean properties to the `content_snippet` schema (Preview spec only) and updates all four inline response examples (list, create, get by id, update). The existing integer fields are unchanged.

<sub>Generated with Claude Code</sub>