### PR TITLE
Document boolean values in V3 Search API query value field

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -33361,6 +33361,7 @@ components:
           oneOf:
           - type: string
           - type: integer
+          - type: boolean
           - type: array
             items:
               oneOf:

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -15846,6 +15846,7 @@ components:
           oneOf:
           - type: string
           - type: integer
+          - type: boolean
           - type: array
             items:
               type: string

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -17309,6 +17309,7 @@ components:
           oneOf:
           - type: string
           - type: integer
+          - type: boolean
           - type: array
             items:
               type: string

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -17249,6 +17249,7 @@ components:
           oneOf:
           - type: string
           - type: integer
+          - type: boolean
           - type: array
             items:
               type: string

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -18861,6 +18861,7 @@ components:
           oneOf:
           - type: string
           - type: integer
+          - type: boolean
           - type: array
             items:
               oneOf:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -21252,6 +21252,7 @@ components:
           oneOf:
           - type: string
           - type: integer
+          - type: boolean
           - type: array
             items:
               oneOf:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -22112,6 +22112,7 @@ components:
           oneOf:
           - type: string
           - type: integer
+          - type: boolean
           - type: array
             items:
               oneOf:

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -13845,6 +13845,7 @@ components:
           oneOf:
           - type: string
           - type: integer
+          - type: boolean
           - type: array
             items:
               type: string

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -13869,6 +13869,7 @@ components:
           oneOf:
           - type: string
           - type: integer
+          - type: boolean
           - type: array
             items:
               oneOf:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -15222,6 +15222,7 @@ components:
           oneOf:
           - type: string
           - type: integer
+          - type: boolean
           - type: array
             items:
               type: string


### PR DESCRIPTION
### Why?

The V3 Search API query `value` field accepts boolean values, but the reference only listed `string`, `integer` and `array`. That left a gap: filtering a boolean field with the `!=` operator is valid, but the docs gave no indication booleans were accepted search values.

### How?

Added `boolean` to the shared search predicate `value` schema. The schema is shared across the conversations, contacts and tickets search endpoints, and the change is applied to every documented version.

<sub>Generated with Claude Code</sub>