### PR TITLE
Add QA monitor evaluations and scorecards to Preview Conversations API

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -8018,6 +8018,22 @@ paths:
         description: String used to get the next page of conversations.
         schema:
           type: string
+      - name: include_monitors
+        in: query
+        required: false
+        description: If set to true, the response will include a `monitor_evaluations` array on each conversation with any QA monitor results that flagged it.
+        example: true
+        schema:
+          type: boolean
+          default: false
+      - name: include_scorecards
+        in: query
+        required: false
+        description: If set to true, the response will include a `scorecards` array on each conversation with any QA scorecard results.
+        example: true
+        schema:
+          type: boolean
+          default: false
       tags:
       - Conversations
       operationId: listConversations
@@ -8100,6 +8116,54 @@ paths:
                       channel:
                         initial: messenger
                         current: messenger
+                with QA evaluations:
+                  summary: Response with `include_monitors=true` and `include_scorecards=true`
+                  value:
+                    type: conversation.list
+                    pages:
+                      type: pages
+                      page: 1
+                      per_page: 20
+                      total_pages: 1
+                    total_count: 1
+                    conversations:
+                    - type: conversation
+                      id: '601'
+                      created_at: 1734537700
+                      updated_at: 1734537760
+                      title:
+                      open: true
+                      state: open
+                      read: true
+                      priority: not_priority
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 5017691
+                      ai_agent_participated: false
+                      monitor_evaluations:
+                      - monitor_id: '12345'
+                        monitor_name: Customer complaint handling
+                        monitor_type: prompt
+                        result: flagged
+                        explanation: The customer mentioned wanting a refund without resolution.
+                        evaluated_at: 1734537760
+                      scorecards:
+                      - scorecard_id: '67890'
+                        scorecard_version_id: '67891'
+                        name: Standard QA Review
+                        scorecard_type: human
+                        passed: true
+                        score: 0.85
+                        ai_score: 0.9
+                        evaluated_at: 1734537760
+                        reviewed_teammate:
+                          type: admin
+                          admin_id: '991267715'
+                        evaluators:
+                        - evaluator_id: '54321'
+                          result:
+                            value: pass
+                            source: ai
+                            reasoning: The agent acknowledged the issue and resolved it within the same response.
               schema:
                 "$ref": "#/components/schemas/conversation_list"
         '401':
@@ -8268,6 +8332,22 @@ paths:
         example: true
         schema:
           type: boolean
+      - name: include_monitors
+        in: query
+        required: false
+        description: If set to true, the response will include a `monitor_evaluations` array with any QA monitor results that flagged this conversation.
+        example: true
+        schema:
+          type: boolean
+          default: false
+      - name: include_scorecards
+        in: query
+        required: false
+        description: If set to true, the response will include a `scorecards` array with any QA scorecard results for this conversation.
+        example: true
+        schema:
+          type: boolean
+          default: false
       tags:
       - Conversations
       operationId: retrieveConversation
@@ -8634,6 +8714,46 @@ paths:
                             result: success
                         app_package_code: null
                       total_count: 4
+                with QA evaluations:
+                  summary: Response with `include_monitors=true` and `include_scorecards=true`
+                  value:
+                    type: conversation
+                    id: '601'
+                    created_at: 1734537700
+                    updated_at: 1734537760
+                    title:
+                    open: true
+                    state: open
+                    read: true
+                    priority: not_priority
+                    admin_assignee_id: 991267715
+                    team_assignee_id: 5017691
+                    ai_agent_participated: false
+                    monitor_evaluations:
+                    - monitor_id: '12345'
+                      monitor_name: Customer complaint handling
+                      monitor_type: prompt
+                      result: flagged
+                      explanation: The customer mentioned wanting a refund without resolution.
+                      evaluated_at: 1734537760
+                    scorecards:
+                    - scorecard_id: '67890'
+                      scorecard_version_id: '67891'
+                      name: Standard QA Review
+                      scorecard_type: human
+                      passed: true
+                      score: 0.85
+                      ai_score: 0.9
+                      evaluated_at: 1734537760
+                      reviewed_teammate:
+                        type: admin
+                        admin_id: '991267715'
+                      evaluators:
+                      - evaluator_id: '54321'
+                        result:
+                          value: pass
+                          source: ai
+                          reasoning: The agent acknowledged the issue and resolved it within the same response.
               schema:
                 "$ref": "#/components/schemas/conversation"
         '404':
@@ -9060,6 +9180,22 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
+      - name: include_monitors
+        in: query
+        required: false
+        description: If set to true, the response will include a `monitor_evaluations` array on each conversation with any QA monitor results that flagged it.
+        example: true
+        schema:
+          type: boolean
+          default: false
+      - name: include_scorecards
+        in: query
+        required: false
+        description: If set to true, the response will include a `scorecards` array on each conversation with any QA scorecard results.
+        example: true
+        schema:
+          type: boolean
+          default: false
       tags:
       - Conversations
       operationId: searchConversations
@@ -9234,6 +9370,54 @@ paths:
                       channel:
                         initial: messenger
                         current: messenger
+                with QA evaluations:
+                  summary: Response with `include_monitors=true` and `include_scorecards=true`
+                  value:
+                    type: conversation.list
+                    pages:
+                      type: pages
+                      page: 1
+                      per_page: 5
+                      total_pages: 1
+                    total_count: 1
+                    conversations:
+                    - type: conversation
+                      id: '601'
+                      created_at: 1734537700
+                      updated_at: 1734537760
+                      title:
+                      open: true
+                      state: open
+                      read: true
+                      priority: not_priority
+                      admin_assignee_id: 991267715
+                      team_assignee_id: 5017691
+                      ai_agent_participated: false
+                      monitor_evaluations:
+                      - monitor_id: '12345'
+                        monitor_name: Customer complaint handling
+                        monitor_type: prompt
+                        result: flagged
+                        explanation: The customer mentioned wanting a refund without resolution.
+                        evaluated_at: 1734537760
+                      scorecards:
+                      - scorecard_id: '67890'
+                        scorecard_version_id: '67891'
+                        name: Standard QA Review
+                        scorecard_type: human
+                        passed: true
+                        score: 0.85
+                        ai_score: 0.9
+                        evaluated_at: 1734537760
+                        reviewed_teammate:
+                          type: admin
+                          admin_id: '991267715'
+                        evaluators:
+                        - evaluator_id: '54321'
+                          result:
+                            value: pass
+                            source: ai
+                            reasoning: The agent acknowledged the issue and resolved it within the same response.
               schema:
                 "$ref": "#/components/schemas/conversation_list"
       requestBody:
@@ -24330,6 +24514,16 @@ components:
           type: object
           nullable: true
           description: The channel through which the conversation was initiated and its current channel.
+        monitor_evaluations:
+          type: array
+          description: QA monitor evaluations that flagged this conversation. Only included when `include_monitors=true` is passed as a query parameter.
+          items:
+            "$ref": "#/components/schemas/conversation_monitor_evaluation"
+        scorecards:
+          type: array
+          description: QA scorecard results for this conversation. Only included when `include_scorecards=true` is passed as a query parameter.
+          items:
+            "$ref": "#/components/schemas/conversation_scorecard"
     conversation:
       title: Conversation
       type: object
@@ -24459,6 +24653,174 @@ components:
           type: object
           nullable: true
           description: The channel through which the conversation was initiated and its current channel.
+        monitor_evaluations:
+          type: array
+          description: QA monitor evaluations that flagged this conversation. Only included when `include_monitors=true` is passed as a query parameter.
+          items:
+            "$ref": "#/components/schemas/conversation_monitor_evaluation"
+        scorecards:
+          type: array
+          description: QA scorecard results for this conversation. Only included when `include_scorecards=true` is passed as a query parameter.
+          items:
+            "$ref": "#/components/schemas/conversation_scorecard"
+    conversation_monitor_evaluation:
+      title: Conversation Monitor Evaluation
+      type: object
+      x-tags:
+      - Conversations
+      description: A QA monitor evaluation that flagged this conversation. Returned in the `monitor_evaluations` array on conversation responses when `include_monitors=true` is passed.
+      properties:
+        monitor_id:
+          type: string
+          description: The unique identifier of the monitor that produced this evaluation.
+          example: '12345'
+        monitor_name:
+          type: string
+          nullable: true
+          description: The name of the monitor at the time of evaluation. Null if the monitor has since been deleted.
+          example: Customer complaint handling
+        monitor_type:
+          type: string
+          nullable: true
+          description: The type of the monitor. Null if the monitor has since been deleted.
+          example: prompt
+        result:
+          type: string
+          description: The evaluation outcome reported by the monitor.
+          example: flagged
+        explanation:
+          type: string
+          nullable: true
+          description: The reasoning provided by the monitor for its result. May be null if no reasoning was generated.
+          example: The customer mentioned wanting a refund without resolution.
+        evaluated_at:
+          type: integer
+          format: date-time
+          nullable: true
+          description: The time the monitor evaluated this conversation. Null in the rare case the underlying record's timestamp is not yet set.
+          example: 1719493065
+    conversation_scorecard:
+      title: Conversation Scorecard
+      type: object
+      x-tags:
+      - Conversations
+      description: A QA scorecard result for this conversation. Returned in the `scorecards` array on conversation responses when `include_scorecards=true` is passed.
+      properties:
+        scorecard_id:
+          type: string
+          description: The unique identifier of the scorecard definition.
+          example: '67890'
+        scorecard_version_id:
+          type: string
+          description: The unique identifier of the specific scorecard version that produced this result.
+          example: '67891'
+        name:
+          type: string
+          description: The name of the scorecard.
+          example: Standard QA Review
+        scorecard_type:
+          type: string
+          description: The type of scorecard.
+          example: human
+        passed:
+          type: boolean
+          nullable: true
+          description: Whether the conversation passed the scorecard. Null when the scorecard has not been scored.
+          example: true
+        score:
+          type: number
+          nullable: true
+          description: The numeric score for the scorecard. Null when the scorecard has not been scored.
+          example: 0.85
+        ai_score:
+          type: number
+          nullable: true
+          description: The numeric score produced by AI evaluation, if applicable. Null when not AI-scored.
+          example: 0.9
+        evaluated_at:
+          type: integer
+          format: date-time
+          nullable: true
+          description: The time the scorecard was last evaluated. Null in the rare case the underlying record's timestamp is not yet set.
+          example: 1719493065
+        reviewed_teammate:
+          "$ref": "#/components/schemas/conversation_scorecard_reviewed_teammate"
+        evaluators:
+          type: array
+          description: Per-evaluator results within this scorecard.
+          items:
+            "$ref": "#/components/schemas/conversation_scorecard_evaluator"
+    conversation_scorecard_reviewed_teammate:
+      title: Reviewed Teammate
+      type: object
+      x-tags:
+      - Conversations
+      description: The teammate (or AI agent) whose handling of the conversation was reviewed by this scorecard.
+      properties:
+        type:
+          type: string
+          enum:
+          - ai
+          - admin
+          description: The kind of reviewee. `ai` if the conversation was handled by Fin or scored without a specific teammate; `admin` if a specific teammate was reviewed.
+          example: admin
+        admin_id:
+          type: string
+          nullable: true
+          description: The id of the admin who was reviewed. Present only when `type` is `admin`.
+          example: '991267715'
+    conversation_scorecard_evaluator:
+      title: Conversation Scorecard Evaluator
+      type: object
+      x-tags:
+      - Conversations
+      description: A single evaluator within a scorecard, including its result for this conversation.
+      properties:
+        evaluator_id:
+          type: string
+          description: The unique identifier of the evaluator (criterion) within the scorecard.
+          example: '54321'
+        result:
+          allOf:
+            - "$ref": "#/components/schemas/conversation_scorecard_evaluator_result"
+          nullable: true
+          description: The evaluator's result for this conversation. Null if the evaluator was not scored.
+    conversation_scorecard_evaluator_result:
+      title: Conversation Scorecard Evaluator Result
+      type: object
+      x-tags:
+      - Conversations
+      description: The outcome of a single evaluator within a scorecard.
+      properties:
+        value:
+          type: string
+          nullable: true
+          description: The evaluator's selected value (typically a label such as `pass`, `fail`, or a category identifier).
+          example: pass
+        source:
+          type: string
+          nullable: true
+          description: The origin of the result (for example, `ai` or `human`).
+          example: ai
+        reasoning:
+          type: string
+          nullable: true
+          description: A free-text explanation of the result.
+          example: The agent acknowledged the issue and resolved it within the same response.
+        reason_ids:
+          type: array
+          nullable: true
+          description: Identifiers for structured reasons assigned to the result, if any.
+          items:
+            type: string
+          example:
+          - '101'
+          - '102'
+        other_text:
+          type: string
+          nullable: true
+          description: Free-text entered by the reviewer to supplement or stand in for the structured `reason_ids` — typically captured when the reviewer selects an "Other" option or adds a custom note. Null when not provided.
+          example: Agent acknowledged the issue but missed the follow-up question about billing.
     conversation_channel:
       title: Conversation Channel
       type: object


### PR DESCRIPTION
### Why?

Customers pulling conversations via the public API had no way to see which QA monitors flagged a conversation or how scorecards scored it. The new opt-in fields give them this inverse lookup — they can now request QA signal alongside conversation data in a single API call.

### How?

Adds two opt-in query parameters — `include_monitors=true` and `include_scorecards=true` — to `GET /conversations`, `GET /conversations/{id}`, and `POST /conversations/search`. When set, responses include `monitor_evaluations` and `scorecards` arrays. Each parameter defaults to `false`. Change is Preview-only (`descriptions/0/`); stable versions are unchanged.

The new properties are declared on both the `conversation` schema and the `conversation_list_item` schema, so the fields appear consistently across the single-conversation response and the lighter list/search response shape.

### References

- intercom/developer-docs#938 — companion developer-docs PR

<sub>Generated with Claude Code</sub>