### PR TITLE
Add 2.15 to the Intercom-Version enum and fix its default

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -30268,6 +30268,7 @@ components:
       - '2.12'
       - '2.13'
       - '2.14'
+      - '2.15'
       - Preview
     linked_object:
       title: Linked Object

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -21286,7 +21286,6 @@ components:
       - '2.13'
       - '2.14'
       - '2.15'
-      - 'Preview'
     linked_object:
       title: Linked Object
       type: object

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -21262,8 +21262,8 @@ components:
       description: Intercom API version.</br>By default, it's equal to the version
         set in the app package.
       type: string
-      example: '2.14'
-      default: '2.14'
+      example: '2.15'
+      default: '2.15'
       enum:
       - '1.0'
       - '1.1'
@@ -21285,6 +21285,8 @@ components:
       - '2.12'
       - '2.13'
       - '2.14'
+      - '2.15'
+      - 'Preview'
     linked_object:
       title: Linked Object
       type: object


### PR DESCRIPTION
### Why?

The 2.15 API version was missing from the `Intercom-Version` enum, and the 2.15 description's `default`/`example` still pointed at 2.14.

### How?

Set the 2.15 description's `Intercom-Version` `default`/`example` to `2.15`, and add `2.15` to the version enum on both the `2.15` and unstable (`0`) descriptions.

<sub>Generated with Claude Code</sub>