### PR TITLE
Add audit, suggestion, audience, and Fin statistics fields to Article API (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -21835,6 +21835,16 @@ components:
           type: boolean
           description: Whether the article is available for AI Sales Agent.
           example: true
+        created_by_id:
+          type: integer
+          nullable: true
+          description: The ID of the teammate who created this content version.
+          example: '5017691'
+        updated_by_id:
+          type: integer
+          nullable: true
+          description: The ID of the teammate who last updated this content version.
+          example: '5017691'
     internal_article_list:
       title: Internal Articles
       type: object
@@ -22061,6 +22071,22 @@ components:
           description: Whether the article is available for AI Sales Agent. For multilingual
             articles, this will be the value of the default language's content.
           example: true
+        created_by_id:
+          type: integer
+          nullable: true
+          description: The ID of the teammate who created the article. For multilingual
+            articles, this will be the creator of the default language's content.
+          example: '5017691'
+        updated_by_id:
+          type: integer
+          nullable: true
+          description: The ID of the teammate who last updated the article. For multilingual
+            articles, this will be the last editor of the default language's content.
+          example: '5017691'
+        exclude_from_article_suggestions:
+          type: boolean
+          description: Whether the article is excluded from Fin AI Agent article suggestions.
+          example: false
     internal_article_list_item:
       title: Internal Articles
       type: object

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -21838,13 +21838,15 @@ components:
         created_by_id:
           type: integer
           nullable: true
+          readOnly: true
           description: The ID of the teammate who created this content version.
-          example: '5017691'
+          example: 5017691
         updated_by_id:
           type: integer
           nullable: true
+          readOnly: true
           description: The ID of the teammate who last updated this content version.
-          example: '5017691'
+          example: 5017691
     internal_article_list:
       title: Internal Articles
       type: object
@@ -22074,17 +22076,20 @@ components:
         created_by_id:
           type: integer
           nullable: true
+          readOnly: true
           description: The ID of the teammate who created the article. For multilingual
             articles, this will be the creator of the default language's content.
-          example: '5017691'
+          example: 5017691
         updated_by_id:
           type: integer
           nullable: true
+          readOnly: true
           description: The ID of the teammate who last updated the article. For multilingual
             articles, this will be the last editor of the default language's content.
-          example: '5017691'
+          example: 5017691
         exclude_from_article_suggestions:
           type: boolean
+          readOnly: true
           description: Whether the article is excluded from Fin AI Agent article suggestions.
           example: false
     internal_article_list_item:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22346,17 +22346,20 @@ components:
           example: 20.0
         fin_involvements:
           type: integer
+          readOnly: true
           description: The number of conversations in which Fin AI Agent used this article,
             summed across all of the article's locales.
           example: 10
         fin_resolutions:
           type: integer
+          readOnly: true
           description: The number of conversations Fin AI Agent resolved using this article,
             summed across all of the article's locales.
           example: 8
         fin_resolution_rate:
           type: number
           format: float
+          readOnly: true
           description: The percentage of Fin AI Agent involvements that resulted in a resolution
             (fin_resolutions / fin_involvements * 100).
           example: 80.0

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22092,6 +22092,21 @@ components:
           readOnly: true
           description: Whether the article is excluded from Fin AI Agent article suggestions.
           example: false
+        help_center_audience:
+          type: string
+          nullable: true
+          readOnly: true
+          enum:
+          - everyone
+          - all_users
+          - all_visitors
+          - all_leads
+          - all_visitors_and_leads
+          - restricted
+          description: The audience that can view this article in the Help Center. `everyone`
+            means all users and visitors can view it; `restricted` indicates a custom audience
+            ruleset. For multilingual articles, this is the article-level audience.
+          example: everyone
     internal_article_list_item:
       title: Internal Articles
       type: object
@@ -22329,6 +22344,22 @@ components:
           description: The percentage of sad reactions the article has received against
             other types of reaction.
           example: 20.0
+        fin_involvements:
+          type: integer
+          description: The number of conversations in which Fin AI Agent used this article,
+            summed across all of the article's locales.
+          example: 10
+        fin_resolutions:
+          type: integer
+          description: The number of conversations Fin AI Agent resolved using this article,
+            summed across all of the article's locales.
+          example: 8
+        fin_resolution_rate:
+          type: number
+          format: float
+          description: The percentage of Fin AI Agent involvements that resulted in a resolution
+            (fin_resolutions / fin_involvements * 100).
+          example: 80.0
     article_translated_content:
       title: Article Translated Content
       type: object


### PR DESCRIPTION
### Why?

Surface additional Article configuration and Fin AI Agent reporting in the Preview Article API. These fields are already returned by the API; this updates the spec so generated SDKs and docs include them.

### How?

Appends optional, read-only properties to the Article schemas:

- `article_list_item` — `created_by_id`, `updated_by_id`, `exclude_from_article_suggestions`, and `help_center_audience` (an enum describing which Help Center audience can view the article).
- `article_content` — `created_by_id`, `updated_by_id` (these surface both at the article root and per-locale inside `translated_content`).
- `article_statistics` — `fin_involvements`, `fin_resolutions`, and `fin_resolution_rate` (Fin AI Agent reporting, summed across the article's locales).

<sub>Generated with Claude Code</sub>