### PR TITLE
fix: type listAwayStatusReasons response as list wrapper

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -29,6 +29,33 @@ paths:
         - admins
       x-fern-sdk-method-name: away
       x-fern-request-name: ConfigureAwayAdminRequest
+  # The spec types the 200 response as a bare `AwayStatusReason[]`, but the API
+  # actually returns the standard list wrapper `{ type: "list", data: [...] }`.
+  /away_status_reasons:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                "$ref": null
+                type: object
+                title: AwayStatusReasonList
+                description: A list of away status reasons.
+                items: null
+                properties:
+                  type:
+                    type: string
+                    description: String representing the object's type. Always has the value `list`.
+                    example: list
+                  data:
+                    type: array
+                    description: An array of away status reason objects.
+                    items:
+                      "$ref": "#/components/schemas/away_status_reason"
+                required:
+                  - type
+                  - data
   /articles:
     get:
       x-fern-pagination:

--- a/fern/preview-openapi-overrides.yml
+++ b/fern/preview-openapi-overrides.yml
@@ -22,6 +22,33 @@ paths:
               $ref: '#/components/schemas/CreateArticleRequestBody'
   '/articles/{id}':
     put: null
+  # The spec types the 200 response as a bare `AwayStatusReason[]`, but the API
+  # actually returns the standard list wrapper `{ type: "list", data: [...] }`.
+  '/away_status_reasons':
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                "$ref": null
+                type: object
+                title: AwayStatusReasonList
+                description: A list of away status reasons.
+                items: null
+                properties:
+                  type:
+                    type: string
+                    description: String representing the object's type. Always has the value `list`.
+                    example: list
+                  data:
+                    type: array
+                    description: An array of away status reason objects.
+                    items:
+                      "$ref": "#/components/schemas/away_status_reason"
+                required:
+                  - type
+                  - data
   '/articles/{article_id}/versions':
     get:
       x-fern-pagination:


### PR DESCRIPTION
## What changed

`GET /away_status_reasons` (`listAwayStatusReasons`) had its `200` response modeled as a bare array, `AwayStatusReason[]`. The endpoint actually returns Intercom's standard list wrapper:

```json
{ "type": "list", "data": [ /* AwayStatusReason objects */ ] }
```

Because Fern generates from the spec, every SDK cast the wrapper object straight to `AwayStatusReason[]`, so the typed return value never matched the runtime value (e.g. `response[0]` / `response.map(...)` silently break).

This PR overrides the response schema to the list wrapper in both Fern override files (the `descriptions/` specs are a generated artifact, so the fix belongs in the override layer):

- `fern/openapi-overrides.yml` — stable spec (drives the `2.14` SDK source)
- `fern/preview-openapi-overrides.yml` — preview namespace (drives the `0` source)

## Which API versions are affected

The endpoint exists in `2.14`, `2.15`, and `0` (preview). The override layer applies to the two specs that drive SDK generation: stable (`2.14`) and preview (`0`).

## Verification

Preview-generated the TypeScript SDK locally with the override:

```ts
export interface ListAwayStatusReasonsResponse {
    type: string;
    data: Intercom.AwayStatusReason[];
}
// listAwayStatusReasons() -> HttpResponsePromise<Intercom.ListAwayStatusReasonsResponse>
```

The regenerated wire test now mocks and asserts `{ type: "list", data: [...] }`. `fern check` reports no new errors versus `main`.

> [!NOTE]
> This is technically a breaking change to the generated return type, though the SDK was already incorrect at runtime. Worth sequencing the SDK releases as a major bump.

Fixes intercom/intercom-node#520
Linear: FER-11398
