### PR TITLE
Add Audiences CRUD to Preview OpenAPI spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -1798,11 +1798,31 @@ paths:
                     - type: audience
                       id: '123'
                       name: VIP Customers
+                      predicates:
+                      - attribute: company.name
+                        type: string
+                        comparison: contains
+                        value: Acme
+                      role_predicates:
+                      - attribute: role
+                        type: role
+                        comparison: eq
+                        value: user
                       created_at: 1717200000
                       updated_at: 1717200000
                     - type: audience
                       id: '456'
                       name: Enterprise Accounts
+                      predicates:
+                      - attribute: custom_attributes.plan
+                        type: string
+                        comparison: eq
+                        value: enterprise
+                      role_predicates:
+                      - attribute: role
+                        type: role
+                        comparison: eq
+                        value: user
                       created_at: 1717200000
                       updated_at: 1717200000
                     total_count: 2
@@ -1836,46 +1856,8 @@ paths:
       - Audiences
       operationId: createAudience
       description: You can create a new audience by making a POST request to `https://api.intercom.io/audiences`.
-      responses:
-        '200':
-          description: Audience created
-          content:
-            application/json:
-              examples:
-                Audience created:
-                  value:
-                    type: audience
-                    id: '789'
-                    name: VIP Customers
-                    predicates:
-                    - attribute: role
-                      type: role
-                      comparison: eq
-                      value: user
-                    role_predicates:
-                    - attribute: role
-                      type: role
-                      comparison: eq
-                      value: user
-                    created_at: 1717200000
-                    updated_at: 1717200000
-              schema:
-                "$ref": "#/components/schemas/audience"
-        '401':
-          description: Unauthorized
-          content:
-            application/json:
-              examples:
-                Unauthorized:
-                  value:
-                    type: error.list
-                    request_id: a3e6b0c1-4f2d-4e8a-9c7b-1d2e3f4a5b6c
-                    errors:
-                    - code: unauthorized
-                      message: Access Token Invalid
-              schema:
-                "$ref": "#/components/schemas/error"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1886,15 +1868,68 @@ paths:
                 value:
                   name: VIP Customers
                   predicates:
-                  - attribute: role
-                    type: role
-                    comparison: eq
-                    value: user
+                  - attribute: company.name
+                    type: string
+                    comparison: contains
+                    value: Acme
                   role_predicates:
                   - attribute: role
                     type: role
                     comparison: eq
                     value: user
+      responses:
+        '201':
+          description: Audience created
+          content:
+            application/json:
+              examples:
+                Audience created:
+                  value:
+                    type: audience
+                    id: '789'
+                    name: VIP Customers
+                    predicates:
+                    - attribute: company.name
+                      type: string
+                      comparison: contains
+                      value: Acme
+                    role_predicates:
+                    - attribute: role
+                      type: role
+                      comparison: eq
+                      value: user
+                    created_at: 1717200000
+                    updated_at: 1717200000
+              schema:
+                "$ref": "#/components/schemas/audience"
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              examples:
+                Validation error:
+                  value:
+                    type: error.list
+                    request_id: a3e6b0c1-4f2d-4e8a-9c7b-1d2e3f4a5b6c
+                    errors:
+                    - code: validation_error
+                      message: Name is required
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                Unauthorized:
+                  value:
+                    type: error.list
+                    request_id: c1d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f
+                    errors:
+                    - code: unauthorized
+                      message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
   "/audiences/{id}":
     get:
       summary: Retrieve an audience
@@ -1914,7 +1949,7 @@ paths:
       - Audiences
       operationId: retrieveAudience
       description: You can fetch the details of a single audience by making a GET request
-        to `https://api.intercom.io/audiences/<id>`.
+        to `https://api.intercom.io/audiences/{id}`.
       responses:
         '200':
           description: Audience found
@@ -1927,10 +1962,10 @@ paths:
                     id: '123'
                     name: VIP Customers
                     predicates:
-                    - attribute: role
-                      type: role
-                      comparison: eq
-                      value: user
+                    - attribute: company.name
+                      type: string
+                      comparison: contains
+                      value: Acme
                     role_predicates:
                     - attribute: role
                       type: role
@@ -1986,7 +2021,22 @@ paths:
       - Audiences
       operationId: updateAudience
       description: You can update the details of a single audience by making a PUT request
-        to `https://api.intercom.io/audiences/<id>`.
+        to `https://api.intercom.io/audiences/{id}`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/update_audience_request"
+            examples:
+              audience_updated:
+                summary: Audience updated
+                value:
+                  name: Enterprise Accounts
+                  predicates:
+                  - attribute: custom_attributes.plan
+                    type: string
+                    comparison: eq
+                    value: enterprise
       responses:
         '200':
           description: Audience updated
@@ -1999,10 +2049,10 @@ paths:
                     id: '123'
                     name: Enterprise Accounts
                     predicates:
-                    - attribute: role
-                      type: role
+                    - attribute: custom_attributes.plan
+                      type: string
                       comparison: eq
-                      value: user
+                      value: enterprise
                     role_predicates:
                     - attribute: role
                       type: role
@@ -2026,6 +2076,20 @@ paths:
                       message: Resource Not Found
               schema:
                 "$ref": "#/components/schemas/error"
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              examples:
+                Validation error:
+                  value:
+                    type: error.list
+                    request_id: f0a1b2c3-4d5e-6f7a-8b9c-0d1e2f3a4b5c
+                    errors:
+                    - code: validation_error
+                      message: Name must not be blank
+              schema:
+                "$ref": "#/components/schemas/error"
         '401':
           description: Unauthorized
           content:
@@ -2040,21 +2104,6 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/update_audience_request"
-            examples:
-              audience_updated:
-                summary: Audience updated
-                value:
-                  name: Enterprise Accounts
-                  predicates:
-                  - attribute: role
-                    type: role
-                    comparison: eq
-                    value: user
     delete:
       summary: Delete an audience
       parameters:
@@ -2072,7 +2121,7 @@ paths:
       tags:
       - Audiences
       operationId: deleteAudience
-      description: You can delete a single audience by making a DELETE request to `https://api.intercom.io/audiences/<id>`.
+      description: You can delete a single audience by making a DELETE request to `https://api.intercom.io/audiences/{id}`.
       responses:
         '204':
           description: Audience deleted
@@ -21130,6 +21179,7 @@ components:
           enum:
           - audience
           example: audience
+          readOnly: true
         id:
           type: string
           description: The unique identifier representing the audience.
@@ -21145,13 +21195,14 @@ components:
           items:
             "$ref": "#/components/schemas/predicate"
           example:
-          - attribute: role
-            type: role
-            comparison: eq
-            value: user
+          - attribute: company.name
+            type: string
+            comparison: contains
+            value: Acme
         role_predicates:
           type: array
-          description: Additional role-based predicates for the audience.
+          description: Role-based predicates that further filter audience membership by
+            contact role.
           items:
             "$ref": "#/components/schemas/predicate"
           example:
@@ -21209,19 +21260,19 @@ components:
         attribute:
           type: string
           description: The attribute to filter on.
-          example: role
+          example: company.name
         type:
           type: string
           description: The type of the attribute.
-          example: role
+          example: string
         comparison:
           type: string
           description: The comparison operator.
-          example: eq
+          example: contains
         value:
           type: string
           description: The value to compare against.
-          example: user
+          example: Acme
     article:
       title: Article
       type: object
@@ -24692,13 +24743,14 @@ components:
           items:
             "$ref": "#/components/schemas/predicate"
           example:
-          - attribute: role
-            type: role
-            comparison: eq
-            value: user
+          - attribute: company.name
+            type: string
+            comparison: contains
+            value: Acme
         role_predicates:
           type: array
-          description: Additional role-based predicates for the audience.
+          description: Role-based predicates that further filter audience membership by
+            contact role.
           items:
             "$ref": "#/components/schemas/predicate"
           example:
@@ -31620,20 +31672,21 @@ components:
         name:
           type: string
           description: The name of the audience.
-          example: VIP Customers
+          example: Enterprise Accounts
         predicates:
           type: array
           description: The predicates that define which contacts belong to the audience.
           items:
             "$ref": "#/components/schemas/predicate"
           example:
-          - attribute: role
-            type: role
+          - attribute: custom_attributes.plan
+            type: string
             comparison: eq
-            value: user
+            value: enterprise
         role_predicates:
           type: array
-          description: Additional role-based predicates for the audience.
+          description: Role-based predicates that further filter audience membership by
+            contact role.
           items:
             "$ref": "#/components/schemas/predicate"
           example:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -1825,6 +1825,285 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+    post:
+      summary: Create an audience
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      tags:
+      - Audiences
+      operationId: createAudience
+      description: You can create a new audience by making a POST request to `https://api.intercom.io/audiences`.
+      responses:
+        '200':
+          description: Audience created
+          content:
+            application/json:
+              examples:
+                Audience created:
+                  value:
+                    type: audience
+                    id: '789'
+                    name: VIP Customers
+                    predicates:
+                    - attribute: role
+                      type: role
+                      comparison: eq
+                      value: user
+                    role_predicates:
+                    - attribute: role
+                      type: role
+                      comparison: eq
+                      value: user
+                    created_at: 1717200000
+                    updated_at: 1717200000
+              schema:
+                "$ref": "#/components/schemas/audience"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                Unauthorized:
+                  value:
+                    type: error.list
+                    request_id: a3e6b0c1-4f2d-4e8a-9c7b-1d2e3f4a5b6c
+                    errors:
+                    - code: unauthorized
+                      message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/create_audience_request"
+            examples:
+              audience_created:
+                summary: Audience created
+                value:
+                  name: VIP Customers
+                  predicates:
+                  - attribute: role
+                    type: role
+                    comparison: eq
+                    value: user
+                  role_predicates:
+                  - attribute: role
+                    type: role
+                    comparison: eq
+                    value: user
+  "/audiences/{id}":
+    get:
+      summary: Retrieve an audience
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      - name: id
+        in: path
+        required: true
+        description: The unique identifier for the audience.
+        example: '123'
+        schema:
+          type: string
+      tags:
+      - Audiences
+      operationId: retrieveAudience
+      description: You can fetch the details of a single audience by making a GET request
+        to `https://api.intercom.io/audiences/<id>`.
+      responses:
+        '200':
+          description: Audience found
+          content:
+            application/json:
+              examples:
+                Audience found:
+                  value:
+                    type: audience
+                    id: '123'
+                    name: VIP Customers
+                    predicates:
+                    - attribute: role
+                      type: role
+                      comparison: eq
+                      value: user
+                    role_predicates:
+                    - attribute: role
+                      type: role
+                      comparison: eq
+                      value: user
+                    created_at: 1717200000
+                    updated_at: 1717200000
+              schema:
+                "$ref": "#/components/schemas/audience"
+        '404':
+          description: Audience not found
+          content:
+            application/json:
+              examples:
+                Audience not found:
+                  value:
+                    type: error.list
+                    request_id: d5e6f7a8-1b2c-3d4e-5f6a-7b8c9d0e1f2a
+                    errors:
+                    - code: not_found
+                      message: Resource Not Found
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                Unauthorized:
+                  value:
+                    type: error.list
+                    request_id: c4d5e6f7-8a9b-0c1d-2e3f-4a5b6c7d8e9f
+                    errors:
+                    - code: unauthorized
+                      message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+    put:
+      summary: Update an audience
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      - name: id
+        in: path
+        required: true
+        description: The unique identifier for the audience.
+        example: '123'
+        schema:
+          type: string
+      tags:
+      - Audiences
+      operationId: updateAudience
+      description: You can update the details of a single audience by making a PUT request
+        to `https://api.intercom.io/audiences/<id>`.
+      responses:
+        '200':
+          description: Audience updated
+          content:
+            application/json:
+              examples:
+                Audience updated:
+                  value:
+                    type: audience
+                    id: '123'
+                    name: Enterprise Accounts
+                    predicates:
+                    - attribute: role
+                      type: role
+                      comparison: eq
+                      value: user
+                    role_predicates:
+                    - attribute: role
+                      type: role
+                      comparison: eq
+                      value: user
+                    created_at: 1717200000
+                    updated_at: 1717200100
+              schema:
+                "$ref": "#/components/schemas/audience"
+        '404':
+          description: Audience not found
+          content:
+            application/json:
+              examples:
+                Audience not found:
+                  value:
+                    type: error.list
+                    request_id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
+                    errors:
+                    - code: not_found
+                      message: Resource Not Found
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                Unauthorized:
+                  value:
+                    type: error.list
+                    request_id: f8a9b0c1-2d3e-4f5a-6b7c-8d9e0f1a2b3c
+                    errors:
+                    - code: unauthorized
+                      message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/update_audience_request"
+            examples:
+              audience_updated:
+                summary: Audience updated
+                value:
+                  name: Enterprise Accounts
+                  predicates:
+                  - attribute: role
+                    type: role
+                    comparison: eq
+                    value: user
+    delete:
+      summary: Delete an audience
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      - name: id
+        in: path
+        required: true
+        description: The unique identifier for the audience.
+        example: '123'
+        schema:
+          type: string
+      tags:
+      - Audiences
+      operationId: deleteAudience
+      description: You can delete a single audience by making a DELETE request to `https://api.intercom.io/audiences/<id>`.
+      responses:
+        '204':
+          description: Audience deleted
+        '404':
+          description: Audience not found
+          content:
+            application/json:
+              examples:
+                Audience not found:
+                  value:
+                    type: error.list
+                    request_id: a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+                    errors:
+                    - code: not_found
+                      message: Resource Not Found
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                Unauthorized:
+                  value:
+                    type: error.list
+                    request_id: b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e
+                    errors:
+                    - code: unauthorized
+                      message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
   "/export/reporting_data/enqueue":
     post:
       summary: Enqueue a new reporting data export job
@@ -20855,18 +21134,41 @@ components:
           type: string
           description: The unique identifier representing the audience.
           example: '123'
+          readOnly: true
         name:
           type: string
           description: The name of the audience.
           example: VIP Customers
+        predicates:
+          type: array
+          description: The predicates that define which contacts belong to the audience.
+          items:
+            "$ref": "#/components/schemas/predicate"
+          example:
+          - attribute: role
+            type: role
+            comparison: eq
+            value: user
+        role_predicates:
+          type: array
+          description: Additional role-based predicates for the audience.
+          items:
+            "$ref": "#/components/schemas/predicate"
+          example:
+          - attribute: role
+            type: role
+            comparison: eq
+            value: user
         created_at:
           type: integer
           description: The time the audience was created as a Unix timestamp.
           example: 1717200000
+          readOnly: true
         updated_at:
           type: integer
           description: The time the audience was last updated as a Unix timestamp.
           example: 1717200000
+          readOnly: true
     audience_list:
       title: Audience List
       type: object
@@ -20899,6 +21201,27 @@ components:
           type: integer
           description: The total number of pages.
           example: 1
+    predicate:
+      title: Predicate
+      type: object
+      description: A condition used to filter contacts in an audience.
+      properties:
+        attribute:
+          type: string
+          description: The attribute to filter on.
+          example: role
+        type:
+          type: string
+          description: The type of the attribute.
+          example: role
+        comparison:
+          type: string
+          description: The comparison operator.
+          example: eq
+        value:
+          type: string
+          description: The value to compare against.
+          example: user
     article:
       title: Article
       type: object
@@ -24352,6 +24675,37 @@ components:
       - type
       - user
       - visitor
+    create_audience_request:
+      title: Create Audience Request
+      type: object
+      description: The request payload for creating an audience.
+      required:
+      - name
+      properties:
+        name:
+          type: string
+          description: The name of the audience.
+          example: VIP Customers
+        predicates:
+          type: array
+          description: The predicates that define which contacts belong to the audience.
+          items:
+            "$ref": "#/components/schemas/predicate"
+          example:
+          - attribute: role
+            type: role
+            comparison: eq
+            value: user
+        role_predicates:
+          type: array
+          description: Additional role-based predicates for the audience.
+          items:
+            "$ref": "#/components/schemas/predicate"
+          example:
+          - attribute: role
+            type: role
+            comparison: eq
+            value: user
     create_article_request:
       description: You can create an Article
       type: object
@@ -31257,6 +31611,36 @@ components:
       required:
       - name
       - companies
+    update_audience_request:
+      title: Update Audience Request
+      type: object
+      description: The request payload for updating an audience. All fields are optional
+        — only provided fields will be updated.
+      properties:
+        name:
+          type: string
+          description: The name of the audience.
+          example: VIP Customers
+        predicates:
+          type: array
+          description: The predicates that define which contacts belong to the audience.
+          items:
+            "$ref": "#/components/schemas/predicate"
+          example:
+          - attribute: role
+            type: role
+            comparison: eq
+            value: user
+        role_predicates:
+          type: array
+          description: Additional role-based predicates for the audience.
+          items:
+            "$ref": "#/components/schemas/predicate"
+          example:
+          - attribute: role
+            type: role
+            comparison: eq
+            value: user
     update_article_request:
       description: You can Update an Article
       type: object


### PR DESCRIPTION
### Why?

The Preview OpenAPI spec only exposed `GET /audiences` and a minimal `audience` schema, leaving the rest of the Audiences API invisible to SDK generators and third-party tooling that consume this public distribution.

### How?

Extended `descriptions/0/api.intercom.io.yaml` with the remaining CRUD endpoints (show, create, update, delete), a shared `predicate` schema, request body schemas, and `predicates`/`role_predicates` fields on the `audience` schema.

<details><summary>Decisions</summary>

- Modeled new endpoints on existing `/articles` and `/content_snippets` paths to keep operationId casing, header parameters, and error response shape consistent with the rest of the spec.
- Introduced a shared `predicate` component referenced by both `predicates` and `role_predicates` instead of duplicating the inline shape.
- Added `readOnly: true` to `id`, `created_at`, and `updated_at` as the order requires, even though no other schema in the file currently uses that marker.
- Used `DELETE` → `204 No Content` with a description-only response body, matching the `/content_snippets/{id}` precedent.
- Kept OAuth scope information in endpoint descriptions rather than per-endpoint security blocks, since the spec relies on a global `bearerAuth`.

</details>

### Review Guidance

| Dimension | Score | Reasoning |
|-----------|-------|-----------|
| Complexity | `█░░░░░░░░░ 1.2` | <details><summary>Why</summary>Single-file YAML spec additions following established patterns from /articles and /content_snippets endpoints with no cross-cutting concerns.</details> |
| Unintuitiveness | `░░░░░░░░░░ 0.9` | <details><summary>Why</summary>Diff matches the PR description and plan closely — five CRUD endpoints, shared predicate schema, request bodies, and readOnly markers as specified.</details> |
| Risk Surface | `██░░░░░░░░ 2.0` | <details><summary>Why</summary>Touches a public-facing OpenAPI distribution consumed by SDK generators and third-party tooling, but is purely additive documentation with no runtime/auth/data impact.</details> |

**Attention: Routine review** — Routine additive OpenAPI spec change following documented patterns; reviewer should mostly confirm schema/example consistency with the source-of-truth developer-docs spec.

<sub>🧪 This AI-generated review guidance is experimental. <a href="https://github.com/intercom/parthas/issues/new?title=PR+Risk+Assessment+Feedback&body=PR:+https://github.com/intercom/Intercom-OpenAPI/pull/524%0A%0AFeedback:%0A&labels=risk-assessment-feedback">Share feedback</a></sub>

<details><summary>Implementation Plan</summary>

<details><summary>Worker Implementation Plan</summary>

# Plan: Sync Audiences API spec to Intercom-OpenAPI (Preview)

## Context

The Preview spec at `descriptions/0/api.intercom.io.yaml` has a partial Audiences API — only `GET /audiences` (list, line 1760) and basic `audience`/`audience_list` schemas (lines 20840–20901). The order requires adding the remaining four CRUD endpoints (show, create, update, delete), a `predicate` component schema, `predicates`/`role_predicates` fields on the `audience` schema, request body schemas, and `readOnly` markers.

The spec is ~32,500 lines. No test suite exists; validation is via `fern check` (requires `fern-api` npm package). No `justfile` exists — the order's `just fmt`/`just test` instructions don't apply to this repo.

## Changes Required

### 1. Add `POST /audiences` to the existing `/audiences` path (after line 1827)

The `/audiences` path currently only has `get`. Add a `post` method below it (before the `/export/reporting_data/enqueue` path at line 1828).

**Pattern to follow:** `POST /articles` at line 1282 — same structure:
- `summary: Create an audience`
- `Intercom-Version` header parameter
- `tags: [Audiences]`
- `operationId: createAudience`
- `description` mentioning the POST URL
- `requestBody` referencing `#/components/schemas/create_audience_request`
- Request body example with `name`, `predicates`, `role_predicates`
- `200` response with inline example and schema `$ref: "#/components/schemas/audience"`
- `401` Unauthorized error response (inline example)

### 2. Add `/audiences/{id}` path (after the `/audiences` block, before `/export/reporting_data/enqueue`)

This new path block contains three methods: `get`, `put`, `delete`.

**2a. GET /audiences/{id}** — Show single audience
- Pattern: `GET /articles/{id}` at line 1393
- `summary: Retrieve an audience`
- `operationId: retrieveAudience`
- Path param `id` (type: string, example: '123')
- `200` response with full audience example (including predicates/role_predicates)
- `404` Not Found error response
- `401` Unauthorized error response

**2b. PUT /audiences/{id}** — Update
- Pattern: `PUT /articles/{id}` at line 1477 and `PUT /content_snippets/{id}` at line 7063
- `summary: Update an audience`
- `operationId: updateAudience`
- `requestBody` referencing `#/components/schemas/update_audience_request`
- Request body example
- `200` response with updated audience example
- `404` Not Found, `401` Unauthorized errors

**2c. DELETE /audiences/{id}** — Delete
- Pattern: `DELETE /content_snippets/{id}` at line 7157 (uses 204)
- `summary: Delete an audience`
- `operationId: deleteAudience`
- `204` response with `description: Audience deleted` (no content body)
- `404` Not Found, `401` Unauthorized errors

### 3. Update `audience` schema (line 20840)

Add to existing properties:
- `predicates`: array of `$ref: "#/components/schemas/predicate"`, with description and example
- `role_predicates`: array of `$ref: "#/components/schemas/predicate"`, with description and example
- Add `readOnly: true` to `id`, `created_at`, `updated_at` properties

### 4. Add `predicate` schema (after `audience_list` at line 20901, before `article` at line 20902)

```yaml
    predicate:
      title: Predicate
      type: object
      description: A condition used to filter contacts in an audience.
      properties:
        attribute:
          type: string
          description: The attribute to filter on.
          example: role
        type:
          type: string
          description: The type of the attribute.
          example: role
        comparison:
          type: string
          description: The comparison operator.
          example: eq
        value:
          type: string
          description: The value to compare against.
          example: user
```

### 5. Add `create_audience_request` schema (before `create_article_request` at line 24355)

```yaml
    create_audience_request:
      title: Create Audience Request
      type: object
      description: The request payload for creating an audience.
      required:
      - name
      properties:
        name:
          type: string
          description: The name of the audience.
          example: VIP Customers
        predicates:
          type: array
          description: The predicates that define which contacts belong to the audience.
          items:
            "$ref": "#/components/schemas/predicate"
          example:
          - attribute: role
            type: role
            comparison: eq
            value: user
        role_predicates:
          type: array
          description: Additional role-based predicates for the audience.
          items:
            "$ref": "#/components/schemas/predicate"
          example:
          - attribute: role
            type: role
            comparison: eq
            value: user
```

### 6. Add `update_audience_request` schema (before `update_article_request` at line 31260)

Same shape as create but no required fields (all optional for partial update).

## Implementation Order

1. Update the `audience` schema — add `predicates`, `role_predicates`, and `readOnly` markers
2. Insert `predicate` schema after `audience_list`
3. Insert `create_audience_request` schema before `create_article_request`
4. Insert `update_audience_request` schema before `update_article_request`
5. Add `POST` method to existing `/audiences` path
6. Add `/audiences/{id}` path with `GET`, `PUT`, `DELETE`

## Key Conventions to Follow

- **Intercom-Version header** on every endpoint: `name: Intercom-Version, in: header, schema: $ref: "#/components/schemas/intercom_version"`
- **operationId**: camelCase — `listAudiences`, `retrieveAudience`, `createAudience`, `updateAudience`, `deleteAudience`
- **Tags**: `- Audiences`
- **Error responses**: inline examples with `type: error.list`, `request_id`, `errors` array, schema `$ref: "#/components/schemas/error"`
- **204 response**: just `description`, no content body (see line 770, 7176)
- **Path param id**: `type: string` (audiences use string IDs based on existing examples)
- **No per-endpoint security blocks** — global `bearerAuth` applies; OAuth scope info goes in descriptions only
- **No `readOnly` usage exists** in this spec currently — the order asks for it but this would introduce a new pattern. Add it since the order explicitly requests it.

## Example Data for Inline Responses

Consistent with existing audience examples in the spec:
- `id: '123'`, `name: 'VIP Customers'`, `created_at: 1717200000`, `updated_at: 1717200000`
- Predicates example: `[{attribute: 'role', type: 'role', comparison: 'eq', value: 'user'}]`
- Error request_ids: use UUID-style strings matching existing pattern

## Critical File

- **Only file modified**: `descriptions/0/api.intercom.io.yaml`

## Verification

1. Run `npx fern check` to validate the spec (requires `npm install` first if node_modules missing)
2. Verify all five endpoints are present with `grep -n "audiences" descriptions/0/api.intercom.io.yaml`
3. Verify schemas exist with `grep -n "predicate:\|create_audience\|update_audience" descriptions/0/api.intercom.io.yaml`
4. Commit and run `parthas submit`


</details>

<details><summary>Parthas Order (task/issue)</summary>

**Sync Audiences API spec to Intercom-OpenAPI (Preview)**

## Problem

The `descriptions/0/api.intercom.io.yaml` file in Intercom-OpenAPI (the public-facing spec) has no Audiences API documentation. The developer-docs repo is being updated with the full CRUD spec (a parallel order), but the public OpenAPI repo needs the same changes.

## Why This Matters

Intercom-OpenAPI is the public distribution point for the OpenAPI spec consumed by SDK generators and third-party tooling. Without it, the Audiences API is invisible to those consumers.

## Goal

The Audiences API section in `descriptions/0/api.intercom.io.yaml` matches the developer-docs Preview spec — same endpoints, schemas, and examples.

## Context

The developer-docs Preview spec is the source of truth. The `@Preview` version maps to `descriptions/0/` in this repo. The existing spec at `descriptions/0/api.intercom.io.yaml` currently has no Audiences endpoints or schemas.

The five endpoints to add:
- `GET /audiences` — list (paginated)
- `GET /audiences/{id}` — show single audience
- `POST /audiences` — create (name, predicates, role_predicates)
- `PUT /audiences/{id}` — update
- `DELETE /audiences/{id}` — returns 204

Response schema fields: `type` ("audience"), `id` (string), `name`, `predicates` (array), `role_predicates` (array), `created_at` (unix timestamp), `updated_at` (unix timestamp).

Predicates are arrays of objects with `attribute`, `type`, `comparison`, and `value` fields. `role_predicates` has the same shape. Define a shared `predicate` component schema referenced via `$ref`.

OAuth scopes: `read_audiences` (list, show), `read_write_audiences` (all five).

Create accepts: `name`, `predicates`, `role_predicates`. Update accepts the same. Delete returns 204 No Content.

## Constraints

- This repo is public-facing — no internal context in descriptions or commit messages
- `descriptions/0/` is the Preview version directory
- Follow existing patterns in the spec for endpoint structure, error responses, and schema naming
- Mark `id`, `created_at`, `updated_at` as `readOnly: true`

## Acceptance Criteria

- All five Audiences CRUD endpoints are in `descriptions/0/api.intercom.io.yaml`
- Schemas match: audience, audience_list, predicate, create/update request bodies
- All properties have descriptions and examples
- No internal Intercom context in any description text

</details>

</details>

<sub>Generated with Claude Code, zen coded with <a href="https://github.com/intercom/parthas">Parthas</a></sub>
