### PR TITLE
Add audience_ids to AI External Pages API (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -1033,7 +1033,7 @@ paths:
                   value:
                     type: error.list
                     errors:
-                    - code: invalid_parameter
+                    - code: parameter_invalid
                       message: 'audience_ids contains unknown audience IDs: 999'
               schema:
                 "$ref": "#/components/schemas/error"
@@ -1227,7 +1227,7 @@ paths:
                   value:
                     type: error.list
                     errors:
-                    - code: invalid_parameter
+                    - code: parameter_invalid
                       message: 'audience_ids contains unknown audience IDs: 999'
               schema:
                 "$ref": "#/components/schemas/error"

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -1097,6 +1097,9 @@ paths:
                     created_at: 1734537276
                     updated_at: 1734537276
                     last_ingested_at: 1734537276
+                    audience_ids:
+                    - 1
+                    - 2
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -916,6 +916,9 @@ paths:
                       created_at: 1734537269
                       updated_at: 1734537269
                       last_ingested_at: 1734537269
+                      audience_ids:
+                      - 1
+                      - 2
                     - id: '18'
                       type: external_page
                       title: My External Content
@@ -1002,6 +1005,9 @@ paths:
                     created_at: 1734537273
                     updated_at: 1734537274
                     last_ingested_at: 1734537274
+                    audience_ids:
+                    - 1
+                    - 2
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -1016,6 +1022,19 @@ paths:
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+        '404':
+          description: Unknown audience IDs
+          content:
+            application/json:
+              examples:
+                Unknown audience IDs:
+                  value:
+                    type: error.list
+                    errors:
+                    - code: invalid_parameter
+                      message: 'audience_ids contains unknown audience IDs: 999'
               schema:
                 "$ref": "#/components/schemas/error"
       requestBody:
@@ -1033,6 +1052,9 @@ paths:
                   source_id: 44
                   title: Test
                   url: https://www.example.com
+                  audience_ids:
+                  - 1
+                  - 2
   "/ai/external_pages/{id}":
     parameters:
     - name: id
@@ -1124,6 +1146,9 @@ paths:
                     created_at: 1734537278
                     updated_at: 1734537278
                     last_ingested_at: 1734537278
+                    audience_ids:
+                    - 1
+                    - 2
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -1174,6 +1199,9 @@ paths:
                     created_at: 1734537280
                     updated_at: 1734537281
                     last_ingested_at: 1734537281
+                    audience_ids:
+                    - 1
+                    - 2
               schema:
                 "$ref": "#/components/schemas/external_page"
         '401':
@@ -1188,6 +1216,19 @@ paths:
                     errors:
                     - code: unauthorized
                       message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+        '404':
+          description: Unknown audience IDs
+          content:
+            application/json:
+              examples:
+                Unknown audience IDs:
+                  value:
+                    type: error.list
+                    errors:
+                    - code: invalid_parameter
+                      message: 'audience_ids contains unknown audience IDs: 999'
               schema:
                 "$ref": "#/components/schemas/error"
       requestBody:
@@ -1205,6 +1246,9 @@ paths:
                   source_id: 47
                   title: Test
                   url: https://www.example.com
+                  audience_ids:
+                  - 1
+                  - 2
   "/articles":
     get:
       summary: List all articles

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -23839,6 +23839,20 @@ components:
           description: The identifier for the external page which was given by the
             source. Must be unique for the source.
           example: '5678'
+        audience_ids:
+          type: array
+          nullable: true
+          description: >-
+            The list of audience IDs to target this external page to for Fin AI Agent.
+            Omitting the field preserves any default audience segments inherited from the parent content import source.
+            Pass an explicit array to override inherited defaults with the given set.
+            Pass `[]` to clear all audience memberships (even if the source has defaults).
+            Unknown audience IDs return a `404` error with no partial commit.
+          items:
+            type: integer
+          example:
+          - 1
+          - 2
       required:
       - title
       - html
@@ -26483,6 +26497,17 @@ components:
           format: date-time
           description: The time when the external page was last ingested.
           example: 1672928610
+        audience_ids:
+          type: array
+          nullable: true
+          description: >-
+            The list of audience IDs this external page is targeted to for Fin AI Agent.
+            Empty array means no audience targeting is set.
+          items:
+            type: integer
+          example:
+          - 1
+          - 2
       required:
       - id
       - type
@@ -30038,6 +30063,19 @@ components:
           description: The identifier for the external page which was given by the
             source. Must be unique for the source.
           example: '5678'
+        audience_ids:
+          type: array
+          nullable: true
+          description: >-
+            The list of audience IDs to target this external page to for Fin AI Agent.
+            Omitting the field leaves existing audience memberships unchanged (PATCH semantics).
+            Pass `[]` to clear all audience memberships.
+            Unknown audience IDs return a `404` error with no partial commit.
+          items:
+            type: integer
+          example:
+          - 1
+          - 2
       required:
       - title
       - html


### PR DESCRIPTION
### Why?

Customers integrating with the AI External Pages API now need to read and set Fin AI Agent audience targeting on external pages programmatically. The behavior shipped in the monolith over three PRs but the OpenAPI spec has not been updated — generated SDKs and Postman collections do not surface the field, and developer-docs cannot be synced until this lands.

### How?

Document `audience_ids` as a nullable array of integers on the `external_page` response schema and on both write request schemas. The field is gated by the `AddAudienceIdsToExternalPages` change registered in `UnstableVersion`, so it is Preview-only.

Monolith PRs being documented:

- https://github.com/intercom/intercom/pull/512971 (GET — read support)
- https://github.com/intercom/intercom/pull/513583 (POST — write support on create/upsert)
- https://github.com/intercom/intercom/pull/513451 (PUT — write support on update)

External pages have a unique inheritance dimension because they belong to a parent content import source that can carry default audience segments:

- **POST** — omitting `audience_ids` preserves any defaults inherited from the parent import source. An explicit array overrides those defaults. `[]` clears all targeting (even when the source has defaults).
- **PUT** — PATCH semantics matching the other knowledge-API write endpoints. Omitting leaves memberships intact; `[]` clears; an explicit array replaces.

Unknown audience IDs return `404` with no partial commit. A companion developer-docs PR with the matching schema additions will follow (changelog entry intentionally deferred — will be folded into a single follow-up PR covering all knowledge content types).

_sent by alexbot_