### PR TITLE
Graduate list handling events endpoint to stable 2.15

### DIFF
--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -8562,6 +8562,66 @@ paths:
                   admin_id: 991267748
                   customer:
                     intercom_user_id: 6762f1d11bb69f9f2193bbf1
+  "/conversations/{id}/handling_events":
+    get:
+      summary: List handling events
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      - name: id
+        in: path
+        required: true
+        description: The identifier for the conversation as given by Intercom.
+        example: '123'
+        schema:
+          type: string
+      tags:
+      - Conversations
+      operationId: listHandlingEvents
+      description: |
+        List all pause/resume events for a conversation. These events track when teammates paused or resumed handling a conversation.
+
+        Requires the `read_conversations` OAuth scope.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/handling_event_list"
+              examples:
+                Successful response:
+                  value:
+                    handling_events:
+                    - teammate:
+                        type: admin
+                        id: 123
+                        name: Jane Example
+                        email: jane@example.com
+                      type: paused
+                      timestamp: "2026-01-09T09:00:00Z"
+                      reason: Paused
+                    - teammate:
+                        type: admin
+                        id: 123
+                        name: Jane Example
+                        email: jane@example.com
+                      type: resumed
+                      timestamp: "2026-01-09T09:10:00Z"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error"
+        '404':
+          description: Conversation not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error"
   "/conversations/redact":
     post:
       summary: Redact a conversation part
@@ -21129,6 +21189,42 @@ components:
         zh-TW:
           description: The content of the group in Chinese (Taiwan)
           "$ref": "#/components/schemas/group_content"
+    handling_event:
+      title: Handling Event
+      type: object
+      description: A pause or resume event for a conversation
+      required:
+        - teammate
+        - type
+        - timestamp
+      properties:
+        teammate:
+          "$ref": "#/components/schemas/teammate_reference"
+        type:
+          type: string
+          enum: [paused, resumed]
+          description: The type of handling event
+          example: paused
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO8601 timestamp when the event occurred
+          example: "2026-01-09T09:00:00Z"
+        reason:
+          type: string
+          description: Optional reason for the event (e.g., "Paused", "Away")
+          example: Paused
+          nullable: true
+    handling_event_list:
+      title: Handling Event List
+      type: object
+      description: A list of handling events for a conversation
+      properties:
+        handling_events:
+          type: array
+          description: Array of handling events
+          items:
+            "$ref": "#/components/schemas/handling_event"
     help_center:
       title: Help Center
       type: object
@@ -22486,6 +22582,34 @@ components:
           - 493881
           items:
             type: integer
+    teammate_reference:
+      title: Teammate Reference
+      type: object
+      description: A reference to a teammate (admin, team, or bot)
+      required:
+        - type
+        - id
+        - name
+      properties:
+        type:
+          type: string
+          enum: [admin, team, bot]
+          description: The type of teammate
+          example: admin
+        id:
+          type: integer
+          description: The unique identifier of the teammate
+          example: 123
+        name:
+          type: string
+          description: The display name of the teammate
+          example: Jane Example
+        email:
+          type: string
+          format: email
+          description: The email address of the teammate (optional for teams/bots)
+          example: jane@example.com
+          nullable: true
     ticket:
       title: Ticket
       type: object

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -22585,7 +22585,7 @@ components:
     teammate_reference:
       title: Teammate Reference
       type: object
-      description: A reference to a teammate (admin, team, or bot)
+      description: A reference to a teammate
       required:
         - type
         - id


### PR DESCRIPTION
## What

Graduates the **Conversations → list handling events** endpoint (`GET /conversations/{id}/handling_events`, `listHandlingEvents`) from Preview to stable **2.15** in the source-of-truth spec.

Adds to `descriptions/2.15/api.intercom.io.yaml`:
- the endpoint path
- the `handling_event` and `handling_event_list` response schemas
- the `teammate_reference` schema (dependency of the response — previously only in `descriptions/0/`)

Endpoint is kept in `descriptions/0/` (Unstable) too — it remains served on `Intercom-Version: Preview`, so existing Preview integrations are unaffected.

Additions-only (124 insertions, 0 deletions); spec parses as valid YAML; all `$ref`s resolve within the 2.15 spec (`error` and `intercom_version` already present).

Postman collections regenerate automatically on merge to main (`generate_postman_collection.yml`). SDKs are unaffected (Fern stable source is 2.14; the endpoint is already in the unstable `descriptions/0/` SDK source).

## Why

Per [#team-integration-capabilities thread](https://intercom.slack.com/archives/C0AQSJXD6HW/p1780057702049219), the API team confirmed the endpoint can go straight into the current stable version (2.15). Requesting customer: Preply.

## Companion PRs (three-repo set)

1. intercom/intercom#526927 — monolith: moves `AddHandlingEventsApi` into the 2.15 version block
2. **this PR** — Intercom-OpenAPI source spec (feeds SDKs + Postman)
3. intercom/developer-docs#987 — published reference + changelog

Land this PR first/alongside #987 so the published docs aren't hand-edited ahead of their source.
