### PR TITLE
Preview: link URLs preserved in plaintext conversation content

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -10952,7 +10952,7 @@ paths:
       - name: display_as
         in: query
         required: false
-        description: Set to plaintext to retrieve conversation messages in plain text. This affects both the body and subject fields.
+        description: Set to plaintext to retrieve conversation messages in plain text. This affects both the body and subject fields. Inline links are rendered as `label (url)`, preserving the link URL alongside the visible text.
         example: plaintext
         schema:
           type: string
@@ -11453,7 +11453,7 @@ paths:
       - name: display_as
         in: query
         required: false
-        description: Set to plaintext to retrieve conversation messages in plain text. This affects both the body and subject fields.
+        description: Set to plaintext to retrieve conversation messages in plain text. This affects both the body and subject fields. Inline links are rendered as `label (url)`, preserving the link URL alongside the visible text.
         example: plaintext
         schema:
           type: string


### PR DESCRIPTION
### Why?

On the Preview API version, plaintext conversation content (`display_as=plaintext`) now preserves inline link URLs instead of dropping them — fixing link loss in REST plaintext responses and the `conversation.operator.replied` webhook body. This documents that behavior on the `display_as` parameter.

### What?

Appends a sentence to both `display_as` parameter descriptions noting that inline links render as `label (url)` in plaintext.

Companion to:
- intercom/intercom#531304 (monolith)
- intercom/developer-docs#1007 (developer-docs)

<sub>Generated with Claude Code</sub>