### PR TITLE
Add audience_ids to Content Import Source in v2.15

### DIFF
--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -421,6 +421,7 @@ paths:
                       sync_behavior: automatic
                       created_at: 1734537259
                       updated_at: 1734537259
+                      audience_ids: []
                     - id: 34
                       type: content_import_source
                       last_synced_at: 1734537259
@@ -429,6 +430,7 @@ paths:
                       sync_behavior: automatic
                       created_at: 1734537259
                       updated_at: 1734537259
+                      audience_ids: []
                     - id: 35
                       type: content_import_source
                       last_synced_at: 1734537259
@@ -437,6 +439,7 @@ paths:
                       sync_behavior: automatic
                       created_at: 1734537259
                       updated_at: 1734537259
+                      audience_ids: []
                     pages:
                       type: pages
                       page: 1
@@ -488,6 +491,7 @@ paths:
                     sync_behavior: api
                     created_at: 1734537261
                     updated_at: 1734537261
+                    audience_ids: []
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -580,6 +584,7 @@ paths:
                     sync_behavior: api
                     created_at: 1734537265
                     updated_at: 1734537265
+                    audience_ids: []
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -623,6 +628,7 @@ paths:
                     sync_behavior: api
                     created_at: 1734537267
                     updated_at: 1734537267
+                    audience_ids: []
               schema:
                 "$ref": "#/components/schemas/content_import_source"
         '401':
@@ -17621,6 +17627,13 @@ components:
           format: date-time
           description: The time when the content import source was last updated.
           example: 1672928610
+        audience_ids:
+          type: array
+          items:
+            type: integer
+          description: The unique identifiers for the audiences associated with this content import source.
+          example:
+          - 5678
       required:
       - id
       - type
@@ -18732,6 +18745,16 @@ components:
           type: string
           description: The URL of the content import source.
           example: https://help.example.com
+        audience_ids:
+          nullable: true
+          description: The unique identifiers for the audiences to associate with this content import source. Can be a single integer or an array of integers.
+          example:
+          - 5678
+          oneOf:
+          - type: integer
+          - type: array
+            items:
+              type: integer
       required:
       - sync_behavior
       - url
@@ -23552,6 +23575,21 @@ components:
           description: The URL of the content import source. This may only be different
             from the existing value if the sync behavior is API.
           example: https://help.example.com
+        audience_ids:
+          nullable: true
+          description: The unique identifiers for the audiences to associate with this content import source. Can be a single integer or an array of integers. Set to null or an empty array to remove all audiences.
+          example:
+          - 5678
+          oneOf:
+          - type: integer
+          - type: array
+            items:
+              type: integer
+        apply_audience_to_existing_content:
+          type: boolean
+          description: When true, the audience will be applied to all existing external pages belonging to this content import source.
+          default: false
+          example: false
       required:
       - sync_behavior
       - url

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -17629,6 +17629,7 @@ components:
           example: 1672928610
         audience_ids:
           type: array
+          nullable: true
           items:
             type: integer
           description: The unique identifiers for the audiences associated with this content import source.


### PR DESCRIPTION
### Why?

The `audience_ids` field (and `apply_audience_to_existing_content` on update) for Content Import Sources was previously available only in the Preview spec. Because the change is non-breaking — purely additive — it is being promoted to the stable v2.15 version rather than held for the next major version.

### How?

Adds the field to the Content Import Source schema, create and update request payloads, and response examples in `descriptions/2.15`.

<sub>Generated with Claude Code</sub>