### PR TITLE
Add audience_ids to Content Snippets API (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22281,6 +22281,17 @@ components:
           type: integer
           description: The time the snippet was last updated as a UNIX timestamp.
           example: 1663597223
+        audience_ids:
+          type: array
+          nullable: true
+          description: >-
+            The list of audience IDs this content snippet is targeted to for Fin AI Agent.
+            Empty array means no audience targeting is set.
+          items:
+            type: integer
+          example:
+          - 1
+          - 2
     content_snippet_list:
       title: Content Snippet List
       type: object
@@ -22348,6 +22359,18 @@ components:
           description: The locale of the content snippet. Defaults to `en`.
           default: en
           example: en
+        audience_ids:
+          type: array
+          nullable: true
+          description: >-
+            The list of audience IDs to target this content snippet to for Fin AI Agent.
+            Pass an empty array or omit the field for no audience targeting.
+            Unknown audience IDs return a `404` error with no partial commit.
+          items:
+            type: integer
+          example:
+          - 1
+          - 2
     content_snippet_update_request:
       title: Update Content Snippet Request
       type: object
@@ -22380,6 +22403,19 @@ components:
           type: string
           description: The locale of the content snippet.
           example: en
+        audience_ids:
+          type: array
+          nullable: true
+          description: >-
+            The list of audience IDs to target this content snippet to for Fin AI Agent.
+            Omitting the field leaves existing audience memberships unchanged (PATCH semantics).
+            Pass `[]` to clear all audience memberships.
+            Unknown audience IDs return a `404` error with no partial commit.
+          items:
+            type: integer
+          example:
+          - 1
+          - 2
     conversation_list_item:
       title: Conversation List Item
       type: object


### PR DESCRIPTION
### Why?

Customers integrating with the Content Snippets API need a programmatic way to read and set Fin AI Agent audience targeting on snippets. The behavior shipped in the monolith over three PRs but the OpenAPI spec has not been updated — without that, generated SDKs and Postman collections do not surface the field, and developer-docs cannot be synced.

### How?

Document `audience_ids` as a nullable array of integers on the `content_snippet` response schema and on both write request schemas. The field is gated by the `AddAudienceIdsToContentSnippets` change registered in `UnstableVersion`, so it is Preview-only — stable versions of the spec are untouched.

Monolith PRs being documented:

- https://github.com/intercom/intercom/pull/511599 (GET — read support)
- https://github.com/intercom/intercom/pull/512249 (POST — write support on create)
- https://github.com/intercom/intercom/pull/511780 (PUT — write support on update)

Companion developer-docs PR (syncs the YAML + adds a Preview changelog entry):

- https://github.com/intercom/developer-docs/pull/927

The PUT endpoint uses PATCH semantics: omitting `audience_ids` leaves memberships intact; sending `[]` clears them. Unknown audience IDs return `404` with no partial commit. Audience targeting on snippets is a single entity (no per-locale nesting, unlike articles), so the field stays flat on the schema root.

_sent by alexbot_
