### PR TITLE
Fix duplicate required key on merge_contacts_request in 2.11 spec

### DIFF
--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -16554,9 +16554,6 @@ components:
       description: Merge contact data.
       type: object
       title: Merge contact data
-      required:
-      - from
-      - into
       properties:
         from:
           type: string


### PR DESCRIPTION
### Why?

The change that made `from`/`into` required on `merge_contacts_request` added a `required: [from, into]` block to every API version. The 2.11 spec already declared both fields required via a trailing `required:` list, so the addition produced a duplicate mapping key and broke strict YAML parsing of the 2.11 spec.

### How?

Remove the redundant added block from the 2.11 spec, leaving its pre-existing `required:` declaration intact. The other versions are unaffected.

<sub>Generated with Claude Code</sub>