### PR TITLE
Add agent availability fields to Preview API spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -23216,12 +23216,15 @@ components:
           example: "# How to reset your password\n\nNavigate to Settings > Security > Reset password.\n"
         chatbot_availability:
           type: integer
-          description: Whether this snippet is available for Fin (1 = on, 0 = off).
+          deprecated: true
+          description: Deprecated. Use ai_chatbot_availability instead. Whether this
+            snippet is available for Fin (1 = on, 0 = off).
           example: 1
         copilot_availability:
           type: integer
-          description: Whether this snippet is available for Copilot (1 = on, 0 =
-            off).
+          deprecated: true
+          description: Deprecated. Use ai_copilot_availability instead. Whether this
+            snippet is available for Copilot (1 = on, 0 = off).
           example: 1
         ai_chatbot_availability:
           type: boolean

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -909,6 +909,7 @@ paths:
                       url: https://support.example.com/us/3
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 42
@@ -923,6 +924,7 @@ paths:
                       url: https://support.example.com/us/2
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 41
@@ -937,6 +939,7 @@ paths:
                       url: https://support.example.com/us/1
                       ai_agent_availability: true
                       ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       fin_availability: true
                       locale: en
                       source_id: 40
@@ -995,6 +998,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 44
@@ -1068,6 +1072,7 @@ paths:
                     url: https://support.example.com/us/5
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 45
@@ -1117,6 +1122,7 @@ paths:
                     url: https://support.example.com/us/6
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 46
@@ -1167,6 +1173,7 @@ paths:
                     url: https://www.example.com
                     ai_agent_availability: true
                     ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     fin_availability: true
                     locale: en
                     source_id: 47
@@ -2622,6 +2629,9 @@ paths:
                       audience_ids:
                       - 1
                       - 2
+                      ai_chatbot_availability: true
+                      ai_copilot_availability: true
+                      ai_sales_agent_availability: true
               schema:
                 "$ref": "#/components/schemas/internal_article_list"
         '401':
@@ -2667,6 +2677,9 @@ paths:
                     audience_ids:
                     - 1
                     - 2
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
               schema:
                 "$ref": "#/components/schemas/internal_article"
         '400':
@@ -2770,6 +2783,9 @@ paths:
                     audience_ids:
                     - 1
                     - 2
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
               schema:
                 "$ref": "#/components/schemas/internal_article"
         '404':
@@ -2836,6 +2852,9 @@ paths:
                     audience_ids:
                     - 1
                     - 2
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
               schema:
                 "$ref": "#/components/schemas/internal_article"
         '404':
@@ -6885,6 +6904,9 @@ paths:
                       body_markdown: "# How to reset your password\n\nNavigate to Settings > Security > Reset password.\n"
                       chatbot_availability: 1
                       copilot_availability: 1
+                      ai_chatbot_availability: true
+                      ai_copilot_availability: true
+                      ai_sales_agent_availability: true
                       created_at: 1663597223
                       updated_at: 1663597223
                       audience_ids:
@@ -6942,6 +6964,9 @@ paths:
                     body_markdown: "# How to reset your password\n\nNavigate to Settings > Security > Reset password.\n"
                     chatbot_availability: 1
                     copilot_availability: 1
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     created_at: 1663597223
                     updated_at: 1663597223
                     audience_ids:
@@ -7012,6 +7037,9 @@ paths:
                     body_markdown: "# How to reset your password\n\nNavigate to Settings > Security > Reset password.\n"
                     chatbot_availability: 1
                     copilot_availability: 1
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     created_at: 1663597223
                     updated_at: 1663597223
                     audience_ids:
@@ -7084,6 +7112,9 @@ paths:
                     body_markdown: "# How to reset your password (updated)\n\nGo to Settings > Security > Reset password and follow the steps.\n"
                     chatbot_availability: 1
                     copilot_availability: 1
+                    ai_chatbot_availability: true
+                    ai_copilot_availability: true
+                    ai_sales_agent_availability: true
                     created_at: 1663597223
                     updated_at: 1663597300
                     audience_ids:
@@ -21267,6 +21298,18 @@ components:
           example:
           - 1
           - 2
+        ai_chatbot_availability:
+          type: boolean
+          description: Whether the internal article is available for AI Chatbot (Fin).
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the internal article is available for AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the internal article is available for AI Sales Agent.
+          example: true
     article_search_highlights:
       title: Article Search Highlights
       type: object
@@ -23180,6 +23223,18 @@ components:
           description: Whether this snippet is available for Copilot (1 = on, 0 =
             off).
           example: 1
+        ai_chatbot_availability:
+          type: boolean
+          description: Whether the content snippet is available for AI Chatbot (Fin).
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the content snippet is available for AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the content snippet is available for AI Sales Agent.
+          example: true
         created_at:
           type: integer
           description: The time the snippet was created as a UNIX timestamp.
@@ -23278,6 +23333,24 @@ components:
           example:
           - 1
           - 2
+        ai_chatbot_availability:
+          type: boolean
+          description: Whether the content snippet should be available for AI Chatbot
+            (Fin). Defaults to false.
+          default: false
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the content snippet should be available for AI Copilot.
+            Defaults to false.
+          default: false
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the content snippet should be available for AI Sales
+            Agent. Defaults to false.
+          default: false
+          example: true
     content_snippet_update_request:
       title: Update Content Snippet Request
       type: object
@@ -23323,6 +23396,20 @@ components:
           example:
           - 1
           - 2
+        ai_chatbot_availability:
+          type: boolean
+          description: Whether the content snippet should be available for AI Chatbot
+            (Fin).
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the content snippet should be available for AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the content snippet should be available for AI Sales
+            Agent.
+          example: true
     conversation_list_item:
       title: Conversation List Item
       type: object
@@ -24344,6 +24431,21 @@ components:
           example:
           - 1
           - 2
+        ai_chatbot_availability:
+          type: boolean
+          description: Whether the article should be available for AI Chatbot (Fin).
+            For multilingual articles, this sets the default language's availability.
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the article should be available for AI Copilot. For
+            multilingual articles, this sets the default language's availability.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the article should be available for AI Sales Agent.
+            For multilingual articles, this sets the default language's availability.
+          example: true
       required:
       - title
       - author_id
@@ -24391,6 +24493,24 @@ components:
           example:
           - 1
           - 2
+        ai_chatbot_availability:
+          type: boolean
+          description: Whether the internal article should be available for AI Chatbot
+            (Fin). Defaults to false.
+          default: false
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the internal article should be available for AI Copilot.
+            Defaults to false.
+          default: false
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the internal article should be available for AI Sales
+            Agent. Defaults to false.
+          default: false
+          example: true
       required:
       - title
       - owner_id
@@ -24798,6 +24918,12 @@ components:
           type: boolean
           description: Whether the external page should be used to answer questions
             by AI Copilot. Will not default when updating an existing external page.
+          default: false
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the external page should be used to answer questions
+            by AI Sales Agent. Will not default when updating an existing external page.
           default: false
           example: true
         locale:
@@ -27878,10 +28004,15 @@ components:
           description: Whether the external page should be used to answer questions
             by AI Copilot.
           example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the external page should be used to answer questions
+            by AI Sales Agent.
+          example: true
         fin_availability:
           type: boolean
-          description: Deprecated. Use ai_agent_availability and ai_copilot_availability
-            instead.
+          description: Deprecated. Use ai_agent_availability, ai_copilot_availability,
+            and ai_sales_agent_availability instead.
           example: true
         locale:
           type: string
@@ -31206,6 +31337,21 @@ components:
           example:
           - 1
           - 2
+        ai_chatbot_availability:
+          type: boolean
+          description: Whether the article should be available for AI Chatbot (Fin).
+            For multilingual articles, this sets the default language's availability.
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the article should be available for AI Copilot. For
+            multilingual articles, this sets the default language's availability.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the article should be available for AI Sales Agent.
+            For multilingual articles, this sets the default language's availability.
+          example: true
     update_internal_article_request:
       description: You can Update an Internal Article
       type: object
@@ -31250,6 +31396,20 @@ components:
           example:
           - 1
           - 2
+        ai_chatbot_availability:
+          type: boolean
+          description: Whether the internal article should be available for AI Chatbot
+            (Fin).
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the internal article should be available for AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the internal article should be available for AI Sales
+            Agent.
+          example: true
     update_collection_request:
       description: You can update a collection
       type: object
@@ -31460,11 +31620,25 @@ components:
           description: The URL of the external page. This will be used by Fin to link
             end users to the page it based its answer on.
           example: https://help.example.com/en/articles/1234-getting-started
-        fin_availability:
+        ai_agent_availability:
           type: boolean
           description: Whether the external page should be used to answer questions
-            by Fin.
-          default: true
+            by AI Agent.
+          example: true
+        ai_copilot_availability:
+          type: boolean
+          description: Whether the external page should be used to answer questions
+            by AI Copilot.
+          example: true
+        ai_sales_agent_availability:
+          type: boolean
+          description: Whether the external page should be used to answer questions
+            by AI Sales Agent.
+          example: true
+        fin_availability:
+          type: boolean
+          description: Deprecated. Use ai_agent_availability, ai_copilot_availability,
+            and ai_sales_agent_availability instead.
           example: true
         locale:
           type: string


### PR DESCRIPTION
### Why?

The three boolean fields `ai_chatbot_availability`, `ai_copilot_availability`, and `ai_sales_agent_availability` were recently added to the underlying API implementation for Content Snippets, Internal Articles, Articles, and External Pages. This PR updates the Preview OpenAPI spec so the published documentation reflects those fields.

### How?

Add the three boolean fields to schema definitions and inline examples for the affected resources in `descriptions/0/api.intercom.io.yaml`. Where `fin_availability` is now superseded, a deprecation note is added pointing to the new fields.

<sub>Generated with Claude Code</sub>