### PR TITLE
Remove procedures setting from Fin Agent Settings (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -33345,16 +33345,6 @@ components:
             with a single, self-contained answer — for example, in asynchronous channels where
             back-and-forth conversation is not practical.
           example: true
-        procedures:
-          type: boolean
-          default: true
-          description: |
-            When `true` (default), Fin will follow any configured procedures during the
-            conversation.
-
-            When `false`, Fin skips procedures and responds using its general knowledge and
-            configured content only.
-          example: false
         email:
           type: boolean
           default: false


### PR DESCRIPTION
### Why?

The `procedures` setting is being removed from the Fin Agent API. Procedures now run based purely on whether the conversation is conversational (`/fin/ask` and follow-up-disabled conversations never run them), not on a client-supplied flag — so the setting no longer exists in the API and shouldn't be documented.

Backend change: intercom/intercom#528794

### How?

Remove the `procedures` property from the Preview Fin Agent Settings schema. Preview-only — the setting was never present in any stable version.

<sub>Generated with Claude Code</sub>