### PR TITLE
Change /contacts/bulk from POST to PUT

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -8249,7 +8249,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/error"
   "/contacts/bulk":
-    post:
+    put:
       summary: Bulk update contacts
       parameters:
       - name: Intercom-Version


### PR DESCRIPTION
Changes the `/contacts/bulk` endpoint method from `POST` to `PUT`. Request body, examples, and responses are unchanged.

<sub>Generated with Claude Code</sub>