### PR TITLE
Add attachment_files to admin ticket reply request

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -24832,7 +24832,8 @@ components:
         attachment_files:
           type: array
           description: A list of files that will be added as attachments. You can
-            include up to 10 files
+            include up to 10 files. If both attachment_files and attachment_urls are
+            provided, attachment_files takes precedence.
           items:
             "$ref": "#/components/schemas/conversation_attachment_files"
           maxItems: 10

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -24829,6 +24829,13 @@ components:
             type: string
             format: uri
           maxItems: 10
+        attachment_files:
+          type: array
+          description: A list of files that will be added as attachments. You can
+            include up to 10 files
+          items:
+            "$ref": "#/components/schemas/conversation_attachment_files"
+          maxItems: 10
         cross_post:
           type: boolean
           description: If set to true, the note will be cross-posted to all linked


### PR DESCRIPTION
### Why?
Docs PR:
- https://github.com/intercom/developer-docs/pull/1008

The `POST /tickets/{id}/reply` endpoint now accepts `attachment_files` for admin senders, allowing base64-encoded file uploads with explicit name and content type.

### How?

Adds `attachment_files` to the `admin_reply_ticket_request` schema in `descriptions/0/api.intercom.io.yaml`, referencing the existing `conversation_attachment_files` schema.

<sub>Generated with Claude Code</sub>