### PR TITLE
Document granular conversation priority levels in Preview spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -10531,7 +10531,7 @@ paths:
                       tags:
                         type: tag.list
                         tags: []
-                      priority: not_priority
+                      priority: none
                       sla_applied:
                       statistics:
                       conversation_rating:
@@ -10570,7 +10570,7 @@ paths:
                       open: true
                       state: open
                       read: true
-                      priority: not_priority
+                      priority: none
                       admin_assignee_id: 991267715
                       team_assignee_id: 5017691
                       ai_agent_participated: false
@@ -10847,7 +10847,7 @@ paths:
                         applied_by:
                           type: contact
                           id: '1a2b3c'
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -11027,7 +11027,7 @@ paths:
                         applied_by:
                           type: contact
                           id: '1a2b3c'
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -11160,7 +11160,7 @@ paths:
                     open: true
                     state: open
                     read: true
-                    priority: not_priority
+                    priority: none
                     admin_assignee_id: 991267715
                     team_assignee_id: 5017691
                     ai_agent_participated: false
@@ -11325,7 +11325,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -11333,7 +11333,7 @@ paths:
                     title:
                     custom_attributes:
                       issue_type: Billing
-                      priority: High
+                      priority: high
                     topics: {}
                     ticket:
                     linked_objects:
@@ -11426,7 +11426,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -11518,7 +11518,7 @@ paths:
                   title: new conversation title
                   custom_attributes:
                     issue_type: Billing
-                    priority: High
+                    priority: high
               update_a_conversation_with_an_association_to_a_custom_object_instance:
                 summary: update a conversation with an association to a custom object
                   instance
@@ -11533,7 +11533,7 @@ paths:
                   title: new conversation title
                   custom_attributes:
                     issue_type: Billing
-                    priority: High
+                    priority: high
     delete:
       summary: Delete a conversation
       parameters:
@@ -11794,7 +11794,7 @@ paths:
                       tags:
                         type: tag.list
                         tags: []
-                      priority: not_priority
+                      priority: none
                       sla_applied:
                       statistics:
                       conversation_rating:
@@ -11833,7 +11833,7 @@ paths:
                       open: true
                       state: open
                       read: true
-                      priority: not_priority
+                      priority: none
                       admin_assignee_id: 991267715
                       team_assignee_id: 5017691
                       ai_agent_participated: false
@@ -11954,7 +11954,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -12034,7 +12034,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -12126,7 +12126,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -12209,7 +12209,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -12413,7 +12413,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -12493,7 +12493,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -12573,7 +12573,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -12653,7 +12653,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -13365,7 +13365,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -13527,7 +13527,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: not_priority
+                    priority: none
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -18887,28 +18887,28 @@ paths:
                   phone: "+353832345678"
                   custom_attributes:
                     issue_type: Billing
-                    priority: High
+                    priority: high
               bad_request_-_exception_sending_sms:
                 summary: bad request - exception sending sms
                 value:
                   phone: "+353832345678"
                   custom_attributes:
                     issue_type: Billing
-                    priority: High
+                    priority: high
               bad_request_-_invalid_number:
                 summary: bad request - invalid number
                 value:
                   phone: "+353832345678"
                   custom_attributes:
                     issue_type: Billing
-                    priority: High
+                    priority: high
               unprocessable_entity:
                 summary: unprocessable entity
                 value:
                   phone: "+40241100100"
                   custom_attributes:
                     issue_type: Billing
-                    priority: High
+                    priority: high
   "/calls":
     get:
       summary: List all calls
@@ -28687,10 +28687,14 @@ components:
         priority:
           type: string
           enum:
-          - priority
-          - not_priority
-          description: If marked as priority, it will return priority or else not_priority.
-          example: priority
+          - none
+          - low
+          - medium
+          - high
+          - urgent
+          description: The priority level of the conversation. Returns one of none,
+            low, medium, high, or urgent.
+          example: high
         admin_assignee_id:
           type: integer
           description: The id of the admin assigned to the conversation. If it's not
@@ -28822,10 +28826,14 @@ components:
         priority:
           type: string
           enum:
-          - priority
-          - not_priority
-          description: If marked as priority, it will return priority or else not_priority.
-          example: priority
+          - none
+          - low
+          - medium
+          - high
+          - urgent
+          description: The priority level of the conversation. Returns one of none,
+            low, medium, high, or urgent.
+          example: high
         admin_assignee_id:
           type: integer
           description: The id of the admin assigned to the conversation. If it's not
@@ -33118,14 +33126,14 @@ components:
       properties:
         current_priority:
           type: string
-          enum: ["priority", "not_priority"]
-          description: Current priority state
-          example: "priority"
+          enum: ["none", "low", "medium", "high", "urgent"]
+          description: Current priority level
+          example: "high"
         previous_priority:
           type: string
-          enum: ["priority", "not_priority"]
-          description: Previous priority state
-          example: "not_priority"
+          enum: ["none", "low", "medium", "high", "urgent"]
+          description: Previous priority level
+          example: "none"
     conversation_sla_applied_by_rule:
       title: Part type - conversation_sla_applied_by_rule
       type: object


### PR DESCRIPTION
### Why?

The conversation `priority` field is moving from binary values to granular
priority levels in the Preview API version. The OpenAPI spec needs to reflect
the new values so consumers on Preview see the correct contract.

### How?

Update the conversation `priority` enum and the `priority_changed` conversation
part enum in the Preview spec to `none, low, medium, high, urgent`, and
normalize example values to match.

<sub>Generated with Claude Code</sub>