### PR TITLE
Add date-range caveat to first_open and first_series_disengagement field descriptions

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -32373,7 +32373,7 @@ components:
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
@@ -32384,7 +32384,8 @@ components:
             one exists.
         first_open:
           type: integer
-          description: The first time the user opened this message.
+          description: The first time the user opened this message. Only events within
+            the export job's requested date range are counted.
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -32361,15 +32361,15 @@ components:
         first_reply:
           type: integer
           description: The first time a user replied to this message if the content
-            was able to receive replies.
+            was able to receive replies. Only events within the export job's requested date range are counted.
         first_completion:
           type: integer
           description: The first time a user completed this message if the content
-            was able to be completed e.g. Tours, Surveys.
+            was able to be completed e.g. Tours, Surveys. Only events within the export job's requested date range are counted.
         first_series_completion:
           type: integer
           description: The first time the series this message was a part of was completed
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
@@ -32377,11 +32377,11 @@ components:
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_goal_success:
           type: integer
           description: The first time the user met this messages associated goal if
-            one exists.
+            one exists. Only events within the export job's requested date range are counted.
         first_open:
           type: integer
           description: The first time the user opened this message. Only events within
@@ -32389,16 +32389,16 @@ components:
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within
-            this message.
+            this message. Only events within the export job's requested date range are counted.
         first_dismisall:
           type: integer
-          description: The first time the series the user dismissed this message.
+          description: The first time the series the user dismissed this message. Only events within the export job's requested date range are counted.
         first_unsubscribe:
           type: integer
-          description: The first time the user unsubscribed from this message.
+          description: The first time the user unsubscribed from this message. Only events within the export job's requested date range are counted.
         first_hard_bounce:
           type: integer
-          description: The first time this message hard bounced for this user
+          description: The first time this message hard bounced for this user. Only events within the export job's requested date range are counted.
     deleted_article_object:
       title: Deleted Article Object
       type: object

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -14719,15 +14719,15 @@ components:
         first_reply:
           type: integer
           description: The first time a user replied to this message if the content
-            was able to receive replies.
+            was able to receive replies. Only events within the export job's requested date range are counted.
         first_completion:
           type: integer
           description: The first time a user completed this message if the content
-            was able to be completed e.g. Tours, Surveys.
+            was able to be completed e.g. Tours, Surveys. Only events within the export job's requested date range are counted.
         first_series_completion:
           type: integer
           description: The first time the series this message was a part of was completed
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
@@ -14735,11 +14735,11 @@ components:
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_goal_success:
           type: integer
           description: The first time the user met this messages associated goal if
-            one exists.
+            one exists. Only events within the export job's requested date range are counted.
         first_open:
           type: integer
           description: The first time the user opened this message. Only events within
@@ -14747,16 +14747,16 @@ components:
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within
-            this message.
+            this message. Only events within the export job's requested date range are counted.
         first_dismisall:
           type: integer
-          description: The first time the series the user dismissed this message.
+          description: The first time the series the user dismissed this message. Only events within the export job's requested date range are counted.
         first_unsubscribe:
           type: integer
-          description: The first time the user unsubscribed from this message.
+          description: The first time the user unsubscribed from this message. Only events within the export job's requested date range are counted.
         first_hard_bounce:
           type: integer
-          description: The first time this message hard bounced for this user
+          description: The first time this message hard bounced for this user. Only events within the export job's requested date range are counted.
     deleted_article_object:
       title: Deleted Article Object
       type: object

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -14731,7 +14731,7 @@ components:
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
@@ -14742,7 +14742,8 @@ components:
             one exists.
         first_open:
           type: integer
-          description: The first time the user opened this message.
+          description: The first time the user opened this message. Only events within
+            the export job's requested date range are counted.
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -15594,7 +15594,7 @@ components:
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
@@ -15605,7 +15605,8 @@ components:
             one exists.
         first_open:
           type: integer
-          description: The first time the user opened this message.
+          description: The first time the user opened this message. Only events within
+            the export job's requested date range are counted.
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -15582,15 +15582,15 @@ components:
         first_reply:
           type: integer
           description: The first time a user replied to this message if the content
-            was able to receive replies.
+            was able to receive replies. Only events within the export job's requested date range are counted.
         first_completion:
           type: integer
           description: The first time a user completed this message if the content
-            was able to be completed e.g. Tours, Surveys.
+            was able to be completed e.g. Tours, Surveys. Only events within the export job's requested date range are counted.
         first_series_completion:
           type: integer
           description: The first time the series this message was a part of was completed
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
@@ -15598,11 +15598,11 @@ components:
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_goal_success:
           type: integer
           description: The first time the user met this messages associated goal if
-            one exists.
+            one exists. Only events within the export job's requested date range are counted.
         first_open:
           type: integer
           description: The first time the user opened this message. Only events within
@@ -15610,16 +15610,16 @@ components:
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within
-            this message.
+            this message. Only events within the export job's requested date range are counted.
         first_dismisall:
           type: integer
-          description: The first time the series the user dismissed this message.
+          description: The first time the series the user dismissed this message. Only events within the export job's requested date range are counted.
         first_unsubscribe:
           type: integer
-          description: The first time the user unsubscribed from this message.
+          description: The first time the user unsubscribed from this message. Only events within the export job's requested date range are counted.
         first_hard_bounce:
           type: integer
-          description: The first time this message hard bounced for this user
+          description: The first time this message hard bounced for this user. Only events within the export job's requested date range are counted.
       required:
         - user_id
         - company_id

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -16006,7 +16006,7 @@ components:
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
@@ -16017,7 +16017,8 @@ components:
             one exists.
         first_open:
           type: integer
-          description: The first time the user opened this message.
+          description: The first time the user opened this message. Only events within
+            the export job's requested date range are counted.
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -15994,15 +15994,15 @@ components:
         first_reply:
           type: integer
           description: The first time a user replied to this message if the content
-            was able to receive replies.
+            was able to receive replies. Only events within the export job's requested date range are counted.
         first_completion:
           type: integer
           description: The first time a user completed this message if the content
-            was able to be completed e.g. Tours, Surveys.
+            was able to be completed e.g. Tours, Surveys. Only events within the export job's requested date range are counted.
         first_series_completion:
           type: integer
           description: The first time the series this message was a part of was completed
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
@@ -16010,11 +16010,11 @@ components:
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_goal_success:
           type: integer
           description: The first time the user met this messages associated goal if
-            one exists.
+            one exists. Only events within the export job's requested date range are counted.
         first_open:
           type: integer
           description: The first time the user opened this message. Only events within
@@ -16022,16 +16022,16 @@ components:
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within
-            this message.
+            this message. Only events within the export job's requested date range are counted.
         first_dismisall:
           type: integer
-          description: The first time the series the user dismissed this message.
+          description: The first time the series the user dismissed this message. Only events within the export job's requested date range are counted.
         first_unsubscribe:
           type: integer
-          description: The first time the user unsubscribed from this message.
+          description: The first time the user unsubscribed from this message. Only events within the export job's requested date range are counted.
         first_hard_bounce:
           type: integer
-          description: The first time this message hard bounced for this user
+          description: The first time this message hard bounced for this user. Only events within the export job's requested date range are counted.
     deleted_article_object:
       title: Deleted Article Object
       type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -17460,15 +17460,15 @@ components:
         first_reply:
           type: integer
           description: The first time a user replied to this message if the content
-            was able to receive replies.
+            was able to receive replies. Only events within the export job's requested date range are counted.
         first_completion:
           type: integer
           description: The first time a user completed this message if the content
-            was able to be completed e.g. Tours, Surveys.
+            was able to be completed e.g. Tours, Surveys. Only events within the export job's requested date range are counted.
         first_series_completion:
           type: integer
           description: The first time the series this message was a part of was completed
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
@@ -17476,11 +17476,11 @@ components:
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_goal_success:
           type: integer
           description: The first time the user met this messages associated goal if
-            one exists.
+            one exists. Only events within the export job's requested date range are counted.
         first_open:
           type: integer
           description: The first time the user opened this message. Only events within
@@ -17488,16 +17488,16 @@ components:
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within
-            this message.
+            this message. Only events within the export job's requested date range are counted.
         first_dismisall:
           type: integer
-          description: The first time the series the user dismissed this message.
+          description: The first time the series the user dismissed this message. Only events within the export job's requested date range are counted.
         first_unsubscribe:
           type: integer
-          description: The first time the user unsubscribed from this message.
+          description: The first time the user unsubscribed from this message. Only events within the export job's requested date range are counted.
         first_hard_bounce:
           type: integer
-          description: The first time this message hard bounced for this user
+          description: The first time this message hard bounced for this user. Only events within the export job's requested date range are counted.
     deleted_article_object:
       title: Deleted Article Object
       type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -17472,7 +17472,7 @@ components:
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
@@ -17483,7 +17483,8 @@ components:
             one exists.
         first_open:
           type: integer
-          description: The first time the user opened this message.
+          description: The first time the user opened this message. Only events within
+            the export job's requested date range are counted.
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -19318,7 +19318,7 @@ components:
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
@@ -19329,7 +19329,8 @@ components:
             one exists.
         first_open:
           type: integer
-          description: The first time the user opened this message.
+          description: The first time the user opened this message. Only events within
+            the export job's requested date range are counted.
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -19306,15 +19306,15 @@ components:
         first_reply:
           type: integer
           description: The first time a user replied to this message if the content
-            was able to receive replies.
+            was able to receive replies. Only events within the export job's requested date range are counted.
         first_completion:
           type: integer
           description: The first time a user completed this message if the content
-            was able to be completed e.g. Tours, Surveys.
+            was able to be completed e.g. Tours, Surveys. Only events within the export job's requested date range are counted.
         first_series_completion:
           type: integer
           description: The first time the series this message was a part of was completed
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
@@ -19322,11 +19322,11 @@ components:
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_goal_success:
           type: integer
           description: The first time the user met this messages associated goal if
-            one exists.
+            one exists. Only events within the export job's requested date range are counted.
         first_open:
           type: integer
           description: The first time the user opened this message. Only events within
@@ -19334,16 +19334,16 @@ components:
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within
-            this message.
+            this message. Only events within the export job's requested date range are counted.
         first_dismisall:
           type: integer
-          description: The first time the series the user dismissed this message.
+          description: The first time the series the user dismissed this message. Only events within the export job's requested date range are counted.
         first_unsubscribe:
           type: integer
-          description: The first time the user unsubscribed from this message.
+          description: The first time the user unsubscribed from this message. Only events within the export job's requested date range are counted.
         first_hard_bounce:
           type: integer
-          description: The first time this message hard bounced for this user
+          description: The first time this message hard bounced for this user. Only events within the export job's requested date range are counted.
     deleted_article_object:
       title: Deleted Article Object
       type: object

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -20093,15 +20093,15 @@ components:
         first_reply:
           type: integer
           description: The first time a user replied to this message if the content
-            was able to receive replies.
+            was able to receive replies. Only events within the export job's requested date range are counted.
         first_completion:
           type: integer
           description: The first time a user completed this message if the content
-            was able to be completed e.g. Tours, Surveys.
+            was able to be completed e.g. Tours, Surveys. Only events within the export job's requested date range are counted.
         first_series_completion:
           type: integer
           description: The first time the series this message was a part of was completed
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
@@ -20109,11 +20109,11 @@ components:
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_goal_success:
           type: integer
           description: The first time the user met this messages associated goal if
-            one exists.
+            one exists. Only events within the export job's requested date range are counted.
         first_open:
           type: integer
           description: The first time the user opened this message. Only events within
@@ -20121,16 +20121,16 @@ components:
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within
-            this message.
+            this message. Only events within the export job's requested date range are counted.
         first_dismisall:
           type: integer
-          description: The first time the series the user dismissed this message.
+          description: The first time the series the user dismissed this message. Only events within the export job's requested date range are counted.
         first_unsubscribe:
           type: integer
-          description: The first time the user unsubscribed from this message.
+          description: The first time the user unsubscribed from this message. Only events within the export job's requested date range are counted.
         first_hard_bounce:
           type: integer
-          description: The first time this message hard bounced for this user
+          description: The first time this message hard bounced for this user. Only events within the export job's requested date range are counted.
     deleted_article_object:
       title: Deleted Article Object
       type: object

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -20105,7 +20105,7 @@ components:
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
@@ -20116,7 +20116,8 @@ components:
             one exists.
         first_open:
           type: integer
-          description: The first time the user opened this message.
+          description: The first time the user opened this message. Only events within
+            the export job's requested date range are counted.
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -12668,7 +12668,7 @@ components:
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
@@ -12679,7 +12679,8 @@ components:
             one exists.
         first_open:
           type: integer
-          description: The first time the user opened this message.
+          description: The first time the user opened this message. Only events within
+            the export job's requested date range are counted.
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -12656,15 +12656,15 @@ components:
         first_reply:
           type: integer
           description: The first time a user replied to this message if the content
-            was able to receive replies.
+            was able to receive replies. Only events within the export job's requested date range are counted.
         first_completion:
           type: integer
           description: The first time a user completed this message if the content
-            was able to be completed e.g. Tours, Surveys.
+            was able to be completed e.g. Tours, Surveys. Only events within the export job's requested date range are counted.
         first_series_completion:
           type: integer
           description: The first time the series this message was a part of was completed
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
@@ -12672,11 +12672,11 @@ components:
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_goal_success:
           type: integer
           description: The first time the user met this messages associated goal if
-            one exists.
+            one exists. Only events within the export job's requested date range are counted.
         first_open:
           type: integer
           description: The first time the user opened this message. Only events within
@@ -12684,16 +12684,16 @@ components:
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within
-            this message.
+            this message. Only events within the export job's requested date range are counted.
         first_dismisall:
           type: integer
-          description: The first time the series the user dismissed this message.
+          description: The first time the series the user dismissed this message. Only events within the export job's requested date range are counted.
         first_unsubscribe:
           type: integer
-          description: The first time the user unsubscribed from this message.
+          description: The first time the user unsubscribed from this message. Only events within the export job's requested date range are counted.
         first_hard_bounce:
           type: integer
-          description: The first time this message hard bounced for this user
+          description: The first time this message hard bounced for this user. Only events within the export job's requested date range are counted.
     deleted_article_object:
       title: Deleted Article Object
       type: object

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -12692,7 +12692,7 @@ components:
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
@@ -12703,7 +12703,8 @@ components:
             one exists.
         first_open:
           type: integer
-          description: The first time the user opened this message.
+          description: The first time the user opened this message. Only events within
+            the export job's requested date range are counted.
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -12680,15 +12680,15 @@ components:
         first_reply:
           type: integer
           description: The first time a user replied to this message if the content
-            was able to receive replies.
+            was able to receive replies. Only events within the export job's requested date range are counted.
         first_completion:
           type: integer
           description: The first time a user completed this message if the content
-            was able to be completed e.g. Tours, Surveys.
+            was able to be completed e.g. Tours, Surveys. Only events within the export job's requested date range are counted.
         first_series_completion:
           type: integer
           description: The first time the series this message was a part of was completed
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
@@ -12696,11 +12696,11 @@ components:
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_goal_success:
           type: integer
           description: The first time the user met this messages associated goal if
-            one exists.
+            one exists. Only events within the export job's requested date range are counted.
         first_open:
           type: integer
           description: The first time the user opened this message. Only events within
@@ -12708,16 +12708,16 @@ components:
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within
-            this message.
+            this message. Only events within the export job's requested date range are counted.
         first_dismisall:
           type: integer
-          description: The first time the series the user dismissed this message.
+          description: The first time the series the user dismissed this message. Only events within the export job's requested date range are counted.
         first_unsubscribe:
           type: integer
-          description: The first time the user unsubscribed from this message.
+          description: The first time the user unsubscribed from this message. Only events within the export job's requested date range are counted.
         first_hard_bounce:
           type: integer
-          description: The first time this message hard bounced for this user
+          description: The first time this message hard bounced for this user. Only events within the export job's requested date range are counted.
     deleted_article_object:
       title: Deleted Article Object
       type: object

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -14031,15 +14031,15 @@ components:
         first_reply:
           type: integer
           description: The first time a user replied to this message if the content
-            was able to receive replies.
+            was able to receive replies. Only events within the export job's requested date range are counted.
         first_completion:
           type: integer
           description: The first time a user completed this message if the content
-            was able to be completed e.g. Tours, Surveys.
+            was able to be completed e.g. Tours, Surveys. Only events within the export job's requested date range are counted.
         first_series_completion:
           type: integer
           description: The first time the series this message was a part of was completed
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
@@ -14047,11 +14047,11 @@ components:
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_goal_success:
           type: integer
           description: The first time the user met this messages associated goal if
-            one exists.
+            one exists. Only events within the export job's requested date range are counted.
         first_open:
           type: integer
           description: The first time the user opened this message. Only events within
@@ -14059,16 +14059,16 @@ components:
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within
-            this message.
+            this message. Only events within the export job's requested date range are counted.
         first_dismisall:
           type: integer
-          description: The first time the series the user dismissed this message.
+          description: The first time the series the user dismissed this message. Only events within the export job's requested date range are counted.
         first_unsubscribe:
           type: integer
-          description: The first time the user unsubscribed from this message.
+          description: The first time the user unsubscribed from this message. Only events within the export job's requested date range are counted.
         first_hard_bounce:
           type: integer
-          description: The first time this message hard bounced for this user
+          description: The first time this message hard bounced for this user. Only events within the export job's requested date range are counted.
     deleted_article_object:
       title: Deleted Article Object
       type: object

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -14043,7 +14043,7 @@ components:
         first_series_disengagement:
           type: integer
           description: The first time the series this message was a part of was disengaged
-            by the user.
+            by the user. Only events within the export job's requested date range are counted.
         first_series_exit:
           type: integer
           description: The first time the series this message was a part of was exited
@@ -14054,7 +14054,8 @@ components:
             one exists.
         first_open:
           type: integer
-          description: The first time the user opened this message.
+          description: The first time the user opened this message. Only events within
+            the export job's requested date range are counted.
         first_click:
           type: integer
           description: The first time the series the user clicked on a link within


### PR DESCRIPTION
### Why?

The `first_open` and `first_series_disengagement` export stats fields were missing a key constraint: only events within the export job's requested date range are counted. Without this, developers could misinterpret the values as lifetime counts.

### How?

Append the clarifying sentence to both field descriptions across all versioned spec files.

- intercom/developer-docs#991

<sub>Generated with Claude Code</sub>