### PR TITLE
Add agent availability fields to Internal Articles API (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -2619,6 +2619,9 @@ paths:
                       owner_id: 991266252
                       author_id: 991266252
                       locale: en
+                      ai_chatbot_availability: true
+                      ai_copilot_availability: true
+                      ai_sales_agent_availability: true
               schema:
                 "$ref": "#/components/schemas/internal_article_list"
         '401':
@@ -2661,6 +2664,9 @@ paths:
                     owner_id: 991266252
                     author_id: 991266252
                     locale: en
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
               schema:
                 "$ref": "#/components/schemas/internal_article"
         '400':
@@ -2745,6 +2751,9 @@ paths:
                     owner_id: 991266252
                     author_id: 991266252
                     locale: en
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
               schema:
                 "$ref": "#/components/schemas/internal_article"
         '404':
@@ -2808,6 +2817,9 @@ paths:
                     owner_id: 991266252
                     author_id: 991266252
                     locale: en
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
               schema:
                 "$ref": "#/components/schemas/internal_article"
         '404':
@@ -20360,6 +20372,18 @@ components:
           nullable: true
           description: The ID of the folder this article belongs to, or null if not in a folder.
           example: 6
+        ai_chatbot_availability:
+          type: boolean
+          description: Whether the internal article is available for AI Chatbot.
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the internal article is available for AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the internal article is available for AI Sales Agent.
+          example: true
     article_search_highlights:
       title: Article Search Highlights
       type: object


### PR DESCRIPTION
### Why?

The Internal Articles API lacked visibility into AI agent availability, while the public Articles API already exposes equivalent fields. This brings the two into parity so API consumers can determine whether an internal article is configured for AI Chatbot, Copilot, and Sales Agent.

### How?

Adds `ai_chatbot_availability`, `ai_copilot_availability`, and `ai_sales_agent_availability` boolean properties to the `internal_article_list_item` schema (Preview spec only) and updates the inline response examples for list, create, retrieve, and update endpoints.

<sub>Generated with Claude Code</sub>