### PR TITLE
docs: specify Unix timestamp in seconds for contact write paths

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -1261,8 +1261,8 @@ components:
               format: date-time
               nullable: true
               description:
-                The time when the contact was last seen (Unix timestamp in seconds).
-                Either where the Intercom Messenger was installed or when specified manually
+                The time when the contact was last seen (either where the Intercom
+                Messenger was installed or when specified manually). Unix timestamp in seconds
               example: 1571672154
             owner_id:
               type: integer
@@ -1314,8 +1314,8 @@ components:
               format: date-time
               nullable: true
               description:
-                The time when the contact was last seen (Unix timestamp in seconds).
-                Either where the Intercom Messenger was installed or when specified manually
+                The time when the contact was last seen (either where the Intercom
+                Messenger was installed or when specified manually). Unix timestamp in seconds
               example: 1571672154
             owner_id:
               type: integer
@@ -1367,8 +1367,8 @@ components:
               format: date-time
               nullable: true
               description:
-                The time when the contact was last seen (Unix timestamp in seconds).
-                Either where the Intercom Messenger was installed or when specified manually
+                The time when the contact was last seen (either where the Intercom
+                Messenger was installed or when specified manually). Unix timestamp in seconds
               example: 1571672154
             owner_id:
               type: integer

--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -1254,15 +1254,15 @@ components:
               type: integer
               format: date-time
               nullable: true
-              description: The time specified for when a contact signed up
+              description: The time specified for when a contact signed up (Unix timestamp in seconds)
               example: 1571672154
             last_seen_at:
               type: integer
               format: date-time
               nullable: true
               description:
-                The time when the contact was last seen (either where the Intercom
-                Messenger was installed or when specified manually)
+                The time when the contact was last seen (Unix timestamp in seconds).
+                Either where the Intercom Messenger was installed or when specified manually
               example: 1571672154
             owner_id:
               type: integer
@@ -1307,15 +1307,15 @@ components:
               type: integer
               format: date-time
               nullable: true
-              description: The time specified for when a contact signed up
+              description: The time specified for when a contact signed up (Unix timestamp in seconds)
               example: 1571672154
             last_seen_at:
               type: integer
               format: date-time
               nullable: true
               description:
-                The time when the contact was last seen (either where the Intercom
-                Messenger was installed or when specified manually)
+                The time when the contact was last seen (Unix timestamp in seconds).
+                Either where the Intercom Messenger was installed or when specified manually
               example: 1571672154
             owner_id:
               type: integer
@@ -1360,15 +1360,15 @@ components:
               type: integer
               format: date-time
               nullable: true
-              description: The time specified for when a contact signed up
+              description: The time specified for when a contact signed up (Unix timestamp in seconds)
               example: 1571672154
             last_seen_at:
               type: integer
               format: date-time
               nullable: true
               description:
-                The time when the contact was last seen (either where the Intercom
-                Messenger was installed or when specified manually)
+                The time when the contact was last seen (Unix timestamp in seconds).
+                Either where the Intercom Messenger was installed or when specified manually
               example: 1571672154
             owner_id:
               type: integer

--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -1261,8 +1261,8 @@ components:
               format: date-time
               nullable: true
               description:
-                The time when the contact was last seen (either where the Intercom
-                Messenger was installed or when specified manually). Unix timestamp in seconds
+                The time when the contact was last seen (Unix timestamp in seconds),
+                either where the Intercom Messenger was installed or when specified manually
               example: 1571672154
             owner_id:
               type: integer
@@ -1314,8 +1314,8 @@ components:
               format: date-time
               nullable: true
               description:
-                The time when the contact was last seen (either where the Intercom
-                Messenger was installed or when specified manually). Unix timestamp in seconds
+                The time when the contact was last seen (Unix timestamp in seconds),
+                either where the Intercom Messenger was installed or when specified manually
               example: 1571672154
             owner_id:
               type: integer
@@ -1367,8 +1367,8 @@ components:
               format: date-time
               nullable: true
               description:
-                The time when the contact was last seen (either where the Intercom
-                Messenger was installed or when specified manually). Unix timestamp in seconds
+                The time when the contact was last seen (Unix timestamp in seconds),
+                either where the Intercom Messenger was installed or when specified manually
               example: 1571672154
             owner_id:
               type: integer


### PR DESCRIPTION
## Summary

- Updates `signed_up_at` and `last_seen_at` descriptions in all three `CreateContactRequest` schema variants in `openapi-overrides.yml` to specify "Unix timestamp in seconds"
- Preserves existing context (e.g., "either where the Intercom Messenger was installed or when specified manually")

## Context

Customers have been sending millisecond timestamps to the Contacts API, causing data corruption. The OpenAPI spec didn't specify the expected unit, contributing to confusion.

Companion PRs:
- intercom/intercom#515644 — adds timestamp validation to the Contacts controller
- intercom/intercom#515838 — updates OpenAPI schemas in the monolith
- intercom/developer-docs — updates the developer-facing docs (this PR's sibling)

## Files changed

- `fern/openapi-overrides.yml` — 3 occurrences across CreateContactRequestWithEmail, CreateContactRequestWithExternalId, CreateContactRequestWithRole

🤖 Generated with [Claude Code](https://claude.com/claude-code)