### PR TITLE
Document API email-reply bot-comment behavior on replyConversation

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -11047,13 +11047,10 @@ paths:
       description: |-
         You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
 
-        {% admonition type="warning" name="Bot or Operator replies to inbound email conversations" %}
-        When a bot or Operator reply is posted via this endpoint to a conversation that originated from an inbound customer email, the reply is recorded as an internal, unnotifiable bot comment by default. As a result:
+        {% admonition type="warning" name="Bot replies to inbound email" %}
+        By default, bot or Operator replies to a conversation that started as an inbound customer email aren't sent to the customer as email. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
 
-        - No outbound email is sent to the customer.
-        - No `seen` receipt is generated. Receipts are only produced once an outbound email has actually been delivered.
-
-        Outbound email replies from bots or Operator via the API are gated by a workspace feature flag — until it is enabled, replies stay as internal comments and no `seen` receipt is produced. Contact your Intercom representative to enable it.
+        To send these replies as outbound emails, contact your accounts team to enable the email-reply feature flag for your workspace.
         {% /admonition %}
       responses:
         '200':

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -11051,9 +11051,9 @@ paths:
         When a bot or Operator reply is posted via this endpoint to a conversation that originated from an inbound customer email, the reply is recorded as an internal, unnotifiable bot comment by default. As a result:
 
         - No outbound email is sent to the customer.
-        - No `seen` receipt is generated, because no email is delivered.
+        - No `seen` receipt is generated. Receipts are only produced once an outbound email has actually been delivered.
 
-        Outbound email replies from bots or Operator via the API are gated by a workspace setting. To enable them, contact your Intercom representative.
+        Outbound email replies from bots or Operator via the API are gated by a workspace feature flag — until it is enabled, replies stay as internal comments and no `seen` receipt is produced. Contact your Intercom representative to enable it.
         {% /admonition %}
       responses:
         '200':

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -11048,9 +11048,9 @@ paths:
         You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
 
         {% admonition type="warning" name="Bot replies to inbound email" %}
-        By default, bot or Operator replies to a conversation that started as an inbound customer email aren't sent to the customer as email. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
+        By default, bot or Operator replies to an inbound email conversation aren't sent to your customer. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
 
-        To send these replies as outbound emails, contact your accounts team to enable the email-reply feature flag for your workspace.
+        To send these replies as outbound emails, reach out to your accounts team to enable the email-reply feature flag for your workspace.
         {% /admonition %}
       responses:
         '200':

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -11044,8 +11044,17 @@ paths:
       tags:
       - Conversations
       operationId: replyConversation
-      description: You can reply to a conversation with a message from an admin or
-        on behalf of a contact, or with a note for admins.
+      description: |-
+        You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
+
+        {% admonition type="warning" name="Bot or Operator replies to inbound email conversations" %}
+        When a bot or Operator reply is posted via this endpoint to a conversation that originated from an inbound customer email, the reply is recorded as an internal, unnotifiable bot comment by default. As a result:
+
+        - No outbound email is sent to the customer.
+        - No `seen` receipt is generated, because no email is delivered.
+
+        Outbound email replies from bots or Operator via the API are gated by a workspace setting. To enable them, contact your Intercom representative.
+        {% /admonition %}
       responses:
         '200':
           description: User last conversation reply

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -5016,8 +5016,14 @@ paths:
       tags:
       - Conversations
       operationId: replyConversation
-      description: You can reply to a conversation with a message from an admin or
-        on behalf of a contact, or with a note for admins.
+      description: |-
+        You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
+
+        {% admonition type="warning" name="Bot replies to inbound email" %}
+        By default, bot or Operator replies to an inbound email conversation aren't sent to your customer. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
+
+        To send these replies as outbound emails, reach out to your accounts team to enable the email-reply feature flag for your workspace.
+        {% /admonition %}
       responses:
         '200':
           description: User last conversation reply

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -5134,8 +5134,14 @@ paths:
       tags:
       - Conversations
       operationId: replyConversation
-      description: You can reply to a conversation with a message from an admin or
-        on behalf of a contact, or with a note for admins.
+      description: |-
+        You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
+
+        {% admonition type="warning" name="Bot replies to inbound email" %}
+        By default, bot or Operator replies to an inbound email conversation aren't sent to your customer. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
+
+        To send these replies as outbound emails, reach out to your accounts team to enable the email-reply feature flag for your workspace.
+        {% /admonition %}
       responses:
         '200':
           description: User last conversation reply

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -5702,8 +5702,14 @@ paths:
       tags:
       - Conversations
       operationId: replyConversation
-      description: You can reply to a conversation with a message from an admin or
-        on behalf of a contact, or with a note for admins.
+      description: |-
+        You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
+
+        {% admonition type="warning" name="Bot replies to inbound email" %}
+        By default, bot or Operator replies to an inbound email conversation aren't sent to your customer. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
+
+        To send these replies as outbound emails, reach out to your accounts team to enable the email-reply feature flag for your workspace.
+        {% /admonition %}
       responses:
         '200':
           description: User last conversation reply

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -6585,8 +6585,14 @@ paths:
       tags:
       - Conversations
       operationId: replyConversation
-      description: You can reply to a conversation with a message from an admin or
-        on behalf of a contact, or with a note for admins.
+      description: |-
+        You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
+
+        {% admonition type="warning" name="Bot replies to inbound email" %}
+        By default, bot or Operator replies to an inbound email conversation aren't sent to your customer. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
+
+        To send these replies as outbound emails, reach out to your accounts team to enable the email-reply feature flag for your workspace.
+        {% /admonition %}
       responses:
         '200':
           description: User last conversation reply

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -7403,8 +7403,14 @@ paths:
       tags:
       - Conversations
       operationId: replyConversation
-      description: You can reply to a conversation with a message from an admin or
-        on behalf of a contact, or with a note for admins.
+      description: |-
+        You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
+
+        {% admonition type="warning" name="Bot replies to inbound email" %}
+        By default, bot or Operator replies to an inbound email conversation aren't sent to your customer. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
+
+        To send these replies as outbound emails, reach out to your accounts team to enable the email-reply feature flag for your workspace.
+        {% /admonition %}
       responses:
         '200':
           description: User last conversation reply

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -7477,13 +7477,10 @@ paths:
       description: |-
         You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
 
-        {% admonition type="warning" name="Bot or Operator replies to inbound email conversations" %}
-        When a bot or Operator reply is posted via this endpoint to a conversation that originated from an inbound customer email, the reply is recorded as an internal, unnotifiable bot comment by default. As a result:
+        {% admonition type="warning" name="Bot replies to inbound email" %}
+        By default, bot or Operator replies to a conversation that started as an inbound customer email aren't sent to the customer as email. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
 
-        - No outbound email is sent to the customer.
-        - No `seen` receipt is generated. Receipts are only produced once an outbound email has actually been delivered.
-
-        Outbound email replies from bots or Operator via the API are gated by a workspace feature flag — until it is enabled, replies stay as internal comments and no `seen` receipt is produced. Contact your Intercom representative to enable it.
+        To send these replies as outbound emails, contact your accounts team to enable the email-reply feature flag for your workspace.
         {% /admonition %}
       responses:
         '200':

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -7481,9 +7481,9 @@ paths:
         When a bot or Operator reply is posted via this endpoint to a conversation that originated from an inbound customer email, the reply is recorded as an internal, unnotifiable bot comment by default. As a result:
 
         - No outbound email is sent to the customer.
-        - No `seen` receipt is generated, because no email is delivered.
+        - No `seen` receipt is generated. Receipts are only produced once an outbound email has actually been delivered.
 
-        Outbound email replies from bots or Operator via the API are gated by a workspace setting. To enable them, contact your Intercom representative.
+        Outbound email replies from bots or Operator via the API are gated by a workspace feature flag — until it is enabled, replies stay as internal comments and no `seen` receipt is produced. Contact your Intercom representative to enable it.
         {% /admonition %}
       responses:
         '200':

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -7478,9 +7478,9 @@ paths:
         You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
 
         {% admonition type="warning" name="Bot replies to inbound email" %}
-        By default, bot or Operator replies to a conversation that started as an inbound customer email aren't sent to the customer as email. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
+        By default, bot or Operator replies to an inbound email conversation aren't sent to your customer. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
 
-        To send these replies as outbound emails, contact your accounts team to enable the email-reply feature flag for your workspace.
+        To send these replies as outbound emails, reach out to your accounts team to enable the email-reply feature flag for your workspace.
         {% /admonition %}
       responses:
         '200':

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -7474,8 +7474,17 @@ paths:
       tags:
       - Conversations
       operationId: replyConversation
-      description: You can reply to a conversation with a message from an admin or
-        on behalf of a contact, or with a note for admins.
+      description: |-
+        You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
+
+        {% admonition type="warning" name="Bot or Operator replies to inbound email conversations" %}
+        When a bot or Operator reply is posted via this endpoint to a conversation that originated from an inbound customer email, the reply is recorded as an internal, unnotifiable bot comment by default. As a result:
+
+        - No outbound email is sent to the customer.
+        - No `seen` receipt is generated, because no email is delivered.
+
+        Outbound email replies from bots or Operator via the API are gated by a workspace setting. To enable them, contact your Intercom representative.
+        {% /admonition %}
       responses:
         '200':
           description: User last conversation reply

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -5204,8 +5204,14 @@ paths:
       tags:
       - Conversations
       operationId: replyConversation
-      description: You can reply to a conversation with a message from an admin or
-        on behalf of a contact, or with a note for admins.
+      description: |-
+        You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
+
+        {% admonition type="warning" name="Bot replies to inbound email" %}
+        By default, bot or Operator replies to an inbound email conversation aren't sent to your customer. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
+
+        To send these replies as outbound emails, reach out to your accounts team to enable the email-reply feature flag for your workspace.
+        {% /admonition %}
       responses:
         '200':
           description: User last conversation reply

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -5204,8 +5204,14 @@ paths:
       tags:
       - Conversations
       operationId: replyConversation
-      description: You can reply to a conversation with a message from an admin or
-        on behalf of a contact, or with a note for admins.
+      description: |-
+        You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
+
+        {% admonition type="warning" name="Bot replies to inbound email" %}
+        By default, bot or Operator replies to an inbound email conversation aren't sent to your customer. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
+
+        To send these replies as outbound emails, reach out to your accounts team to enable the email-reply feature flag for your workspace.
+        {% /admonition %}
       responses:
         '200':
           description: User last conversation reply

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -5208,8 +5208,14 @@ paths:
       tags:
       - Conversations
       operationId: replyConversation
-      description: You can reply to a conversation with a message from an admin or
-        on behalf of a contact, or with a note for admins.
+      description: |-
+        You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.
+
+        {% admonition type="warning" name="Bot replies to inbound email" %}
+        By default, bot or Operator replies to an inbound email conversation aren't sent to your customer. The reply is stored as an unnotifiable bot comment, and no `seen` receipt is generated until an email is actually delivered.
+
+        To send these replies as outbound emails, reach out to your accounts team to enable the email-reply feature flag for your workspace.
+        {% /admonition %}
       responses:
         '200':
           description: User last conversation reply


### PR DESCRIPTION
### Why?
https://app.intercom.com/a/inbox/tx2p130c/inbox/team/5826718/conversation/215474495894253?view=List

Customers using `POST /conversations/{conversation_id}/reply` to reply to a conversation that originated from an inbound customer email expect the reply to send an outbound email and to eventually produce a `seen` receipt. That's not what happens: by default the reply is recorded as an unnotifiable bot comment — no email goes out, and no `seen` receipt is ever generated. Outbound email replies from bots or Operator via the API are gated by a workspace setting.

The previous one-line operation description didn't capture any of this, which has been causing confusion in customer reports.

### How?

Extended the `replyConversation` operation description in both the v2.15 and Preview specs with a warning admonition that calls out the default behavior, the absence of a `seen` receipt, and how to enable outbound email replies.

<sub>Generated with Claude Code</sub>