### PR TITLE
Document no-reply conversation population on Reporting Data Export (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -2870,6 +2870,7 @@ paths:
   "/export/reporting_data/enqueue":
     post:
       summary: Enqueue a new reporting data export job
+      description: For the **conversation** dataset, from the Preview version this export returns all conversations, including those that never received a user reply. Earlier versions return only conversations that received at least one user reply. Other datasets are unaffected.
       tags: [Export]
       parameters:
       - name: Intercom-Version


### PR DESCRIPTION
## Why

The Reporting Data Export API is gaining a no-reply-inclusive conversation population on the **Preview** version, as part of the *Reporting what's in the inbox* project. This documents the changed population semantics in the Preview OpenAPI spec.

Scope: only the `conversation` dataset is affected. On Preview, the export returns all conversations including those that never received a user reply; earlier versions return only replied conversations. Other datasets are unchanged.

## What

Adds a `description` to `POST /export/reporting_data/enqueue` in `descriptions/0/api.intercom.io.yaml` (Preview) documenting the new population.

**DRAFT — do not merge before the no-reply data is GA (target 25 Jun, intercom/intercom#519258).** The Preview spec would otherwise advertise a population the index can't yet return.

## Related

- Monolith promotion PR: intercom/intercom#520233
- Companion developer-docs PR: _(to be linked)_
- Tracking issue: intercom/intercom#520253
- Project tracker: intercom/intercom#511395

<sub>Generated with Claude Code</sub>