### PR TITLE
Add clarifying note to listSubscriptionsForAContact (all versions)

### DIFF
--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -2652,6 +2652,8 @@ paths:
 
           1.Opt-out subscription types that the user has opted-out from.
           2.Opt-in subscription types that the user has opted-in to receiving.
+
+        **Note:** This endpoint only returns subscriptions where the contact has explicitly configured their preference. Subscriptions that are in the default state — where the contact has not made an explicit opt-in or opt-out choice — are not included in the response.
       responses:
         '200':
           description: Successful

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -2732,6 +2732,8 @@ paths:
 
           1.Opt-out subscription types that the user has opted-out from.
           2.Opt-in subscription types that the user has opted-in to receiving.
+
+        **Note:** This endpoint only returns subscriptions where the contact has explicitly configured their preference. Subscriptions that are in the default state — where the contact has not made an explicit opt-in or opt-out choice — are not included in the response.
       responses:
         '200':
           description: Successful

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -3241,6 +3241,8 @@ paths:
 
           1.Opt-out subscription types that the user has opted-out from.
           2.Opt-in subscription types that the user has opted-in to receiving.
+
+        **Note:** This endpoint only returns subscriptions where the contact has explicitly configured their preference. Subscriptions that are in the default state — where the contact has not made an explicit opt-in or opt-out choice — are not included in the response.
       responses:
         '200':
           description: Successful

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -3654,6 +3654,8 @@ paths:
 
           1.Opt-out subscription types that the user has opted-out from.
           2.Opt-in subscription types that the user has opted-in to receiving.
+
+        **Note:** This endpoint only returns subscriptions where the contact has explicitly configured their preference. Subscriptions that are in the default state — where the contact has not made an explicit opt-in or opt-out choice — are not included in the response.
       responses:
         '200':
           description: Successful

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -4465,6 +4465,8 @@ paths:
 
           1.Opt-out subscription types that the user has opted-out from.
           2.Opt-in subscription types that the user has opted-in to receiving.
+
+        **Note:** This endpoint only returns subscriptions where the contact has explicitly configured their preference. Subscriptions that are in the default state — where the contact has not made an explicit opt-in or opt-out choice — are not included in the response.
       responses:
         '200':
           description: Successful

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -4536,6 +4536,8 @@ paths:
 
           1.Opt-out subscription types that the user has opted-out from.
           2.Opt-in subscription types that the user has opted-in to receiving.
+
+        **Note:** This endpoint only returns subscriptions where the contact has explicitly configured their preference. Subscriptions that are in the default state — where the contact has not made an explicit opt-in or opt-out choice — are not included in the response.
       responses:
         '200':
           description: Successful

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -2871,6 +2871,8 @@ paths:
 
           1.Opt-out subscription types that the user has opted-out from.
           2.Opt-in subscription types that the user has opted-in to receiving.
+
+        **Note:** This endpoint only returns subscriptions where the contact has explicitly configured their preference. Subscriptions that are in the default state — where the contact has not made an explicit opt-in or opt-out choice — are not included in the response.
       responses:
         '200':
           description: Successful

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -2871,6 +2871,8 @@ paths:
 
           1.Opt-out subscription types that the user has opted-out from.
           2.Opt-in subscription types that the user has opted-in to receiving.
+
+        **Note:** This endpoint only returns subscriptions where the contact has explicitly configured their preference. Subscriptions that are in the default state — where the contact has not made an explicit opt-in or opt-out choice — are not included in the response.
       responses:
         '200':
           description: Successful

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -2871,6 +2871,8 @@ paths:
 
           1.Opt-out subscription types that the user has opted-out from.
           2.Opt-in subscription types that the user has opted-in to receiving.
+
+        **Note:** This endpoint only returns subscriptions where the contact has explicitly configured their preference. Subscriptions that are in the default state — where the contact has not made an explicit opt-in or opt-out choice — are not included in the response.
       responses:
         '200':
           description: Successful


### PR DESCRIPTION
### Why?

The `listSubscriptionsForAContact` endpoint description was missing a clarification about which subscriptions it returns. Without this note, it was ambiguous whether contacts with default (unchanged) subscription preferences would appear in the response.

### How?

Added a `**Note:**` paragraph to the `listSubscriptionsForAContact` operation description in all supported versions (2.7–2.15), making explicit that only subscriptions where the contact has actively opted in or out are included. Versions already containing this note were not modified.

- intercom/developer-docs#989

<sub>Generated with Claude Code</sub>