### PR TITLE
Add ai_sales_agent_availability to External Pages API

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -909,6 +909,7 @@ paths:
                       url: https://support.example.com/us/3
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 42
@@ -923,6 +924,7 @@ paths:
                       url: https://support.example.com/us/2
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 41
@@ -937,6 +939,7 @@ paths:
                       url: https://support.example.com/us/1
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 40
@@ -995,6 +998,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 44
@@ -1068,6 +1072,7 @@ paths:
                     url: https://support.example.com/us/5
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 45
@@ -1117,6 +1122,7 @@ paths:
                     url: https://support.example.com/us/6
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 46
@@ -1167,6 +1173,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 47
@@ -26441,6 +26448,11 @@ components:
           type: boolean
           description: Whether the external page should be used to answer questions
             by AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the external page should be used to answer questions
+            by AI Sales Agent.
           example: true
         fin_availability:
           type: boolean

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -652,6 +652,7 @@ paths:
                       url: https://support.example.com/us/3
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 10
@@ -666,6 +667,7 @@ paths:
                       url: https://support.example.com/us/2
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 9
@@ -680,6 +682,7 @@ paths:
                       url: https://support.example.com/us/1
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 8
@@ -738,6 +741,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 12
@@ -811,6 +815,7 @@ paths:
                     url: https://support.example.com/us/5
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 13
@@ -860,6 +865,7 @@ paths:
                     url: https://support.example.com/us/6
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 14
@@ -910,6 +916,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 15
@@ -16185,6 +16192,11 @@ components:
           type: boolean
           description: Whether the external page should be used to answer questions
             by AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the external page should be used to answer questions
+            by AI Sales Agent.
           example: true
         fin_availability:
           type: boolean

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -652,6 +652,7 @@ paths:
                       url: https://support.example.com/us/3
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 10
@@ -666,6 +667,7 @@ paths:
                       url: https://support.example.com/us/2
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 9
@@ -680,6 +682,7 @@ paths:
                       url: https://support.example.com/us/1
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 8
@@ -738,6 +741,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 12
@@ -811,6 +815,7 @@ paths:
                     url: https://support.example.com/us/5
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 13
@@ -860,6 +865,7 @@ paths:
                     url: https://support.example.com/us/6
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 14
@@ -910,6 +916,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 15
@@ -17793,6 +17800,11 @@ components:
           type: boolean
           description: Whether the external page should be used to answer questions
             by AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the external page should be used to answer questions
+            by AI Sales Agent.
           example: true
         fin_availability:
           type: boolean

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -678,6 +678,7 @@ paths:
                       url: https://support.example.com/us/3
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 42
@@ -692,6 +693,7 @@ paths:
                       url: https://support.example.com/us/2
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 41
@@ -706,6 +708,7 @@ paths:
                       url: https://support.example.com/us/1
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 40
@@ -764,6 +767,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 44
@@ -837,6 +841,7 @@ paths:
                     url: https://support.example.com/us/5
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 45
@@ -886,6 +891,7 @@ paths:
                     url: https://support.example.com/us/6
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 46
@@ -936,6 +942,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 47
@@ -19661,6 +19668,11 @@ components:
           type: boolean
           description: Whether the external page should be used to answer questions
             by AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the external page should be used to answer questions
+            by AI Sales Agent.
           example: true
         fin_availability:
           type: boolean

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -678,6 +678,7 @@ paths:
                       url: https://support.example.com/us/3
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 42
@@ -692,6 +693,7 @@ paths:
                       url: https://support.example.com/us/2
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 41
@@ -706,6 +708,7 @@ paths:
                       url: https://support.example.com/us/1
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 40
@@ -764,6 +767,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 44
@@ -837,6 +841,7 @@ paths:
                     url: https://support.example.com/us/5
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 45
@@ -886,6 +891,7 @@ paths:
                     url: https://support.example.com/us/6
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 46
@@ -936,6 +942,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 47
@@ -20489,6 +20496,11 @@ components:
           type: boolean
           description: Whether the external page should be used to answer questions
             by AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the external page should be used to answer questions
+            by AI Sales Agent.
           example: true
         fin_availability:
           type: boolean


### PR DESCRIPTION
### Why?

The External Pages API response lacked visibility into whether a page is configured for the AI Sales Agent. This allows API consumers to determine AI Sales Agent content availability alongside the existing AI Agent and Copilot availability fields.

### How?

Adds `ai_sales_agent_availability` as a boolean field to the `external_page` schema following the same pattern as `ai_agent_availability` and `ai_copilot_availability`. Applies to all API versions with the External Pages endpoint (Preview and 2.12–2.15), updating the schema definition and inline response examples in each.

<sub>Generated with Claude Code</sub>