### PR TITLE
docs(contacts): document 409 Conflict on Create contact

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -6812,6 +6812,27 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '409':
+          description: Conflict - a contact matching those details already exists
+          content:
+            application/json:
+              examples:
+                Contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 1f8a3c5d-9b2e-4d7a-8c61-2e4f6a8b0d13
+                    errors:
+                    - code: conflict
+                      message: A contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+                Archived contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 2a9b4d6e-0c3f-4e8b-9d72-3f5a7b9c1e24
+                    errors:
+                    - code: conflict
+                      message: An archived contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -3969,6 +3969,27 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '409':
+          description: Conflict - a contact matching those details already exists
+          content:
+            application/json:
+              examples:
+                Contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 1f8a3c5d-9b2e-4d7a-8c61-2e4f6a8b0d13
+                    errors:
+                    - code: conflict
+                      message: A contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+                Archived contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 2a9b4d6e-0c3f-4e8b-9d72-3f5a7b9c1e24
+                    errors:
+                    - code: conflict
+                      message: An archived contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -4068,6 +4068,27 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '409':
+          description: Conflict - a contact matching those details already exists
+          content:
+            application/json:
+              examples:
+                Contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 1f8a3c5d-9b2e-4d7a-8c61-2e4f6a8b0d13
+                    errors:
+                    - code: conflict
+                      message: A contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+                Archived contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 2a9b4d6e-0c3f-4e8b-9d72-3f5a7b9c1e24
+                    errors:
+                    - code: conflict
+                      message: An archived contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -4590,6 +4590,27 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '409':
+          description: Conflict - a contact matching those details already exists
+          content:
+            application/json:
+              examples:
+                Contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 1f8a3c5d-9b2e-4d7a-8c61-2e4f6a8b0d13
+                    errors:
+                    - code: conflict
+                      message: A contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+                Archived contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 2a9b4d6e-0c3f-4e8b-9d72-3f5a7b9c1e24
+                    errors:
+                    - code: conflict
+                      message: An archived contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -5111,6 +5111,27 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '409':
+          description: Conflict - a contact matching those details already exists
+          content:
+            application/json:
+              examples:
+                Contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 1f8a3c5d-9b2e-4d7a-8c61-2e4f6a8b0d13
+                    errors:
+                    - code: conflict
+                      message: A contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+                Archived contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 2a9b4d6e-0c3f-4e8b-9d72-3f5a7b9c1e24
+                    errors:
+                    - code: conflict
+                      message: An archived contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -5921,6 +5921,27 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '409':
+          description: Conflict - a contact matching those details already exists
+          content:
+            application/json:
+              examples:
+                Contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 1f8a3c5d-9b2e-4d7a-8c61-2e4f6a8b0d13
+                    errors:
+                    - code: conflict
+                      message: A contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+                Archived contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 2a9b4d6e-0c3f-4e8b-9d72-3f5a7b9c1e24
+                    errors:
+                    - code: conflict
+                      message: An archived contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -5992,6 +5992,27 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '409':
+          description: Conflict - a contact matching those details already exists
+          content:
+            application/json:
+              examples:
+                Contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 1f8a3c5d-9b2e-4d7a-8c61-2e4f6a8b0d13
+                    errors:
+                    - code: conflict
+                      message: A contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+                Archived contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 2a9b4d6e-0c3f-4e8b-9d72-3f5a7b9c1e24
+                    errors:
+                    - code: conflict
+                      message: An archived contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -4187,6 +4187,27 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '409':
+          description: Conflict - a contact matching those details already exists
+          content:
+            application/json:
+              examples:
+                Contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 1f8a3c5d-9b2e-4d7a-8c61-2e4f6a8b0d13
+                    errors:
+                    - code: conflict
+                      message: A contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+                Archived contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 2a9b4d6e-0c3f-4e8b-9d72-3f5a7b9c1e24
+                    errors:
+                    - code: conflict
+                      message: An archived contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -4187,6 +4187,27 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '409':
+          description: Conflict - a contact matching those details already exists
+          content:
+            application/json:
+              examples:
+                Contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 1f8a3c5d-9b2e-4d7a-8c61-2e4f6a8b0d13
+                    errors:
+                    - code: conflict
+                      message: A contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+                Archived contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 2a9b4d6e-0c3f-4e8b-9d72-3f5a7b9c1e24
+                    errors:
+                    - code: conflict
+                      message: An archived contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -4187,6 +4187,27 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '409':
+          description: Conflict - a contact matching those details already exists
+          content:
+            application/json:
+              examples:
+                Contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 1f8a3c5d-9b2e-4d7a-8c61-2e4f6a8b0d13
+                    errors:
+                    - code: conflict
+                      message: A contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+                Archived contact already exists:
+                  value:
+                    type: error.list
+                    request_id: 2a9b4d6e-0c3f-4e8b-9d72-3f5a7b9c1e24
+                    errors:
+                    - code: conflict
+                      message: An archived contact matching those details already exists with id=6762f0dd1bb69f9f2193bb83
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
### Why?

`POST /contacts` can return a `409 Conflict` when a contact with matching details already exists, but the response was not described in the spec — so generated SDKs and integrators had no typed signal to handle it. This also covers the distinct archived-contact case, which returns the same status with a different message.

### How?

Adds a `409` response to the Create contact operation across all description versions (`2.7`–`2.15` and `0`), with two named examples — a live duplicate and an archived duplicate — both referencing the shared `error` schema.

<sub>Generated with Claude Code</sub>