### PR TITLE
Add audience_ids to Internal Articles API (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -20360,6 +20360,17 @@ components:
           nullable: true
           description: The ID of the folder this article belongs to, or null if not in a folder.
           example: 6
+        audience_ids:
+          type: array
+          nullable: true
+          description: >-
+            The list of audience IDs this internal article is targeted to for Fin AI Agent.
+            Empty array means no audience targeting is set.
+          items:
+            type: integer
+          example:
+          - 1
+          - 2
     article_search_highlights:
       title: Article Search Highlights
       type: object
@@ -23409,6 +23420,18 @@ components:
           nullable: true
           description: The ID of the folder to place this article in, or null to leave it without a folder.
           example: 6
+        audience_ids:
+          type: array
+          nullable: true
+          description: >-
+            The list of audience IDs to target this internal article to for Fin AI Agent.
+            Pass an empty array or omit the field for no audience targeting.
+            Unknown audience IDs return a `404` error with no partial commit.
+          items:
+            type: integer
+          example:
+          - 1
+          - 2
       required:
       - title
       - owner_id
@@ -29801,6 +29824,19 @@ components:
           nullable: true
           description: The ID of the folder to place this article in, or null to remove it from its folder.
           example: 6
+        audience_ids:
+          type: array
+          nullable: true
+          description: >-
+            The list of audience IDs to target this internal article to for Fin AI Agent.
+            Omitting the field leaves existing audience memberships unchanged (PATCH semantics).
+            Pass `[]` to clear all audience memberships.
+            Unknown audience IDs return a `404` error with no partial commit.
+          items:
+            type: integer
+          example:
+          - 1
+          - 2
     update_collection_request:
       description: You can update a collection
       type: object


### PR DESCRIPTION
### Why?

Customers integrating with the Internal Articles API need a programmatic way to read and set Fin AI Agent audience targeting on internal articles. The behavior shipped in the monolith over three PRs but the OpenAPI spec has not been updated — without that, generated SDKs and Postman collections do not surface the field, and developer-docs cannot be synced.

### How?

Document `audience_ids` as a nullable array of integers on the `internal_article_list_item` response schema (which `internal_article` extends via `allOf`, so all read paths inherit it) and on both write request schemas. The field is gated by the `AddAudienceIdsToInternalArticles` change registered in `UnstableVersion`, so it is Preview-only — stable versions of the spec are untouched.

Monolith PRs being documented:

- https://github.com/intercom/intercom/pull/511232 (GET — read support)
- https://github.com/intercom/intercom/pull/512335 (POST — write support on create)
- https://github.com/intercom/intercom/pull/511815 (PUT — write support on update)

Companion developer-docs PR (syncs the YAML + adds a Preview changelog entry):

- https://github.com/intercom/developer-docs/pull/928

The PUT endpoint uses PATCH semantics: omitting `audience_ids` leaves memberships intact; sending `[]` clears them. Unknown audience IDs return `404` with no partial commit. Internal articles are a single entity (no per-locale nesting, unlike multilingual help-center articles), so the field stays flat on the schema root.

_sent by alexbot_
