### PR TITLE
docs: fix workspace settings path in duplicate conversation attribute notice

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -8843,7 +8843,7 @@ paths:
         To resolve, rename or archive the duplicate attribute so each name is unique, then retry the request. You can do this through:
 
         - The Conversation Attributes API — list with `GET /conversations/attributes`, then rename with `PUT /conversations/attributes/{id}` or archive with `DELETE /conversations/attributes/{id}`
-        - Your workspace settings (Settings → Data → Conversation attributes)
+        - Your workspace settings (Settings → Data → Conversation)
         {% /admonition %}
 
       responses:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -8843,7 +8843,7 @@ paths:
         To resolve, rename or archive the duplicate attribute so each name is unique, then retry the request. You can do this through:
 
         - The Conversation Attributes API — list with `GET /conversations/attributes`, then rename with `PUT /conversations/attributes/{id}` or archive with `DELETE /conversations/attributes/{id}`
-        - Your workspace settings (Settings → Data → Conversation)
+        - Your workspace settings (Settings → Data → Conversations)
         {% /admonition %}
 
       responses:


### PR DESCRIPTION
### Why?

The duplicate-attribute notice on `PUT /conversations/{id}` referenced the in-app path where users manage conversation custom attributes. The setting is named **Settings → Data → Conversation** (not **Settings → Data → Conversation attributes**), so the docs need to match what users actually see in the product.

### How?

One-line wording fix on the `updateConversation` admonition block in the Preview spec. Stable v2.7–v2.15 don't carry this admonition, so no cross-version update is needed.

<sub>Generated with Claude Code</sub>