### PR TITLE
Remove limited-availability framing from Office Hours API docs

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -2682,20 +2682,6 @@ paths:
                 "$ref": "#/components/schemas/office_hours_schedule_list"
         '401':
           "$ref": "#/components/responses/Unauthorized"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: 591a0c2f-78b3-41bb-bfa7-f1fae15107b9
-                    errors:
-                    - code: api_plan_restricted
-                      message: Office Hours API feature not enabled for this workspace
-              schema:
-                "$ref": "#/components/schemas/error"
     post:
       summary: Create an office hours schedule
       parameters:
@@ -2744,20 +2730,6 @@ paths:
                 "$ref": "#/components/schemas/office_hours_schedule"
         '401':
           "$ref": "#/components/responses/Unauthorized"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: 591a0c2f-78b3-41bb-bfa7-f1fae15107b9
-                    errors:
-                    - code: api_plan_restricted
-                      message: Office Hours API feature not enabled for this workspace
-              schema:
-                "$ref": "#/components/schemas/error"
         '422':
           "$ref": "#/components/responses/ValidationError"
   "/office_hours_schedules/{id}":
@@ -2802,20 +2774,6 @@ paths:
                 "$ref": "#/components/schemas/office_hours_schedule"
         '401':
           "$ref": "#/components/responses/Unauthorized"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: 591a0c2f-78b3-41bb-bfa7-f1fae15107b9
-                    errors:
-                    - code: api_plan_restricted
-                      message: Office Hours API feature not enabled for this workspace
-              schema:
-                "$ref": "#/components/schemas/error"
         '404':
           "$ref": "#/components/responses/ObjectNotFound"
     put:
@@ -2871,20 +2829,6 @@ paths:
                 "$ref": "#/components/schemas/office_hours_schedule"
         '401':
           "$ref": "#/components/responses/Unauthorized"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: 591a0c2f-78b3-41bb-bfa7-f1fae15107b9
-                    errors:
-                    - code: api_plan_restricted
-                      message: Office Hours API feature not enabled for this workspace
-              schema:
-                "$ref": "#/components/schemas/error"
         '404':
           "$ref": "#/components/responses/ObjectNotFound"
         '422':
@@ -2932,20 +2876,6 @@ paths:
                     example: true
         '401':
           "$ref": "#/components/responses/Unauthorized"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: 591a0c2f-78b3-41bb-bfa7-f1fae15107b9
-                    errors:
-                    - code: api_plan_restricted
-                      message: Office Hours API feature not enabled for this workspace
-              schema:
-                "$ref": "#/components/schemas/error"
         '404':
           "$ref": "#/components/responses/ObjectNotFound"
   "/office_hours_schedules/{office_hours_schedule_id}/office_hours_exceptions":
@@ -3004,20 +2934,6 @@ paths:
                 "$ref": "#/components/schemas/office_hours_exception_list"
         '401':
           "$ref": "#/components/responses/Unauthorized"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: 591a0c2f-78b3-41bb-bfa7-f1fae15107b9
-                    errors:
-                    - code: api_plan_restricted
-                      message: Office Hours API feature not enabled for this workspace
-              schema:
-                "$ref": "#/components/schemas/error"
         '404':
           "$ref": "#/components/responses/ObjectNotFound"
     post:
@@ -3075,20 +2991,6 @@ paths:
                 "$ref": "#/components/schemas/office_hours_exception"
         '401':
           "$ref": "#/components/responses/Unauthorized"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: 591a0c2f-78b3-41bb-bfa7-f1fae15107b9
-                    errors:
-                    - code: api_plan_restricted
-                      message: Office Hours API feature not enabled for this workspace
-              schema:
-                "$ref": "#/components/schemas/error"
         '404':
           "$ref": "#/components/responses/ObjectNotFound"
         '422':
@@ -3141,20 +3043,6 @@ paths:
                 "$ref": "#/components/schemas/office_hours_exception"
         '401':
           "$ref": "#/components/responses/Unauthorized"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: 591a0c2f-78b3-41bb-bfa7-f1fae15107b9
-                    errors:
-                    - code: api_plan_restricted
-                      message: Office Hours API feature not enabled for this workspace
-              schema:
-                "$ref": "#/components/schemas/error"
         '404':
           "$ref": "#/components/responses/ObjectNotFound"
     put:
@@ -3221,20 +3109,6 @@ paths:
                 "$ref": "#/components/schemas/office_hours_exception"
         '401':
           "$ref": "#/components/responses/Unauthorized"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: 591a0c2f-78b3-41bb-bfa7-f1fae15107b9
-                    errors:
-                    - code: api_plan_restricted
-                      message: Office Hours API feature not enabled for this workspace
-              schema:
-                "$ref": "#/components/schemas/error"
         '404':
           "$ref": "#/components/responses/ObjectNotFound"
         '422':
@@ -3289,20 +3163,6 @@ paths:
                     example: true
         '401':
           "$ref": "#/components/responses/Unauthorized"
-        '403':
-          description: API plan restricted
-          content:
-            application/json:
-              examples:
-                API plan restricted:
-                  value:
-                    type: error.list
-                    request_id: 591a0c2f-78b3-41bb-bfa7-f1fae15107b9
-                    errors:
-                    - code: api_plan_restricted
-                      message: Office Hours API feature not enabled for this workspace
-              schema:
-                "$ref": "#/components/schemas/error"
         '404':
           "$ref": "#/components/responses/ObjectNotFound"
   "/export/reporting_data/enqueue":
@@ -37350,10 +37210,8 @@ tags:
   description: Everything about your Notes
 - name: Office Hours
   description: |
-    Manage office hours schedules and their exceptions. These endpoints are part of
-    the `Preview` API version and require an OAuth token with the `read_write_office_hours`
-    scope. The API is in limited availability — the scope becomes available once the
-    feature is enabled for your workspace; until then requests return `403 api_plan_restricted`.
+    Manage office hours schedules and their exceptions. These endpoints require an
+    OAuth token with the `read_write_office_hours` scope.
 - name: Procedures
   description: |
     Submit human-collected input to Fin Procedures via the HITL (Human in the Loop) API.


### PR DESCRIPTION
### Why?

The Office Hours API documentation described these endpoints as
limited-availability and plan-restricted. That framing is being
removed so the reference reflects how the endpoints actually behave.

### How?

Removed the limited-availability wording from the Office Hours tag
description, and dropped the `api_plan_restricted` 403 response from
the schedules and exceptions endpoints.

<sub>Generated with Claude Code</sub>