### PR TITLE
Document Tier 1 + Tier 2 content/search filter params (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -8590,6 +8590,198 @@ paths:
           default: 10
           minimum: 1
           maximum: 50
+      - name: states
+        in: query
+        required: false
+        description: Filter by publication state. Accepts a comma-separated list
+          or repeated params.
+        example: published,draft
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - published
+            - draft
+        style: form
+        explode: false
+      - name: locales
+        in: query
+        required: false
+        description: Filter by locale codes (e.g. `en`, `fr`, `de`). Accepts a
+          comma-separated list or repeated params.
+        example: en,fr
+        schema:
+          type: array
+          items:
+            type: string
+        style: form
+        explode: false
+      - name: tag_ids
+        in: query
+        required: false
+        description: Filter by tag IDs. Pairs with `tag_operator` to control match
+          semantics. Accepts a comma-separated list or repeated params.
+        example: 1,2,3
+        schema:
+          type: array
+          items:
+            type: integer
+        style: form
+        explode: false
+      - name: tag_operator
+        in: query
+        required: false
+        description: Match operator paired with `tag_ids`. `IN` returns content
+          matching any of the given tags; `NIN` excludes content matching any
+          of them.
+        example: IN
+        schema:
+          type: string
+          enum:
+          - IN
+          - NIN
+      - name: any_tag_ids
+        in: query
+        required: false
+        description: Filter by tag IDs using OR semantics — returns content
+          matching any of the given tags. Alternative to `tag_ids` + `tag_operator`.
+          Accepts a comma-separated list or repeated params.
+        example: 1,2,3
+        schema:
+          type: array
+          items:
+            type: integer
+        style: form
+        explode: false
+      - name: folder_ids
+        in: query
+        required: false
+        description: Filter by folder IDs. Must be sent together with
+          `folder_entity_type`. Accepts a comma-separated list or repeated params.
+        example: 10,20
+        schema:
+          type: array
+          items:
+            type: integer
+        style: form
+        explode: false
+      - name: folder_entity_type
+        in: query
+        required: false
+        description: Required when `folder_ids` is provided. Identifies the entity
+          type the folder IDs refer to.
+        example: folder
+        schema:
+          type: string
+          enum:
+          - folder
+      - name: content_types
+        in: query
+        required: false
+        description: Restrict the search to specific content types. When provided,
+          this REPLACES the default content type set rather than filtering on top
+          of it. Accepts a comma-separated list or repeated params.
+        example: article,snippet
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - snippet
+            - external_content
+            - file_source_content
+            - internal_article
+            - article
+        style: form
+        explode: false
+      - name: copilot_state
+        in: query
+        required: false
+        description: Filter by whether the content is enabled for Copilot.
+        example: 'on'
+        schema:
+          type: string
+          enum:
+          - 'on'
+          - 'off'
+      - name: fin_service_state
+        in: query
+        required: false
+        description: Filter by whether the content is enabled for Fin AI Agent
+          (customer-facing service).
+        example: 'on'
+        schema:
+          type: string
+          enum:
+          - 'on'
+          - 'off'
+      - name: fin_sales_state
+        in: query
+        required: false
+        description: Filter by whether the content is enabled for Fin Sales Agent.
+        example: 'on'
+        schema:
+          type: string
+          enum:
+          - 'on'
+          - 'off'
+      - name: created_by_ids
+        in: query
+        required: false
+        description: Filter by the admin IDs that created the content. Accepts a
+          comma-separated list or repeated params.
+        example: 991267464,991267465
+        schema:
+          type: array
+          items:
+            type: integer
+        style: form
+        explode: false
+      - name: last_updated_by_ids
+        in: query
+        required: false
+        description: Filter by the admin IDs that last updated the content.
+          Accepts a comma-separated list or repeated params.
+        example: 991267464,991267465
+        schema:
+          type: array
+          items:
+            type: integer
+        style: form
+        explode: false
+      - name: created_at_after
+        in: query
+        required: false
+        description: Return content created at or after this time. Unix epoch
+          seconds.
+        example: 1677253093
+        schema:
+          type: integer
+      - name: created_at_before
+        in: query
+        required: false
+        description: Return content created at or before this time. Unix epoch
+          seconds.
+        example: 1677861493
+        schema:
+          type: integer
+      - name: updated_at_after
+        in: query
+        required: false
+        description: Return content last updated at or after this time. Unix
+          epoch seconds.
+        example: 1677253093
+        schema:
+          type: integer
+      - name: updated_at_before
+        in: query
+        required: false
+        description: Return content last updated at or before this time. Unix
+          epoch seconds.
+        example: 1677861493
+        schema:
+          type: integer
       tags:
       - Content
       operationId: searchContent


### PR DESCRIPTION
### Why?

The public `GET /content/search` endpoint shipped two waves of new filter parameters to the monolith (intercom/intercom#520626 and intercom/intercom#521153) without corresponding updates to the canonical OpenAPI spec. SDK-generated clients and the developer-docs reference can't surface the 14 new params, so the Knowledge Hub UI filter parity work (intercom/intercom#510966) is invisible to customers.

### How?

Append the 14 new query parameters to the existing `GET /content/search` operation in the Preview spec (`descriptions/0/api.intercom.io.yaml`), mirroring shapes already documented elsewhere in the file. Surgical, additions-only edit batched across both tiers to match the natural review unit.

<details><summary>Decisions</summary>

- Batched Tier 1 and Tier 2 into a single PR since both target the same operation and follow identical patterns — avoids a second round of spec churn a week later.
- Used OpenAPI 3.0.1 `style: form` + `explode: false` for array params (CSV form, e.g. `?tag_ids=1,2,3`) as the canonical documented shape; descriptions note that repeated-param form is also accepted by the controller.
- Typed all Unix epoch params as `integer` per the order, matching the request-body precedent on `/admins/activity_logs/search` rather than the older query-string `string` precedent.
- Quoted `'on'` / `'off'` enum values to avoid YAML 1.1 boolean coercion.
- `content_types` description explicitly calls out that it **replaces** the default content type set rather than filtering on top, since that behavior is easy to misread.
- Left the existing `ValidationError` 422 response untouched — no per-param error blocks added, per the order's guidance.
- Developer-docs sync deferred to a separate follow-up PR, matching the PR #540 → PR #960 precedent.

</details>

### Review Guidance

| Dimension | Score | Reasoning |
|-----------|-------|-----------|
| Complexity | `█░░░░░░░░░ 1.2` | <details><summary>Why</summary>Single-file additive YAML edit appending parameter blocks to one operation.</details> |
| Unintuitiveness | `███░░░░░░░ 3.8` | <details><summary>Why</summary>Description and Order both say "14 params" but diff adds 17 — implementer flagged this and followed the authoritative tables.</details> |
| Risk Surface | `██░░░░░░░░ 2.2` | <details><summary>Why</summary>Documentation-only changes to a public-API spec; affects SDK generation but no runtime behavior.</details> |

**Attention: Normal review** — Routine spec sync, but reviewer should reconcile the 14-vs-17 count mismatch and confirm the new array-query CSV convention is the one we want to set as precedent.

| | Callout | Detail |
|---|---------|--------|
| ⚠️ | PR says 14 params, diff adds 17 | <details><summary>Why</summary>PR description and Order summary text say "14 new query parameters," but the per-param tables (and this diff) actually add 17: Tier 1 has 7 params (states, locales, tag_ids, tag_operator, any_tag_ids, folder_ids, folder_entity_type) and Tier 2 has 10. Implementer noted this discrepancy and followed the tables as authoritative. Worth a reviewer eyeball that all 17 names/types/enums match what the monolith controller actually accepts in PR #520626 and #521153, since the description's running total no longer acts as a sanity check.</details> |
| ℹ️ | First array query params in this spec | <details><summary>Why</summary>Per the plan, this spec previously had no array-typed query params — all 94 existing query params are scalars or objects. This PR introduces the `style: form` + `explode: false` CSV convention for array query params for the first time, which will be the precedent SDK generators and future contributors follow. Worth a quick check that this matches the org's intended serialization standard before it locks in.</details> |


<sub>🧪 This AI-generated review guidance is experimental. <a href="https://github.com/intercom/parthas/issues/new?title=PR+Risk+Assessment+Feedback&body=PR:+https://github.com/intercom/Intercom-OpenAPI/pull/548%0A%0AFeedback:%0A&labels=risk-assessment-feedback">Share feedback</a></sub>

- Relates to https://github.com/intercom/intercom/pull/520626
- Relates to https://github.com/intercom/intercom/pull/521153
- Relates to https://github.com/intercom/intercom/issues/510966

<details><summary>Implementation Plan</summary>

<details><summary>Worker Implementation Plan</summary>

# Plan: Document Tier 1 + Tier 2 filter params on `GET /content/search`

## Context

The public `GET /content/search` endpoint shipped two waves of new filter parameters to the Intercom monolith, but the canonical OpenAPI spec at `intercom/Intercom-OpenAPI` (this repo) was not updated either time. Customers using SDK-generated clients or the developer-docs reference can't discover the 14 new params or get type-checked usage.

- **Tier 1** (monolith PR #520626, merged 2026-06-10): `states`, `locales`, `tag_ids` + `tag_operator`, `any_tag_ids`, `folder_ids` + `folder_entity_type`.
- **Tier 2** (monolith PR #521153, merged 2026-06-10): `content_types`, `copilot_state`, `fin_service_state`, `fin_sales_state`, `created_by_ids`, `last_updated_by_ids`, `created_at_after`, `created_at_before`, `updated_at_after`, `updated_at_before`.

Both waves go into a single OpenAPI PR — same endpoint, identical patterns. Tracking issue: `intercom/intercom#510966`.

## Target file (only file modified)

`descriptions/0/api.intercom.io.yaml` — the Preview spec. (Per `CLAUDE.md`, version `0` is internally "Preview". These endpoints are preview-only — the `GET /content/search` op references `intercom_version_preview` at line 8563.)

**Insertion point:** after the existing `per_page` parameter (ends at line 8592), before `tags:` at line 8593. The current `parameters:` array on the `get:` operation has: `Intercom-Version`, `query`, `page`, `per_page`. The 14 new params go at the end of this list.

## Implementation steps

1. Open `descriptions/0/api.intercom.io.yaml`.
2. Locate `/content/search:` → `get:` → `parameters:` (line 8556 `paths` entry, parameters at 8559–8592).
3. Append the 14 new parameter entries to `parameters:` immediately after the `per_page` entry (line 8592), before `tags:` (line 8593).
4. Use the exact YAML below — order: all 7 Tier 1 params, then all 10 Tier 2 params. Each param is `- name:` form, two-space-indented under the parameters list level (matching surrounding entries at 6 leading spaces).
5. Do not touch ANY other line. Acceptance criteria: `git diff --stat` shows only this single file with additions only.

## YAML to insert (verbatim — paste after `per_page` block, before `tags:`)

```yaml
      - name: states
        in: query
        required: false
        description: Filter by publication state. Accepts a comma-separated list
          or repeated params.
        example: published,draft
        schema:
          type: array
          items:
            type: string
            enum:
            - published
            - draft
        style: form
        explode: false
      - name: locales
        in: query
        required: false
        description: Filter by locale codes (e.g. `en`, `fr`, `de`). Accepts a
          comma-separated list or repeated params.
        example: en,fr
        schema:
          type: array
          items:
            type: string
        style: form
        explode: false
      - name: tag_ids
        in: query
        required: false
        description: Filter by tag IDs. Pairs with `tag_operator` to control match
          semantics. Accepts a comma-separated list or repeated params.
        example: 1,2,3
        schema:
          type: array
          items:
            type: integer
        style: form
        explode: false
      - name: tag_operator
        in: query
        required: false
        description: Match operator paired with `tag_ids`. `IN` returns content
          matching any of the given tags; `NIN` excludes content matching any
          of them.
        example: IN
        schema:
          type: string
          enum:
          - IN
          - NIN
      - name: any_tag_ids
        in: query
        required: false
        description: Filter by tag IDs using OR semantics — returns content
          matching any of the given tags. Alternative to `tag_ids` + `tag_operator`.
          Accepts a comma-separated list or repeated params.
        example: 1,2,3
        schema:
          type: array
          items:
            type: integer
        style: form
        explode: false
      - name: folder_ids
        in: query
        required: false
        description: Filter by folder IDs. Must be sent together with
          `folder_entity_type`. Accepts a comma-separated list or repeated params.
        example: 10,20
        schema:
          type: array
          items:
            type: integer
        style: form
        explode: false
      - name: folder_entity_type
        in: query
        required: false
        description: Required when `folder_ids` is provided. Identifies the entity
          type the folder IDs refer to.
        example: folder
        schema:
          type: string
          enum:
          - folder
      - name: content_types
        in: query
        required: false
        description: Restrict the search to specific content types. When provided,
          this REPLACES the default content type set rather than filtering on top
          of it. Accepts a comma-separated list or repeated params.
        example: article,snippet
        schema:
          type: array
          items:
            type: string
            enum:
            - snippet
            - external_content
            - file_source_content
            - internal_article
            - article
        style: form
        explode: false
      - name: copilot_state
        in: query
        required: false
        description: Filter by whether the content is enabled for Copilot.
        example: 'on'
        schema:
          type: string
          enum:
          - 'on'
          - 'off'
      - name: fin_service_state
        in: query
        required: false
        description: Filter by whether the content is enabled for Fin AI Agent
          (customer-facing service).
        example: 'on'
        schema:
          type: string
          enum:
          - 'on'
          - 'off'
      - name: fin_sales_state
        in: query
        required: false
        description: Filter by whether the content is enabled for Fin Sales Agent.
        example: 'on'
        schema:
          type: string
          enum:
          - 'on'
          - 'off'
      - name: created_by_ids
        in: query
        required: false
        description: Filter by the admin IDs that created the content. Accepts a
          comma-separated list or repeated params.
        example: 991267464,991267465
        schema:
          type: array
          items:
            type: integer
        style: form
        explode: false
      - name: last_updated_by_ids
        in: query
        required: false
        description: Filter by the admin IDs that last updated the content.
          Accepts a comma-separated list or repeated params.
        example: 991267464,991267465
        schema:
          type: array
          items:
            type: integer
        style: form
        explode: false
      - name: created_at_after
        in: query
        required: false
        description: Return content created at or after this time. Unix epoch
          seconds.
        example: 1677253093
        schema:
          type: integer
      - name: created_at_before
        in: query
        required: false
        description: Return content created at or before this time. Unix epoch
          seconds.
        example: 1677861493
        schema:
          type: integer
      - name: updated_at_after
        in: query
        required: false
        description: Return content last updated at or after this time. Unix
          epoch seconds.
        example: 1677253093
        schema:
          type: integer
      - name: updated_at_before
        in: query
        required: false
        description: Return content last updated at or before this time. Unix
          epoch seconds.
        example: 1677861493
        schema:
          type: integer
```

## Conventions / decisions

- **Array query params:** This spec currently has no array-typed query params (all 94 existing query params are scalars or objects). The standard OpenAPI 3.0.1 CSV serialization is `schema.type: array` + `style: form` + `explode: false`. This produces `?tag_ids=1,2,3` style URLs, which the monolith controller accepts. The controller also accepts repeated form (`?tag_ids=1&tag_ids=2`), but CSV is the canonical documented form here. The description on each array param notes both shapes are accepted.
- **Unix epoch type:** The order specifies `integer`. The `/admins/activity_logs` query precedent (line 193) uses `string`, but the request-body precedent (line 296-310 for `/admins/activity_logs/search` POST body) uses `integer`. The order's explicit directive is authoritative; using `integer` is semantically correct and matches the request-body convention.
- **`content_types` description:** Explicitly calls out "REPLACES the default content type set" per the order's emphasis.
- **`copilot_state` / `fin_service_state` / `fin_sales_state` enum values:** YAML-quoted as `'on'` / `'off'` because unquoted `on`/`off` are YAML 1.1 booleans (this would break the spec).
- **No 422 changes:** the endpoint already has `$ref: "#/components/responses/ValidationError"` at line 8649. Leave it alone.
- **No `examples:` updates:** the response shape doesn't change for either tier.

## Verification

After the edit:

1. `git diff --stat descriptions/0/api.intercom.io.yaml` — should show only this file, additions only (no deletions).
2. `git diff descriptions/0/api.intercom.io.yaml` — visually confirm only the 14 param blocks were added between `per_page` and `tags:`.
3. `fern check` (requires `npm install -g fern-api`) — validates the spec. Must pass.
4. Optionally `fern generate --preview --group ts-sdk` to preview-generate the TS SDK and confirm the new params surface in the generated client (do NOT run without `--preview`; per `CLAUDE.md`, `fern generate` without `--preview` auto-submits PRs to SDK repos).
5. Spot-check the new params parse correctly by reading the diff carefully — particular care on the `on`/`off` quoting in the enum lists.

## PR description content (for commit message and `parthas submit` flow)

Title: `Document Tier 1 + Tier 2 content/search filter params (Preview)`

Body should include:
- Summary: adds 14 query parameters to `GET /content/search` in the Preview spec.
- Tier 1 (`states`, `locales`, `tag_ids`, `tag_operator`, `any_tag_ids`, `folder_ids`, `folder_entity_type`) — companion to `intercom/intercom#520626`.
- Tier 2 (`content_types`, `copilot_state`, `fin_service_state`, `fin_sales_state`, `created_by_ids`, `last_updated_by_ids`, `created_at_after`, `created_at_before`, `updated_at_after`, `updated_at_before`) — companion to `intercom/intercom#521153`.
- Tracking parent: `intercom/intercom#510966`.
- Surgical edit: only `descriptions/0/api.intercom.io.yaml`, additions only.
- Developer-docs sync is a separate follow-up (matches the PR #540 → PR #960 precedent).

## Critical files

- `descriptions/0/api.intercom.io.yaml` (the only file modified)
- Reference precedents (read-only):
  - `descriptions/0/api.intercom.io.yaml:8556-8649` — existing `GET /content/search` operation
  - `descriptions/0/api.intercom.io.yaml:193-208` — existing `created_at_after`/`created_at_before` query string precedent (admins activity logs)
  - `descriptions/0/api.intercom.io.yaml:296-310` — existing `created_at_after` integer precedent (activity logs search request body)
- `CLAUDE.md` — project conventions, especially the "DANGER: Never run `fern generate` without `--preview`" warning.


</details>

<details><summary>Parthas Order (task/issue)</summary>

**Document Tier 1 + Tier 2 filter params on GET /content/search (companion to intercom #520626 and #521153)**

## Problem

The public `GET /content/search` endpoint shipped two waves of filter parameters to the Intercom monolith but neither wave updated the canonical OpenAPI spec at `intercom/Intercom-OpenAPI`:

- **Tier 1** (PR intercom/intercom#520626, merged 2026-06-10): `states`, `locales`, `tag_ids` + `tag_operator`, `any_tag_ids`, `folder_ids` + `folder_entity_type`.
- **Tier 2** (PR intercom/intercom#521153, merged 2026-06-10): `content_types`, `copilot_state`, `fin_service_state`, `fin_sales_state`, `created_by_ids`, `last_updated_by_ids`, `created_at_after`, `created_at_before`, `updated_at_after`, `updated_at_before`.

Customers using SDK-generated clients or the developer-docs reference can't discover the 14 new params or get type-checked usage. The runtime accepts them and the controller validates them, but the spec is silent.

## Why This Matters

- The OpenAPI spec is the source of truth for SDK generation and for the downstream developer-docs sync. Both waves' filter parity work is invisible to customers until this lands.
- The two tiers ship the full Knowledge Hub UI filter parity to the public API (tracking issue intercom/intercom#510966). Documenting them late means customers can't replicate the dashboard in scripted workflows, which is the entire goal of the parity work.
- Batching Tier 1 + Tier 2 into one OpenAPI PR matches the natural review unit — both touch the same endpoint, follow identical patterns, and shipping in one wave avoids "Tier 1 spec lands, then Tier 2 spec confuses reviewers a week later" churn.

## Goal

A single PR against `intercom/Intercom-OpenAPI` that adds all 14 new query parameters to the `GET /content/search` operation in `descriptions/0/api.intercom.io.yaml`. Cross-references both monolith PRs. Follows the established pattern from PR #540 (Alex Petrash's scheduled-publishing OpenAPI sync) — surgical edit only, no unrelated diff.

## Context — exact parameter specifications

### Tier 1 params (from monolith PR #520626 — merge SHA `6656d937`)

| Param | Type | Shape | Notes |
|---|---|---|---|
| `states` | array of string enum | csv or repeated | `published`, `draft` |
| `locales` | array of string | csv or repeated | locale codes, e.g. `en`, `fr`, `de` |
| `tag_ids` | array of integer | csv or repeated | |
| `tag_operator` | string enum | scalar | `IN`, `NIN`. Pairs with `tag_ids`. |
| `any_tag_ids` | array of integer | csv or repeated | OR-semantic — alternative to `tag_ids` + `tag_operator` |
| `folder_ids` | array of integer | csv or repeated | Must be sent with `folder_entity_type` (XOR validation) |
| `folder_entity_type` | string enum | scalar | `folder`. Required when `folder_ids` is sent. |

### Tier 2 params (from monolith PR #521153 — merge SHA `58626025`)

| Param | Type | Shape | Notes |
|---|---|---|---|
| `content_types` | array of string enum | csv or repeated | `snippet`, `external_content`, `file_source_content`, `internal_article`, `article`. **REPLACES** the default content-type set when provided, does not filter on top of it. Document this in the description. |
| `copilot_state` | string enum | scalar | `on`, `off` |
| `fin_service_state` | string enum | scalar | `on`, `off`. "Fin Service" = the customer-facing Fin AI Agent. |
| `fin_sales_state` | string enum | scalar | `on`, `off`. "Fin Sales" = Sales Agent / SDR product. |
| `created_by_ids` | array of integer | csv or repeated | Admin IDs |
| `last_updated_by_ids` | array of integer | csv or repeated | Admin IDs |
| `created_at_after` | integer | scalar | Unix epoch seconds. Matches Intercom convention (admins activity logs, conversations parts-created, messages export). |
| `created_at_before` | integer | scalar | Unix epoch seconds |
| `updated_at_after` | integer | scalar | Unix epoch seconds |
| `updated_at_before` | integer | scalar | Unix epoch seconds |

## Context — implementation guidance

- **Target file:** `descriptions/0/api.intercom.io.yaml`
- **Find the existing `GET /content/search` operation** (search for `paths:` → `/content/search:` → `get:`) and add the 14 params to its `parameters:` array.
- **Mirror the param shape already in use in the same file.** Look at an existing array-of-int param like `tag_ids` or `folder_ids` from elsewhere in the spec for the csv/repeated form. For an int scalar, see the unix-epoch params on `/admins/activitylogs` (`created_at_after`/`created_at_before` are precedent) or `/conversations` (`parts_created_after`/`parts_created_before`).
- **For each param, include:** `name`, `in: query`, `required: false` (none are required), `schema:` with appropriate `type`/`items`/`enum`, `description:` (one-sentence customer-facing), `example:` (one realistic value).
- **The 422 `parameter_invalid` response is already documented** at the spec level for the endpoint — don't add new error blocks.
- **For `content_types` specifically:** the description MUST call out that providing it replaces the default content type set, not filters on top. Easy to misread otherwise.
- **For the date params:** the description should note "Unix epoch seconds" explicitly so customers don't try ISO 8601.
- **Cross-reference both monolith PRs** in the OpenAPI PR description: `intercom/intercom#520626` (Tier 1) and `intercom/intercom#521153` (Tier 2). Also reference the tracking issue `intercom/intercom#510966` so the parity work is discoverable.

## Acceptance Criteria

- All 14 params documented in `descriptions/0/api.intercom.io.yaml` under the `GET /content/search` operation.
- `git diff --stat` shows ONLY additions to this file (no deletions of unrelated content, no other file modifications).
- Redocly bot / API design scorecard checks pass on the PR.
- PR description cross-references PR #520626, PR #521153, and tracking issue #510966.

## Non-goals

- **Developer-docs sync** — separate follow-up after this lands, matching the PR #540 → PR #960 pattern (Alex's scheduled-publishing work).
- **Response shape additions** — both Tier 1 and Tier 2 are param-only changes; the response is unchanged.
- **`audience_types`** — still deferred per Tier 1's original PR description.
- **Help Center audience / name / Written by** — public-article-specific UI filters, intentionally excluded.
- **Validation rule documentation** beyond the inline `enum:` constraints — the controller's per-param 422 messages aren't worth mirroring into the spec text.

## Constraints

- Single PR against `intercom/Intercom-OpenAPI`.
- Surgical edit only — must NOT refactor the surrounding YAML, must NOT touch other endpoints, must NOT bump unrelated metadata.
- Param names and types must EXACTLY match what the monolith controller accepts (verified above against the merge commits).

</details>

</details>

<sub>Generated with Claude Code, zen coded with <a href="https://github.com/intercom/parthas">Parthas</a></sub>
