### PR TITLE
Add GET /content/search schema to Preview spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -6802,6 +6802,98 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+  "/content/search":
+    get:
+      summary: Search Knowledge Hub content
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version_preview"
+      - name: query
+        in: query
+        required: true
+        description: The keyword(s) to search for across Knowledge Hub content.
+        example: billing
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        description: The page number to fetch. Defaults to 1. Values below 1 are
+          clamped to 1.
+        example: 1
+        schema:
+          type: integer
+          default: 1
+          minimum: 1
+      - name: per_page
+        in: query
+        required: false
+        description: Number of results per page. Defaults to 10. Maximum 50.
+        example: 10
+        schema:
+          type: integer
+          default: 10
+          minimum: 1
+          maximum: 50
+      tags:
+      - Knowledge Hub
+      operationId: searchContent
+      description: |
+        Search across Knowledge Hub content (content snippets, external pages, uploaded files, internal articles, and help center articles) using a keyword query.
+
+        Each result row has a `type` discriminator. Most types (`content_snippet`, `external_content`, `file_source_content`, `internal_article`) return a flat `{ type, id, title }` shape. Help center articles return a nested shape with a `contents[]` array, one entry per locale.
+
+        Requires the `read_content` OAuth scope.
+      responses:
+        '200':
+          description: Search successful
+          content:
+            application/json:
+              examples:
+                Search successful:
+                  value:
+                    type: list
+                    total_count: 5
+                    pages:
+                      type: pages
+                      page: 1
+                      per_page: 10
+                      total_pages: 1
+                      next:
+                      prev:
+                    data:
+                    - type: content_snippet
+                      id: '123'
+                      title: Billing FAQ
+                    - type: external_content
+                      id: '456'
+                      title: How to reset your password
+                    - type: file_source_content
+                      id: '789'
+                      title: billing-guide.pdf
+                    - type: internal_article
+                      id: '012'
+                      title: 'Internal SOP: Refunds'
+                    - type: article
+                      id: '345'
+                      title: Billing FAQ
+                      contents:
+                      - type: article_content
+                        id: '678'
+                        title: Billing FAQ
+                        locale: en
+                      - type: article_content
+                        id: '910'
+                        title: Facturation FAQ
+                        locale: fr
+              schema:
+                "$ref": "#/components/schemas/content_search_response"
+        '401':
+          $ref: "#/components/responses/Unauthorized"
+        '422':
+          $ref: "#/components/responses/ValidationError"
   "/content_snippets":
     get:
       summary: List all content snippets
@@ -22224,6 +22316,155 @@ components:
           description: The content sources used by AI Agent in the conversation.
           items:
             "$ref": "#/components/schemas/content_source"
+    content_search_article_content_item:
+      title: Content Search Article Content Item
+      type: object
+      description: A single locale variant of a help center article returned from
+        Knowledge Hub search.
+      properties:
+        type:
+          type: string
+          description: Always `article_content`.
+          enum:
+          - article_content
+          example: article_content
+        id:
+          type: string
+          description: The unique identifier of the article content.
+          example: '678'
+        title:
+          type: string
+          description: The localized title of the article.
+          example: Billing FAQ
+        locale:
+          type: string
+          description: The locale of this article content.
+          example: en
+    content_search_article_item:
+      title: Content Search Article Item
+      type: object
+      description: A help center article result from Knowledge Hub search, with
+        one nested `article_content` entry per locale.
+      required:
+      - type
+      properties:
+        type:
+          type: string
+          description: Always `article`.
+          enum:
+          - article
+          example: article
+        id:
+          type: string
+          description: The unique identifier of the article.
+          example: '345'
+        title:
+          type: string
+          description: The article's canonical title.
+          example: Billing FAQ
+        contents:
+          type: array
+          description: One entry per locale of the article.
+          items:
+            "$ref": "#/components/schemas/content_search_article_content_item"
+    content_search_default_item:
+      title: Content Search Default Item
+      type: object
+      description: The flat result shape returned from Knowledge Hub search for
+        content snippets, external pages, uploaded files, and internal articles.
+      required:
+      - type
+      properties:
+        type:
+          type: string
+          description: The kind of content item.
+          enum:
+          - content_snippet
+          - external_content
+          - file_source_content
+          - internal_article
+          example: content_snippet
+        id:
+          type: string
+          description: The unique identifier of the content item.
+          example: '123'
+        title:
+          type: string
+          description: The display title of the content item.
+          example: Billing FAQ
+    content_search_response:
+      title: Content Search Response
+      type: object
+      description: A paginated list of Knowledge Hub content results matching a
+        search query.
+      properties:
+        type:
+          type: string
+          description: Always `list`.
+          enum:
+          - list
+          example: list
+        total_count:
+          type: integer
+          description: Total number of results matching the query.
+          example: 5
+        pages:
+          type: object
+          description: Pagination metadata, including links to neighbouring pages.
+          properties:
+            type:
+              type: string
+              enum:
+              - pages
+              example: pages
+            page:
+              type: integer
+              description: The current page number.
+              example: 1
+            per_page:
+              type: integer
+              description: Number of results per page.
+              example: 10
+            total_pages:
+              type: integer
+              description: Total number of pages of results.
+              example: 1
+            next:
+              type: string
+              format: uri
+              description: A link to the next page of results, or null when on
+                the last page.
+              nullable: true
+              example: https://api.intercom.io/content/search?query=billing&page=2
+            prev:
+              type: string
+              format: uri
+              description: A link to the previous page of results, or null when
+                on the first page.
+              nullable: true
+              example:
+        data:
+          type: array
+          description: The list of matched content items. Each item's `type`
+            field determines its shape.
+          items:
+            "$ref": "#/components/schemas/content_search_result"
+    content_search_result:
+      title: Content Search Result
+      description: A single search result. The `type` field discriminates between
+        the flat shape used for snippets, external pages, files, and internal
+        articles, and the nested shape used for help center articles.
+      oneOf:
+      - "$ref": "#/components/schemas/content_search_default_item"
+      - "$ref": "#/components/schemas/content_search_article_item"
+      discriminator:
+        propertyName: type
+        mapping:
+          content_snippet: "#/components/schemas/content_search_default_item"
+          external_content: "#/components/schemas/content_search_default_item"
+          file_source_content: "#/components/schemas/content_search_default_item"
+          internal_article: "#/components/schemas/content_search_default_item"
+          article: "#/components/schemas/content_search_article_item"
     content_snippet:
       title: Content Snippet
       type: object
@@ -30839,6 +31080,8 @@ tags:
   description: Everything about your Internal Articles
 - name: Jobs
   description: Everything about jobs
+- name: Knowledge Hub
+  description: Search and operations across Knowledge Hub content (content snippets, external pages, uploaded files, internal articles, and help center articles).
 - name: Macros
   description: Operations related to saved replies (macros) in conversations
   x-displayName: Macros

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -6804,7 +6804,7 @@ paths:
                 "$ref": "#/components/schemas/error"
   "/content/search":
     get:
-      summary: Search Knowledge Hub content
+      summary: Search knowledge base contents
       parameters:
       - name: Intercom-Version
         in: header
@@ -6813,7 +6813,7 @@ paths:
       - name: query
         in: query
         required: true
-        description: The keyword(s) to search for across Knowledge Hub content.
+        description: The keyword(s) to search for across the knowledge base contents.
         example: billing
         schema:
           type: string
@@ -6838,10 +6838,10 @@ paths:
           minimum: 1
           maximum: 50
       tags:
-      - Knowledge Hub
+      - Knowledge
       operationId: searchContent
       description: |
-        Search across Knowledge Hub content (content snippets, external pages, uploaded files, internal articles, and help center articles) using a keyword query.
+        Search the knowledge base contents — articles, snippets, external pages, uploaded files, and internal articles — using a keyword query.
 
         Each result row has a `type` discriminator. Most types (`content_snippet`, `external_content`, `file_source_content`, `internal_article`) return a flat `{ type, id, title }` shape. Help center articles return a nested shape with a `contents[]` array, one entry per locale.
 
@@ -31080,8 +31080,8 @@ tags:
   description: Everything about your Internal Articles
 - name: Jobs
   description: Everything about jobs
-- name: Knowledge Hub
-  description: Search and operations across Knowledge Hub content (content snippets, external pages, uploaded files, internal articles, and help center articles).
+- name: Knowledge
+  description: Search the knowledge base contents like articles, snippets, etc.
 - name: Macros
   description: Operations related to saved replies (macros) in conversations
   x-displayName: Macros


### PR DESCRIPTION
### Why?

Adds the OpenAPI schema for `GET /content/search` (Preview) — a keyword search across Knowledge Hub content (content snippets, external pages, uploaded files, internal articles, and help center articles). Supports `query`, `page`, and `per_page` parameters and requires the `read_content` OAuth scope.

### How?

Inserts the new path, five `content_search_*` component schemas, and a `Knowledge Hub` tag into `descriptions/0/api.intercom.io.yaml` at their alphabetical positions.

<details><summary>Decisions</summary>

- Targeted `descriptions/0/api.intercom.io.yaml` only (Preview / unstable mirror), matching the scope of the upstream entry
- Placed the new path before `/content_snippets` and the new schemas before `content_snippet:` to preserve alphabetical ordering
- Used a `oneOf` with a `type` discriminator for `content_search_result`, mapping `article` to `content_search_article_item` and the remaining content types to `content_search_default_item`
- Inserted the `Knowledge Hub` tag between `Jobs` and `Macros` to keep the tag list alphabetical
- Validated via `yaml` parse and `fern-api check` to match the gating CI workflow

</details>

### Review Guidance

| Dimension | Score | Reasoning |
|-----------|-------|-----------|
| Complexity | `░░░░░░░░░░ 0.8` | <details><summary>Why</summary>Pure additive YAML insertions to a single spec file at three alphabetical positions — no cross-cutting logic.</details> |
| Unintuitiveness | `░░░░░░░░░░ 0.4` | <details><summary>Why</summary>Diff matches the PR description and plan exactly: one path, five schemas, one tag, all additive.</details> |
| Risk Surface | `█░░░░░░░░░ 1.8` | <details><summary>Why</summary>Public-mirror OpenAPI spec consumed by external SDK generators/Postman, but change is purely additive and gated by Fern CI.</details> |

**Attention: Routine review** — Routine schema sync — verify the inserted blocks are byte-equivalent to developer-docs PR #926 and CI (fern check) is green.

<sub>🧪 This AI-generated review guidance is experimental. <a href="https://github.com/intercom/parthas/issues/new?title=PR+Risk+Assessment+Feedback&body=PR:+https://github.com/intercom/Intercom-OpenAPI/pull/513%0A%0AFeedback:%0A&labels=risk-assessment-feedback">Share feedback</a></sub>

- Relates to https://github.com/intercom/developer-docs/pull/926
- Relates to https://github.com/intercom/intercom/pull/510798
- Relates to https://github.com/intercom/intercom/pull/512173

<details><summary>Implementation Plan</summary>

<details><summary>Worker Implementation Plan</summary>

# Sync `GET /content/search` schema from developer-docs PR #926 to Intercom-OpenAPI

## Context

The `GET /content/search` endpoint schema just landed in `intercom/developer-docs` via PR #926 (file: `docs/references/@Preview/rest-api/api.intercom.io.yaml`). Per the developer-docs README convention, any YAML change in developer-docs must be mirrored to the public-facing sibling repo `intercom/Intercom-OpenAPI`, which is where external SDK generators (Fern), Postman collections, and partner consumers read from.

Mapping: developer-docs `@Preview` → Intercom-OpenAPI `descriptions/0/api.intercom.io.yaml` (the unstable / Preview spec).

Goal: a public-facing PR that reproduces the same three additive blocks the developer-docs PR added.

## What gets added (3 blocks)

1. **One new path:** `"/content/search"` (GET, `searchContent` operationId, requires `read_content` OAuth scope, tagged `Knowledge Hub`).
2. **Five new component schemas (alphabetical order):**
   - `content_search_article_content_item`
   - `content_search_article_item`
   - `content_search_default_item`
   - `content_search_response`
   - `content_search_result` — a `oneOf` with a `discriminator` keyed on the `type` field. Mapping: `content_snippet | external_content | file_source_content | internal_article → content_search_default_item`; `article → content_search_article_item`.
3. **One new tag:** `Knowledge Hub` with description "Search and operations across Knowledge Hub content (content snippets, external pages, uploaded files, internal articles, and help center articles)."

## Prerequisites verified in destination file

Required `$ref` targets already exist in `descriptions/0/api.intercom.io.yaml`:
- `#/components/responses/Unauthorized` ✅
- `#/components/responses/ValidationError` ✅
- `#/components/schemas/intercom_version_preview` (line 27467) ✅

No additional plumbing needed — the `$ref`s will resolve.

## Exact insertion points in `descriptions/0/api.intercom.io.yaml`

| Block | Insert between current lines | Anchor before | Anchor after |
|---|---|---|---|
| Path `"/content/search"` | 6804 / 6805 | `"$ref": "#/components/schemas/error"` (end of preceding endpoint) | `"/content_snippets":` |
| 5 component schemas (in alphabetical order) | 22226 / 22227 | end of `content_sources_list` schema (`"$ref": "#/components/schemas/content_source"`) | `content_snippet:` |
| `Knowledge Hub` tag | 30841 / 30842 | `Jobs` tag block ends (`description: Everything about jobs`) | `- name: Macros` |

Alphabetical reasoning: `/content/search` < `/content_snippets` because ASCII `/` (0x2F) < `_` (0x5F). `content_search_*` < `content_snippet` because `e` < `n`. Tags are mostly alphabetical and `K` slots cleanly between `Jobs` and `Macros`.

## Source of truth (do NOT modify)

The exact lines to insert come from the developer-docs PR diff, fetched via:
```bash
gh pr diff 926 --repo intercom/developer-docs
```
The diff is a pure additive insert against `docs/references/@Preview/rest-api/api.intercom.io.yaml` — 3 hunks, all additions, no removals. Reproduce the added lines verbatim (including descriptions, examples, indentation) at the destination insertion points above.

## Implementation steps

1. **Fetch the source diff** (re-run if needed):
   ```bash
   gh pr diff 926 --repo intercom/developer-docs > /tmp/pr926.diff
   ```
2. **Apply 3 inserts to `descriptions/0/api.intercom.io.yaml`** using the Edit tool. Three edits, in any order:
   - Edit 1 — path: insert the 92-line `"/content/search":` block between `"$ref": "#/components/schemas/error"` (line 6804) and `"/content_snippets":` (line 6805).
   - Edit 2 — schemas: insert the 5-schema block (~149 lines total, alphabetical order, ending with `content_search_result` and its discriminator mapping) between line 22226 and `content_snippet:` (line 22227).
   - Edit 3 — tag: insert `- name: Knowledge Hub` + description between line 30841 and `- name: Macros` (line 30842).
3. **Validate YAML parses cleanly:**
   ```bash
   node -e "require('yaml').parse(require('fs').readFileSync('descriptions/0/api.intercom.io.yaml','utf8'))"
   ```
   `yaml` is already in `node_modules` per `npm install` (no-op if already present).
4. **(Optional but recommended) Validate with Fern** — the CI workflow `fern_check.yml` runs this on every PR:
   ```bash
   npx --yes fern-api check
   ```
   Run from repo root. If `fern-api` is not pre-installed, this triggers a download. Surface any errors before submit.
5. **Commit** with a focused message:
   ```
   Add GET /content/search schema to Preview spec

   Mirrors developer-docs PR #926. Adds:
   - GET /content/search path
   - content_search_response / _result / _default_item / _article_item / _article_content_item schemas
   - Knowledge Hub tag
   ```
6. **Run `parthas submit`.** This handles rebase, hooks, and reviewer spawn.

## PR description (public-facing, minimal)

The Intercom-OpenAPI repo is public-mirroring — PR descriptions are visible externally. Use:

> Adds the OpenAPI schema for `GET /content/search` (Preview) — a keyword search across Knowledge Hub content (content snippets, external pages, uploaded files, internal articles, and help center articles). Supports `query`, `page`, and `per_page` parameters and requires the `read_content` OAuth scope. Mirrors the developer-docs entry.

No internal ticket numbers, no team names, no internal context. `parthas submit` / `create-pr` will append its footer separately.

## Non-goals

- No edits to any version other than `descriptions/0/api.intercom.io.yaml` (Preview only — the dev-docs PR also only touched `@Preview`).
- No changes to `fern/openapi-overrides.yml`, `preview-openapi-overrides.yml`, or any SDK config — the new schema needs no overrides.
- No reordering of existing schemas, paths, or tags.
- Do not run `fern generate` without `--preview` — that auto-submits SDK PRs (see CLAUDE.md DANGER note).

## Verification

After implementation:
1. `git diff descriptions/0/api.intercom.io.yaml` should show only additions, structurally equivalent to `gh pr diff 926 --repo intercom/developer-docs` (same schema names, descriptions, examples).
2. `node -e "require('yaml').parse(require('fs').readFileSync('descriptions/0/api.intercom.io.yaml','utf8'))"` exits 0.
3. `npx fern-api check` reports no errors (CI will re-run this — must pass).
4. Spot-check the inserted lines render correctly: new path appears before `/content_snippets`, new schemas appear before `content_snippet:`, new tag appears between `Jobs` and `Macros`.

## Key files

- **Edit:** `descriptions/0/api.intercom.io.yaml` (the only file modified)
- **Reference source:** `gh pr diff 926 --repo intercom/developer-docs` — the canonical diff to mirror
- **Validation:** `fern/openapi-overrides.yml` is untouched but worth being aware of (Fern overrides at SDK-gen time); CI workflow `.github/workflows/fern_check.yml` is what gates the PR.


</details>

<details><summary>Parthas Order (task/issue)</summary>

**Sync OpenAPI schema for GET /content/search to Intercom-OpenAPI**

## Problem

The OpenAPI schema for the new `GET /content/search` endpoint was just landed in `intercom/developer-docs` via PR #926 (`@Preview/rest-api/api.intercom.io.yaml`). Per Intercom convention (see `intercom/developer-docs/readme.MD`), any OpenAPI YAML change in developer-docs must be **synced** to the public-facing sibling repo `intercom/Intercom-OpenAPI` — that's where external SDK generators, partners, and the public schema consumers pull from.

The mapping: developer-docs `@Preview` → Intercom-OpenAPI `descriptions/0/api.intercom.io.yaml`.

## Why This Matters

External consumers (Postman collections, OpenAPI-generated SDKs, partner integrations) read from Intercom-OpenAPI, not developer-docs. Without the sync, those consumers can't see the new endpoint or the new schemas. The Captain wants this in before the weekend.

## Goal

A PR in `intercom/Intercom-OpenAPI` that copies the new content/search schema additions from developer-docs PR #926 into `descriptions/0/api.intercom.io.yaml`. PR description is **minimal and public-facing** (no internal context — Intercom-OpenAPI is public-mirroring). CI green on the resulting PR.

## Context

- Repo: `intercom/Intercom-OpenAPI` (registered as Parthas project `Intercom-OpenAPI`).
- Source-of-truth: developer-docs PR https://github.com/intercom/developer-docs/pull/926
- File to edit in this repo: `descriptions/0/api.intercom.io.yaml` (the @Preview/unstable mirror).
- Per `intercom/developer-docs/readme.MD`: "Copy the changed YAML file(s) to the corresponding `descriptions/<version>/api.intercom.io.yaml` in the sibling repo (`@Preview` maps to `descriptions/0/`). Create a PR in the Intercom-OpenAPI repo with a minimal public-facing description (no internal context)."

## Implementation steps

1. **Fetch the diff** from developer-docs PR #926:
   ```bash
   gh pr diff 926 --repo intercom/developer-docs
   ```
   This gives you the exact insertions to mirror.

2. **Inspect the destination file** `descriptions/0/api.intercom.io.yaml` to understand:
   - Does it have the same `components/schemas` and `components/responses` already? (Should — it's the public mirror.)
   - Are the `Unauthorized` + `ValidationError` shared responses defined? (Required for the `$ref` to resolve.)
   - Is the `intercom_version_preview` schema defined?
   - Alphabetical insertion points for the new path (`"/content/search"`) and new component schemas (`content_search_*`).

3. **Apply equivalent insertions:**
   - New path `"/content/search"` at the right alphabetical position
   - 5 new component schemas: `content_search_response`, `content_search_result`, `content_search_default_item`, `content_search_article_item`, `content_search_article_content_item`
   - New `Knowledge Hub` tag in the bottom-of-file `tags:` list

4. **Verify YAML parseability** before committing:
   ```bash
   node -e "require('yaml').parse(require('fs').readFileSync('descriptions/0/api.intercom.io.yaml','utf8'))"
   ```

5. **Open PR with minimal public-facing description.** Suggested body (adapt to actual file conventions in Intercom-OpenAPI):
   > Adds the OpenAPI schema for `GET /content/search` (Preview / unstable) — a keyword search across Knowledge Hub content. Supports `query`, `page`, `per_page` params and the `read_content` OAuth scope. Mirrors the developer-docs entry.

   No internal context, no internal ticket numbers, no team-mention. The Intercom-OpenAPI repo is public-mirroring; PR descriptions are visible externally.

## Acceptance Criteria

- The `descriptions/0/api.intercom.io.yaml` file now contains the same `/content/search` path entry, the 5 component schemas (`content_search_*`), and the `Knowledge Hub` tag that developer-docs PR #926 added.
- The PR's diff is structurally equivalent to developer-docs PR #926's diff — schema names match, descriptions match, examples match. Functional copy.
- PR description is minimal, public-facing, no internal context.
- YAML parses cleanly.
- CI green (Intercom-OpenAPI may have its own linter — surface in plan if you find one).

## Workflow — open a NEW branch off the default branch

Fresh PR off the repo's default branch (likely `main` or `master` — check via `gh repo view intercom/Intercom-OpenAPI`).

## Non-goals

- Do NOT modify any other file or any other endpoint's schema.
- Do NOT update any version mapping or versions config in this repo unless required by structural conventions.
- Do NOT replicate the developer-docs PR description verbatim — that may contain internal context. Write a fresh, minimal, public-facing one.
- Do NOT delete the developer-docs PR #926 — it's the source of truth; both PRs will land independently.

</details>

</details>

<sub>Generated with Claude Code, zen coded with <a href="https://github.com/intercom/parthas">Parthas</a></sub>
