### PR TITLE
docs: type listAwayStatusReasons response as list wrapper

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -2432,9 +2432,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/away_status_reason"
+                "$ref": "#/components/schemas/away_status_reason_list"
         '401':
           "$ref": "#/components/responses/Unauthorized"
   "/audiences":
@@ -26359,6 +26357,22 @@ components:
           type: integer
           description: "The Unix timestamp when the status reason was last updated"
           example: 1734537243
+    away_status_reason_list:
+      title: Away Status Reasons
+      type: object
+      description: A list of away status reasons.
+      properties:
+        type:
+          type: string
+          description: The type of the object
+          enum:
+          - list
+          example: list
+        data:
+          type: array
+          description: A list of away status reason objects.
+          items:
+            "$ref": "#/components/schemas/away_status_reason"
     change_ticket_type_request:
       title: Change Ticket Type Request
       description: You can change the type of a Ticket

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -1508,9 +1508,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/away_status_reason"
+                "$ref": "#/components/schemas/away_status_reason_list"
         '401':
           "$ref": "#/components/responses/Unauthorized"
   "/export/reporting_data/enqueue":
@@ -15771,6 +15769,22 @@ components:
           type: integer
           description: "The Unix timestamp when the status reason was last updated"
           example: 1734537243
+    away_status_reason_list:
+      title: Away Status Reasons
+      type: object
+      description: A list of away status reasons.
+      properties:
+        type:
+          type: string
+          description: The type of the object
+          enum:
+          - list
+          example: list
+        data:
+          type: array
+          description: A list of away status reason objects.
+          items:
+            "$ref": "#/components/schemas/away_status_reason"
     close_conversation_request:
       title: Close Conversation Request
       type: object

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -1514,9 +1514,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/away_status_reason"
+                "$ref": "#/components/schemas/away_status_reason_list"
         '401':
           "$ref": "#/components/responses/Unauthorized"
   "/export/reporting_data/enqueue":
@@ -16511,6 +16509,22 @@ components:
           type: integer
           description: "The Unix timestamp when the status reason was last updated"
           example: 1734537243
+    away_status_reason_list:
+      title: Away Status Reasons
+      type: object
+      description: A list of away status reasons.
+      properties:
+        type:
+          type: string
+          description: The type of the object
+          enum:
+          - list
+          example: list
+        data:
+          type: array
+          description: A list of away status reason objects.
+          items:
+            "$ref": "#/components/schemas/away_status_reason"
     close_conversation_request:
       title: Close Conversation Request
       type: object


### PR DESCRIPTION
### Why?

The published API reference and OpenAPI spec document `GET /away_status_reasons` (`listAwayStatusReasons`) `200` as a bare array of `away_status_reason` objects. The endpoint actually returns Intercom's standard list envelope `{ "type": "list", "data": [...] }`. Verified against the monolith: `Api::V3::AwayStatusReasonsController#index` renders via `Api::V3::AdminStatus::Presenters::AwayStatusReasonListResponse`, which hard-codes `type: "list"` and `data`. The spec has always documented the wrong shape, misleading integrators and SDK codegen.

### How?

Add an `away_status_reason_list` component (matching the existing `tag_list`/`brand_list` convention) and point the `200` response at it, in every version that exposes the endpoint: 2.14, 2.15, and 0 (Preview). `fern check` reports no new errors or warnings vs `main`.

### References

- intercom/Intercom-OpenAPI#558 — Fern SDK fix (override layer); this PR fixes the published spec/docs that the override does not regenerate
- intercom/intercom-node#520
- intercom/developer-docs#1005 — developer-docs mirror of this edit
- Linear FER-11398

<sub>Generated with Claude Code</sub>
