### PR TITLE
Document update_tags bulk action on /content/bulk_actions

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9003,11 +9003,15 @@ paths:
       description: |
         Asynchronously run a bulk action over up to 1,000 Knowledge Hub content items.
 
-        Five actions are supported:
+        Six actions are supported:
           * `publish` and `unpublish` — apply to `article_content` only.
           * `delete` — permanently delete content (excludes synced sources and `external_content`).
           * `set_availability` — toggle Fin AI Agent, Copilot, and Sales Agent availability flags.
           * `set_audience` — manage segment membership on content.
+          * `update_tags` — apply and/or remove existing tags on content. Unlike the other
+            actions, `update_tags` addresses articles by the parent `article` id, not
+            `article_content`. Tags must already exist and not be archived; supply at least one of
+            `add_tag_ids` / `remove_tag_ids`.
 
         The endpoint validates the request, enqueues background work, and returns 202 with a
         placeholder envelope. Items whose `type` is not in the action's allowlist are silently
@@ -9110,6 +9114,18 @@ paths:
                     add_segment_ids:
                     - 100
                     remove_segment_ids:
+                    - 200
+              update_tags:
+                summary: Apply and remove tags on an article
+                value:
+                  action: update_tags
+                  content_ids:
+                  - type: article
+                    id: '12345678'
+                  tags:
+                    add_tag_ids:
+                    - 100
+                    remove_tag_ids:
                     - 200
   "/content/search":
     get:
@@ -27142,12 +27158,14 @@ components:
               * `publish`, `unpublish`: `article_content`
               * `delete`: `article_content`, `content_snippet`, `file_source_content`, `internal_article`
               * `set_availability`, `set_audience`: `article_content`, `content_snippet`, `external_content`, `file_source_content`, `internal_article`
+              * `update_tags`: `article` (the parent Article id, not `article_content`), `content_snippet`, `external_content`, `file_source_content`, `internal_article`
           enum:
           - publish
           - unpublish
           - delete
           - set_availability
           - set_audience
+          - update_tags
           example: publish
         content_ids:
           type: array
@@ -27162,6 +27180,7 @@ components:
               type:
                 type: string
                 enum:
+                - article
                 - article_content
                 - content_snippet
                 - external_content
@@ -27208,6 +27227,28 @@ components:
               type: boolean
               description: When `true`, removes all segments from the selected content.
               example: false
+        tags:
+          type: object
+          description: |
+            Required when `action` is `update_tags`. Applies and/or removes existing tags.
+            Supply at least one of `add_tag_ids` / `remove_tag_ids`. Tag IDs must reference
+            existing, non-archived tags; unknown or archived IDs are rejected with
+            `parameter_invalid` (HTTP 422).
+          properties:
+            add_tag_ids:
+              type: array
+              description: Tag IDs to apply to the selected content.
+              items:
+                type: integer
+              example:
+              - 100
+            remove_tag_ids:
+              type: array
+              description: Tag IDs to remove from the selected content.
+              items:
+                type: integer
+              example:
+              - 200
     content_bulk_action_response:
       title: Content Bulk Action Response Envelope
       type: object

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -27231,9 +27231,10 @@ components:
           type: object
           description: |
             Required when `action` is `update_tags`. Applies and/or removes existing tags.
-            Supply at least one of `add_tag_ids` / `remove_tag_ids`. Tag IDs must reference
-            existing, non-archived tags; unknown or archived IDs are rejected with
-            `parameter_invalid` (HTTP 422).
+            Supply at least one of `add_tag_ids` / `remove_tag_ids`. At most 100 distinct tag IDs
+            may be supplied across `add_tag_ids` and `remove_tag_ids` combined. Tag IDs must
+            reference existing, non-archived tags; exceeding the limit or referencing unknown or
+            archived IDs is rejected with `parameter_invalid` (HTTP 422).
           properties:
             add_tag_ids:
               type: array


### PR DESCRIPTION
### Why?

The public POST /content/bulk_actions endpoint gained a new `update_tags` action for bulk applying/removing tags on Knowledge Hub content, but the OpenAPI spec doesn't reflect it — the action enum, request body, and per-action type allowlist are stale, leaving the action invisible to SDK generators and API consumers. Notably, `update_tags` addresses articles by the parent `article` id (not `article_content`), an asymmetry that silently no-ops if undocumented.

### How?

Extend the `content_bulk_action_request` schema in the Preview spec with the new action value, the `article` content type, a `tags` object (`add_tag_ids`/`remove_tag_ids`), per-action allowlist prose calling out the article-vs-article_content asymmetry, and an example mirroring the sibling `set_audience` shape.

<details><summary>Decisions</summary>

- Mirrored the existing `audience`/`set_audience` block's shape and example style for consistency with the already-documented bulk actions
- Documented the article-by-parent-id rule explicitly in both the endpoint description and the per-action type allowlist, since copying the other actions' `article_content` shape is a silent no-op
- Kept error codes in wire format (`parameter_invalid` / HTTP 422), never Ruby constants
- Documented the combined 100-id cap across `add_tag_ids` + `remove_tag_ids` in prose (can't be expressed as `maxItems` since the limit is on the unique combined count)
- Rode at the existing Preview level — no version-change or manifest edits, since the endpoint itself is still Preview/Unstable
- Scoped strictly to additive schema changes; left the other five actions' documented contract untouched
- Dev-docs half delivered on a separate branch (endpoint was entirely absent from `@Preview` spec, so required a targeted port of the path + both schemas + a changelog entry) and flagged for a separate PR

</details>

### Review Guidance

| Dimension | Score | Reasoning |
|-----------|-------|-----------|
| Complexity | `█░░░░░░░░░ 1.2` | <details><summary>Why</summary>Single-file additive YAML edits to one OpenAPI schema with no cross-cutting effects.</details> |
| Unintuitiveness | `░░░░░░░░░░ 0.9` | <details><summary>Why</summary>Diff matches the PR description and plan exactly — six targeted edits mirroring the existing audience/set_audience pattern.</details> |
| Risk Surface | `░░░░░░░░░░ 0.9` | <details><summary>Why</summary>Docs-only spec change at Preview level; no runtime, auth, billing, or migration surface touched.</details> |

**Attention: Routine review** — Routine additive OpenAPI documentation for an already-shipped Preview action; reviewer just needs to confirm the article-vs-article_content allowlist line is accurate.

<sub>🧪 This AI-generated review guidance is experimental. <a href="https://github.com/intercom/parthas/issues/new?title=PR+Risk+Assessment+Feedback&body=PR:+https://github.com/intercom/Intercom-OpenAPI/pull/554%0A%0AFeedback:%0A&labels=risk-assessment-feedback">Share feedback</a></sub>

<details><summary>Implementation Plan</summary>

<details><summary>Worker Implementation Plan</summary>

# Plan: Document `update_tags` bulk action on `/content/bulk_actions`

## Context

Intercom PR `intercom/intercom#524459` added a sixth action — `update_tags` — to the public
`POST /content/bulk_actions` endpoint (applies/removes existing tags on Knowledge Hub content in
bulk). The endpoint is Preview/Unstable (gated by the existing `AddContentBulkActionsApi` version
change, not yet GA), so `update_tags` rides at that same Preview level. The published docs are
stale: the action enum, the request body, and the per-action content-type allowlist don't mention
it, so it's invisible to SDK generators and API consumers.

The single most important thing to document: **`update_tags` addresses articles by the parent
`article` id, NOT `article_content`** — unlike the other five actions. Copying the shape of the
other actions (using `article_content`) is a silent no-op. This asymmetry is intentional.

This order owns **both halves** of a self-contained PR-pair (Captain's decision — keep bulk
tagging docs separate from sibling order `9d9d8591`):
1. **intercom-openapi** Preview spec — primary deliverable, submitted via `parthas submit`.
2. **developer-docs** `@Preview` spec + changelog — committed on its OWN branch; `parthas submit`
   will NOT carry it (expected). Flag in the final report that it needs a separate push/PR (FO
   opens it). See "Dev-docs delivery" below for the branch/sequencing.

## Contract (verified against PR #524459 diff — not just the order summary)

From `entity_type_mapping.rb` and `bulk_actions_controller.rb` in the PR:
- **New action value:** `update_tags` (added to `ALLOWED_ACTIONS`).
- **New content type:** `article` added to the public type map (`"article" => EntityTypes::ARTICLE`).
- **`update_tags` allowlist** (`ALLOWED_TYPES_BY_ACTION`):
  `article content_snippet external_content file_source_content internal_article`
  — note `article`, and note `article_content` is **deliberately excluded** (the asymmetry).
  The other five actions keep `article_content` and do NOT get `article`.
- **New request property `tags`:** object `{ add_tag_ids: [ids], remove_tag_ids: [ids] }`, mirroring
  the `audience` block's shape. Required when `action` is `update_tags`; at least one of the two
  arrays must be non-empty. Apply and remove are independent (not a replace).
- **Tag liveness:** tag ids must reference existing, non-archived tags (both add and remove);
  rejected synchronously by the controller (`validate_tags_live!`).
- **Error wire code:** `raise_invalid_param` → on-the-wire **`parameter_invalid`** at **HTTP 422**
  (NEVER the Ruby constant `INVALID_PARAMETER`). The endpoint's 422 response already exists.
- **Version:** Preview. `Intercom-Version: Preview`. No version-change/manifest edits — unchanged.
- **Scope unchanged:** `write_content` OAuth scope (endpoint already documents 401/403).

## Part A — intercom-openapi (PRIMARY, submitted via parthas)

File: `descriptions/0/api.intercom.io.yaml` (working dir is this worktree).

Six edits. Do NOT alter the documented contract of the other five actions.

1. **Endpoint description prose** (~lines 9003-9018, under the `post:` `description:`):
   - Change "Five actions are supported" → "Six actions are supported".
   - Add a bullet for `update_tags`, e.g.:
     `* \`update_tags\` — apply and/or remove existing tags on content. Addresses articles by the parent \`article\` id (not \`article_content\`).`
   - Add a sentence: tags must already exist and not be archived; supply at least one of
     `add_tag_ids` / `remove_tag_ids`.

2. **requestBody examples** (after the `set_audience` example, ~line 9113): add an `update_tags`
   example mirroring `set_audience`, using `type: article` to make the granularity rule concrete:
   ```yaml
   update_tags:
     summary: Apply and remove tags on an article
     value:
       action: update_tags
       content_ids:
       - type: article
         id: '12345678'
       tags:
         add_tag_ids:
         - 100
         remove_tag_ids:
         - 200
   ```

3. **Schema `action.description`** (`content_bulk_action_request`, ~lines 27140-27144): add a
   per-action allowlist line documenting the asymmetry explicitly:
   `* \`update_tags\`: \`article\` (the parent Article id, not \`article_content\`), \`content_snippet\`, \`external_content\`, \`file_source_content\`, \`internal_article\``

4. **Schema `action.enum`** (~lines 27145-27151): add `- update_tags`.

5. **`content_ids[].type` enum** (~lines 27164-27170): add `- article` (keep example as
   `article_content`).

6. **Add `tags` property** to the schema, after the `audience` block (~after line 27210),
   mirroring `audience` style (integer-array items with examples):
   ```yaml
   tags:
     type: object
     description: |
       Required when `action` is `update_tags`. Applies and/or removes existing tags.
       Supply at least one of `add_tag_ids` / `remove_tag_ids`. Tag IDs must reference
       existing, non-archived tags; unknown or archived IDs are rejected with
       `parameter_invalid` (HTTP 422).
     properties:
       add_tag_ids:
         type: array
         description: Tag IDs to apply to the selected content.
         items:
           type: integer
         example:
         - 100
       remove_tag_ids:
         type: array
         description: Tag IDs to remove from the selected content.
         items:
           type: integer
         example:
         - 200
   ```

## Part B — developer-docs (OWN branch, separate PR)

**Important discovery (recorded on order):** `/content/bulk_actions` is **entirely absent** from
the developer-docs `@Preview` spec — verified against both the canonical
`first-officer/developer-docs` checkout and the `9d9d8591` worktree (0 matches for
`content_bulk_action`). It exists only in intercom-openapi `descriptions/0` and was never synced.
So the dev-docs deliverable is **not** a small delta — to document `update_tags` there, the whole
endpoint must first exist.

**Approach: targeted port** (NOT a full-file copy — a full copy would sweep in ~460 lines of other
unsynced diffs, out of scope). Into `docs/references/@Preview/rest-api/api.intercom.io.yaml`:
1. Port the entire `"/content/bulk_actions"` path block from intercom-openapi `descriptions/0`
   **in its final 6-action state** (i.e. with all the Part A edits already applied). Insert in path
   order, immediately before `"/content/search"`.
2. Port both schemas — `content_bulk_action_request` (with `update_tags`, `article`, `tags`) and
   `content_bulk_action_response` — into `components/schemas` (alphabetical/logical position).
3. Verify the `intercom_version` schema ref used by the endpoint exists in the dev-docs spec
   (it does — used throughout).

Changelog: `docs/references/@Preview/changelog.md` — add a new `##` section at the top (after the
admonition block / unversioned-changes line, newest-first; above the sibling's
"Tag Knowledge Hub content" section). Mirror that section's tone. Cover: bulk apply/remove of
existing tags via `POST /content/bulk_actions` with `action: update_tags` and
`tags: { add_tag_ids, remove_tag_ids }`; supported content types; the **article-by-parent-id**
rule; tags must already exist and be non-archived; `write_content` scope; `Intercom-Version: Preview`.

### Dev-docs delivery / sequencing
- Create a dedicated developer-docs checkout/branch for THIS order (`fd730a99`). Do NOT push to or
  edit `9d9d8591`'s branch.
- Sibling `9d9d8591` is already submitted and merges first. Cut the dev-docs branch from
  developer-docs `main` **after** `9d9d8591`'s dev-docs change lands so this layers on top of its
  changelog section. If it hasn't merged when reached, base off its branch/commit and note the
  rebase dependency in the report.
- Commit the dev-docs half on its own branch; flag in the final `parthas` report that it needs a
  separate push/PR (FO opens it).

## Conventions / guardrails
- Mirror the existing `audience`/`set_audience` shape and example style exactly (integer-array
  `items`, `example:` lists like `- 100`). Match nearby example ID style (`'12345678'`).
- Error codes in wire format only: `parameter_invalid` / HTTP 422. Never Ruby constants.
- 2-space YAML indent. Keep comments out of the spec.
- Do NOT run `fern generate` without `--preview` (auto-submits SDK PRs). Read-only validation only.

## Verification
1. **intercom-openapi:**
   - `fern check` (if `fern-api` installed). Fallback:
     `python3 -c "import yaml; yaml.safe_load(open('descriptions/0/api.intercom.io.yaml'))" && echo OK`
   - `grep -n 'update_tags' descriptions/0/api.intercom.io.yaml` → confirms enum, description,
     example, allowlist line all present.
   - Confirm the other five actions' enum/allowlist/examples are unchanged (no contract drift).
2. **developer-docs:** YAML parse the @Preview spec; run Redocly/fern lint if available;
   `grep -n 'content/bulk_actions\|update_tags' docs/references/@Preview/rest-api/api.intercom.io.yaml`
   and confirm the new changelog section renders (well-formed markdown/admonitions).
3. Commit each repo separately. `parthas submit` for intercom-openapi. Report flags dev-docs PR.

## Files touched
- `descriptions/0/api.intercom.io.yaml` (intercom-openapi — submitted via parthas)
- `docs/references/@Preview/rest-api/api.intercom.io.yaml` (developer-docs — own branch)
- `docs/references/@Preview/changelog.md` (developer-docs — own branch)


</details>

<details><summary>Parthas Order (task/issue)</summary>

**Document the bulk update_tags action on /content/bulk_actions in the public API spec**

## Problem
The public POST /content/bulk_actions endpoint gained a new `update_tags` action (intercom/intercom PR #524459) that applies/removes tags on knowledge content in bulk. The published OpenAPI spec (intercom-openapi, descriptions/0/api.intercom.io.yaml, schema content_bulk_action_request) and the developer-docs don't reflect it: the action enum, the request body, and the per-action type allowlist are all stale. The action is invisible to SDK generators and API consumers.

## Why This Matters
Without docs, customers and SDKs can't discover or correctly call the new bulk tagging action. Most importantly, they can't learn the article-granularity rule — update_tags addresses articles by the parent `article` id, not `article_content` — which is a silent no-op if they copy the shape of the other bulk actions.

## Goal
The public API documentation accurately describes the update_tags bulk action — its action value, request shape, accepted content types, and the article vs article_content distinction — consistent with how /content/bulk_actions is already documented at the Preview level.

## Context (verified against PR #524459 head)
- /content/bulk_actions is already documented in intercom-openapi (content_bulk_action_request). The endpoint is Preview/Unstable (version change AddContentBulkActionsApi, not yet GA) — already documented ahead of release, so update_tags rides at that same Preview level.
- New action value: update_tags (added alongside publish, unpublish, delete, set_availability, set_audience).
- New request property `tags`: an object with add_tag_ids and remove_tag_ids (arrays of tag ids). Required when action is update_tags; at least one of the two must be non-empty. Tag ids must reference existing, non-archived tags.
- New content type value `article` added to the content_ids[].type enum.
- update_tags accepted content_ids[].type values: article, content_snippet, external_content, file_source_content, internal_article — it takes `article` (parent Article id), NOT article_content, unlike the other actions. This asymmetry is intentional and is the key thing to document in the per-action type-allowlist prose.

## Constraints
- Mirror the existing documentation pattern for this endpoint and the sibling tagging docs work: intercom-openapi Preview spec AND developer-docs @Preview spec + a changelog entry.
- Verify the contract against the PR #524459 branch (or master if it has merged) before writing — the PR is green and the contract is locked, but confirm field names and accepted types against the code, not this order's summary.
- Document error codes in wire format (lowercase snake_case, e.g. parameter_invalid at HTTP 422), never Ruby constant names.
- Keep the change scoped to the request-schema additions; do not alter the documented contract of the other five actions.

## Non-goals
- Per-resource tag endpoints (/articles/:id/tags, /content_snippets/:id/tags, /internal_articles/:id/tags) — covered by the separate consolidated tagging-docs order 9d9d8591.
- External-content tags (/ai/external_pages/:id/tags) — separate docs change.
- No changes to audiences/audience_ids docs.

## Acceptance Criteria
- The OpenAPI spec content_bulk_action_request documents update_tags as an action value, the tags request block (add_tag_ids/remove_tag_ids), and article as an accepted content type.
- The per-action type allowlist documents that update_tags accepts article (not article_content), distinct from the other actions.
- Developer-docs reflect the same addition with a changelog entry, at the existing Preview documentation level.
- Spec linting (fern check / Redocly) passes with no new errors.

</details>

</details>

<sub>Generated with Claude Code, zen coded with <a href="https://github.com/intercom/parthas">Parthas</a></sub>
