### PR TITLE
Add email field to contact_reference schema

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -7479,6 +7479,7 @@ paths:
                         - type: contact
                           id: 6762f0f31bb69f9f2193bb8b
                           external_id: '70'
+                          email: joe@example.com
                       first_contact_reply:
                       admin_assignee_id: 991267715
                       team_assignee_id: 5017691
@@ -7724,6 +7725,7 @@ paths:
                       - type: contact
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                     admin_assignee_id: 991267715
                     team_assignee_id: 5017691
@@ -7904,6 +7906,7 @@ paths:
                       - type: contact
                         id: 6762f1261bb69f9f2193bba7
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                     admin_assignee_id: 991267715
                     team_assignee_id: 5017691
@@ -8160,6 +8163,7 @@ paths:
                       - type: contact
                         id: 6762f1301bb69f9f2193bbab
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                     admin_assignee_id: 991267715
                     team_assignee_id: 5017691
@@ -8261,6 +8265,7 @@ paths:
                       - type: contact
                         id: 6762f1341bb69f9f2193bbac
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                     admin_assignee_id: 991267715
                     team_assignee_id: 5017691
@@ -8613,6 +8618,7 @@ paths:
                         - type: contact
                           id: 6762f14a1bb69f9f2193bbb3
                           external_id: '70'
+                          email: joe@example.com
                       first_contact_reply:
                       admin_assignee_id: 991267715
                       team_assignee_id: 5017691
@@ -8716,6 +8722,7 @@ paths:
                       - type: contact
                         id: 6762f1571bb69f9f2193bbbb
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                       created_at: 1734537561
                       type: conversation
@@ -8799,6 +8806,7 @@ paths:
                       - type: contact
                         id: 6762f15b1bb69f9f2193bbbc
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                     admin_assignee_id: 991267715
                     team_assignee_id: 5017691
@@ -8891,6 +8899,7 @@ paths:
                       - type: contact
                         id: 6762f15e1bb69f9f2193bbbd
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                     admin_assignee_id: 991267715
                     team_assignee_id: 5017691
@@ -8971,6 +8980,7 @@ paths:
                       - type: contact
                         id: 6762f1621bb69f9f2193bbbe
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                       created_at: 1734537572
                       type: conversation
@@ -9178,6 +9188,7 @@ paths:
                       - type: contact
                         id: 6762f16e1bb69f9f2193bbc2
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                     admin_assignee_id: 991267715
                     team_assignee_id: 5017691
@@ -9258,6 +9269,7 @@ paths:
                       - type: contact
                         id: 6762f1711bb69f9f2193bbc3
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                     admin_assignee_id: 991267715
                     team_assignee_id: 5017691
@@ -9418,6 +9430,7 @@ paths:
                       - type: contact
                         id: 6762f1831bb69f9f2193bbcc
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                     admin_assignee_id: 991267715
                     team_assignee_id: 5017691
@@ -10127,6 +10140,7 @@ paths:
                       - type: contact
                         id: 6762f1f81bb69f9f2193bc09
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                       created_at: 1734537722
                       type: conversation
@@ -10289,6 +10303,7 @@ paths:
                       - type: contact
                         id: 6762f1571bb69f9f2193bbbb
                         external_id: '70'
+                        email: joe@example.com
                     first_contact_reply:
                       created_at: 1734537561
                       type: conversation
@@ -10481,6 +10496,7 @@ paths:
                       - type: contact
                         id: 6762f2041bb69f9f2193bc0c
                         external_id: '70'
+                        email: joe@example.com
                     admin_assignee_id: 0
                     team_assignee_id: 0
                     created_at: 1734537732
@@ -17738,6 +17754,7 @@ paths:
                       - type: contact
                         id: 6762f2d81bb69f9f2193bc54
                         external_id: '70'
+                        email: joe@example.com
                     admin_assignee_id: 0
                     team_assignee_id: 0
                     created_at: 1734537944
@@ -22757,6 +22774,11 @@ components:
           description: The unique identifier for the contact which is provided by
             the Client.
           example: "70"
+        email:
+          type: string
+          nullable: true
+          description: The email address of the contact.
+          example: joe@example.com
     contact_reply_base_request:
       title: Contact Reply Base Object
       type: object


### PR DESCRIPTION
### Why?

Contact reference objects in conversation responses were missing the `email` field, requiring consumers to perform a separate contact lookup. This is particularly painful for compliance archiving use cases.

### How?

Adds `email` to the `contact_reference` schema in `descriptions/0/api.intercom.io.yaml` (Preview API).

Companion to intercom/intercom#514973 and intercom/developer-docs#936

<sub>Generated with Claude Code</sub>