### PR TITLE
Fix broken Scroll API link in listAllCompanies description

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -6289,7 +6289,7 @@ paths:
 
         Note that the API does not include companies who have no associated users in list responses.
 
-        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).
+        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](/docs/references/preview/rest-api/api.intercom.io/companies/scrolloverallcompanies).
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `20` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -1925,7 +1925,7 @@ paths:
 
         Note that the API does not include companies who have no associated users in list responses.
 
-        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).
+        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](/docs/references/2.10/rest-api/api.intercom.io/companies/scrolloverallcompanies).
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `20` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -1981,7 +1981,7 @@ paths:
 
         Note that the API does not include companies who have no associated users in list responses.
 
-        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).
+        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](/docs/references/2.11/rest-api/api.intercom.io/companies/scrolloverallcompanies).
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `20` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -2514,7 +2514,7 @@ paths:
 
         Note that the API does not include companies who have no associated users in list responses.
 
-        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).
+        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](/docs/references/2.12/rest-api/api.intercom.io/companies/scrolloverallcompanies).
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `20` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -2927,7 +2927,7 @@ paths:
 
         Note that the API does not include companies who have no associated users in list responses.
 
-        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).
+        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](/docs/references/2.13/rest-api/api.intercom.io/companies/scrolloverallcompanies).
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `20` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -3742,7 +3742,7 @@ paths:
 
         Note that the API does not include companies who have no associated users in list responses.
 
-        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).
+        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](/docs/references/2.14/rest-api/api.intercom.io/companies/scrolloverallcompanies).
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `20` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -3813,7 +3813,7 @@ paths:
 
         Note that the API does not include companies who have no associated users in list responses.
 
-        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).
+        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](/docs/references/2.15/rest-api/api.intercom.io/companies/scrolloverallcompanies).
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `20` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -2144,7 +2144,7 @@ paths:
 
         Note that the API does not include companies who have no associated users in list responses.
 
-        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).
+        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](/docs/references/2.7/rest-api/api.intercom.io/companies/scrolloverallcompanies).
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `20` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -2144,7 +2144,7 @@ paths:
 
         Note that the API does not include companies who have no associated users in list responses.
 
-        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).
+        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](/docs/references/2.8/rest-api/api.intercom.io/companies/scrolloverallcompanies).
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `20` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -2144,7 +2144,7 @@ paths:
 
         Note that the API does not include companies who have no associated users in list responses.
 
-        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).
+        When using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](/docs/references/2.9/rest-api/api.intercom.io/companies/scrolloverallcompanies).
         {% admonition type="warning" name="Pagination" %}
           You can use pagination to limit the number of results returned. The default is `20` results per page.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.


### PR DESCRIPTION
### Why?

The `listAllCompanies` operation description contained a broken absolute URL pointing to an old reference page that no longer exists. This caused the Scroll API link to 404 for anyone following it.

### How?

Replace the broken absolute URL with a root-relative link in each versioned spec file, using the correct version-scoped path per file.

- intercom/developer-docs#990

<sub>Generated with Claude Code</sub>