### PR TITLE
Make from and into required on merge_contacts_request (all versions)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -34619,6 +34619,9 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
+      required:
+      - from
+      - into
       properties:
         from:
           type: string

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -15214,6 +15214,9 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
+      required:
+      - from
+      - into
       properties:
         from:
           type: string

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -16554,6 +16554,9 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
+      required:
+      - from
+      - into
       properties:
         from:
           type: string

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -16618,6 +16618,9 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
+      required:
+      - from
+      - into
       properties:
         from:
           type: string

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -18227,6 +18227,9 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
+      required:
+      - from
+      - into
       properties:
         from:
           type: string

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -20535,6 +20535,9 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
+      required:
+      - from
+      - into
       properties:
         from:
           type: string

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -21484,6 +21484,9 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
+      required:
+      - from
+      - into
       properties:
         from:
           type: string

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -13117,6 +13117,9 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
+      required:
+      - from
+      - into
       properties:
         from:
           type: string

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -13142,6 +13142,9 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
+      required:
+      - from
+      - into
       properties:
         from:
           type: string

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -14494,6 +14494,9 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
+      required:
+      - from
+      - into
       properties:
         from:
           type: string


### PR DESCRIPTION
### Why?

The merge endpoint (`POST /contacts/merge`) cannot complete without both `from` and `into` — a request omitting either is rejected server-side because neither contact can be resolved. The schema previously documented both as optional, so generated SDKs and the "Try it" console treated them as skippable, letting callers construct requests the API will always reject.

### How?

Add `required: [from, into]` to the `merge_contacts_request` schema across every versioned spec that defines the merge endpoint (2.7–2.15 and the unstable description). This is a spec-accuracy change only: it can only reject requests the backend would already reject.

<sub>Generated with Claude Code</sub>