### PR TITLE
Fix bulk update_tags tag IDs to type string (follow-up to #554)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9124,9 +9124,9 @@ paths:
                     id: '12345678'
                   tags:
                     add_tag_ids:
-                    - 100
+                    - '100'
                     remove_tag_ids:
-                    - 200
+                    - '200'
   "/content/search":
     get:
       summary: Search knowledge base contents
@@ -27246,16 +27246,16 @@ components:
               type: array
               description: Tag IDs to apply to the selected content.
               items:
-                type: integer
+                type: string
               example:
-              - 100
+              - '100'
             remove_tag_ids:
               type: array
               description: Tag IDs to remove from the selected content.
               items:
-                type: integer
+                type: string
               example:
-              - 200
+              - '200'
     content_bulk_action_response:
       title: Content Bulk Action Response Envelope
       type: object


### PR DESCRIPTION
### Why?

In the public API, tag IDs are strings — the `tag` schema documents `id` as `type: string` (example `'123456'`), and every content id in `POST /content/bulk_actions` is a quoted string. PR #554 documented the `update_tags` action's `add_tag_ids` / `remove_tag_ids` as `type: integer` with unquoted examples, which is inconsistent with the rest of the API and produces integer-typed array fields in generated SDKs. The endpoint accepts both string and integer ids, so this is a documentation-consistency fix with no runtime change.

### How?

Types `add_tag_ids` / `remove_tag_ids` items as `string` and quotes their examples, in both the `content_bulk_action_request` schema and the `update_tags` request example.

- intercom/intercom-openapi#554

<sub>Generated with Claude Code</sub>