### PR TITLE
Restore Reporting Data Export tag on reporting data export endpoints

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -3358,7 +3358,7 @@ paths:
     post:
       summary: Enqueue a new reporting data export job
       description: For the **conversation** dataset, from the Preview version this export returns all conversations, including those that never received a user reply. Earlier versions return only conversations that received at least one user reply. Other datasets are unaffected.
-      tags: [Export]
+      tags: [Reporting Data Export]
       parameters:
       - name: Intercom-Version
         in: header
@@ -3487,7 +3487,7 @@ paths:
   "/export/reporting_data/{job_identifier}":
     get:
       summary: Get export job status
-      tags: [Export]
+      tags: [Reporting Data Export]
       parameters:
         - name: Intercom-Version
           in: header
@@ -3562,7 +3562,7 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
-      tags: [Export]
+      tags: [Reporting Data Export]
       responses:
         '200':
           description: List of datasets
@@ -3616,7 +3616,7 @@ paths:
         > Octet header required
         >
         > You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.
-      tags: [Export]
+      tags: [Reporting Data Export]
       parameters:
         - name: Intercom-Version
           in: header
@@ -38178,6 +38178,8 @@ tags:
     {% admonition type="warning" %}
     This API requires the Procedures HITL API feature to be enabled for your workspace and an OAuth token with the `write_conversations` scope.
     {% /admonition %}
+- name: Reporting Data Export
+  description: Everything about Reporting Data Export. See this [article](https://www.intercom.com/help/en/articles/12089688-api-metrics-documentation) for details on using the data to generate various metrics.
 - name: Segments
   description: Everything about your Segments
 - name: Subscription Types

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -1514,7 +1514,7 @@ paths:
   "/export/reporting_data/enqueue":
     post:
       summary: Enqueue a new reporting data export job
-      tags: [Export]
+      tags: [Reporting Data Export]
       parameters:
       - name: Intercom-Version
         in: header
@@ -1642,7 +1642,7 @@ paths:
   "/export/reporting_data/{job_identifier}":
     get:
       summary: Get export job status
-      tags: [Export]
+      tags: [Reporting Data Export]
       parameters:
         - name: Intercom-Version
           in: header
@@ -1717,7 +1717,7 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
-      tags: [Export]
+      tags: [Reporting Data Export]
       responses:
         '200':
           description: List of datasets
@@ -1766,7 +1766,7 @@ paths:
         > Octet header required
         >
         > You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.
-      tags: [Export]
+      tags: [Reporting Data Export]
       parameters:
         - name: Intercom-Version
           in: header
@@ -23322,6 +23322,8 @@ tags:
     url: https://www.intercom.com/help/en/articles/6362251-news-explained
 - name: Notes
   description: Everything about your Notes
+- name: Reporting Data Export
+  description: Everything about Reporting Data Export. See this [article](https://www.intercom.com/help/en/articles/12089688-api-metrics-documentation) for details on using the data to generate various metrics.
 - name: Segments
   description: Everything about your Segments
 - name: Subscription Types

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -1520,7 +1520,7 @@ paths:
   "/export/reporting_data/enqueue":
     post:
       summary: Enqueue a new reporting data export job
-      tags: [Export]
+      tags: [Reporting Data Export]
       parameters:
       - name: Intercom-Version
         in: header
@@ -1648,7 +1648,7 @@ paths:
   "/export/reporting_data/{job_identifier}":
     get:
       summary: Get export job status
-      tags: [Export]
+      tags: [Reporting Data Export]
       parameters:
         - name: Intercom-Version
           in: header
@@ -1723,7 +1723,7 @@ paths:
         in: header
         schema:
           "$ref": "#/components/schemas/intercom_version"
-      tags: [Export]
+      tags: [Reporting Data Export]
       responses:
         '200':
           description: List of datasets
@@ -1772,7 +1772,7 @@ paths:
         > Octet header required
         >
         > You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.
-      tags: [Export]
+      tags: [Reporting Data Export]
       parameters:
         - name: Intercom-Version
           in: header
@@ -24436,6 +24436,8 @@ tags:
     url: https://www.intercom.com/help/en/articles/6362251-news-explained
 - name: Notes
   description: Everything about your Notes
+- name: Reporting Data Export
+  description: Everything about Reporting Data Export. See this [article](https://www.intercom.com/help/en/articles/12089688-api-metrics-documentation) for details on using the data to generate various metrics.
 - name: Segments
   description: Everything about your Segments
 - name: Subscription Types


### PR DESCRIPTION
### Why?

The reporting data export endpoints are grouped under a documentation section reachable at a stable `reporting-data-export` URL. A previously shortened tag name (`Export`) changed that section's generated route and broke existing links to it.

### How?

Restored the descriptive `Reporting Data Export` tag name and its description on the `/export/reporting_data/*` operations across the Preview, 2.14, and 2.15 specs, so the section keeps its original URL.

<sub>Generated with Claude Code</sub>