### PR TITLE
Add 3 new activity-log event types to the 2.15 spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -415,6 +415,7 @@ paths:
                     event_types:
                     - admin_conversation_assignment_limit_change
                     - admin_ticket_assignment_limit_change
+                    - admin_avatar_change
                     - admin_away_mode_change
                     - admin_deletion
                     - admin_deprovisioned
@@ -455,6 +456,7 @@ paths:
                     - campaign_deletion
                     - campaign_state_change
                     - conversation_part_deletion
+                    - conversation_pdf_export
                     - conversation_topic_change
                     - conversation_topic_creation
                     - conversation_topic_deletion
@@ -24645,6 +24647,7 @@ components:
           enum:
           - admin_conversation_assignment_limit_change
           - admin_ticket_assignment_limit_change
+          - admin_avatar_change
           - admin_away_mode_change
           - admin_deletion
           - admin_deprovisioned
@@ -24685,6 +24688,7 @@ components:
           - campaign_deletion
           - campaign_state_change
           - conversation_part_deletion
+          - conversation_pdf_export
           - conversation_topic_change
           - conversation_topic_creation
           - conversation_topic_deletion

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -10927,6 +10927,7 @@ components:
           type: string
           enum:
           - admin_assignment_limit_change
+          - admin_avatar_change
           - admin_away_mode_change
           - admin_deletion
           - admin_deprovisioned
@@ -10967,6 +10968,7 @@ components:
           - campaign_deletion
           - campaign_state_change
           - conversation_part_deletion
+          - conversation_pdf_export
           - conversation_topic_change
           - conversation_topic_creation
           - conversation_topic_deletion

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -11012,6 +11012,7 @@ components:
           type: string
           enum:
           - admin_assignment_limit_change
+          - admin_avatar_change
           - admin_away_mode_change
           - admin_deletion
           - admin_deprovisioned
@@ -11052,6 +11053,7 @@ components:
           - campaign_deletion
           - campaign_state_change
           - conversation_part_deletion
+          - conversation_pdf_export
           - conversation_topic_change
           - conversation_topic_creation
           - conversation_topic_deletion

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -11768,6 +11768,7 @@ components:
           type: string
           enum:
           - admin_assignment_limit_change
+          - admin_avatar_change
           - admin_away_mode_change
           - admin_deletion
           - admin_deprovisioned
@@ -11808,6 +11809,7 @@ components:
           - campaign_deletion
           - campaign_state_change
           - conversation_part_deletion
+          - conversation_pdf_export
           - conversation_topic_change
           - conversation_topic_creation
           - conversation_topic_deletion

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -13087,6 +13087,7 @@ components:
           type: string
           enum:
           - admin_assignment_limit_change
+          - admin_avatar_change
           - admin_away_mode_change
           - admin_deletion
           - admin_deprovisioned
@@ -13127,6 +13128,7 @@ components:
           - campaign_deletion
           - campaign_state_change
           - conversation_part_deletion
+          - conversation_pdf_export
           - conversation_topic_change
           - conversation_topic_creation
           - conversation_topic_deletion

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -14451,6 +14451,7 @@ components:
           enum:
           - admin_conversation_assignment_limit_change
           - admin_ticket_assignment_limit_change
+          - admin_avatar_change
           - admin_away_mode_change
           - admin_deletion
           - admin_deprovisioned
@@ -14494,6 +14495,7 @@ components:
           - campaign_deletion
           - campaign_state_change
           - conversation_part_deletion
+          - conversation_pdf_export
           - conversation_topic_change
           - conversation_topic_creation
           - conversation_topic_deletion
@@ -14505,6 +14507,7 @@ components:
           - macro_creation
           - macro_deletion
           - macro_update
+          - macro_usage_export
           - malicious_domains_setting_change
           - message_deletion
           - message_state_change

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -15065,6 +15065,7 @@ components:
           enum:
           - admin_conversation_assignment_limit_change
           - admin_ticket_assignment_limit_change
+          - admin_avatar_change
           - admin_away_mode_change
           - admin_deletion
           - admin_deprovisioned
@@ -15112,6 +15113,7 @@ components:
           - conversation_deletion_schedule_state_change
           - conversation_deletion_schedule_update
           - conversation_part_deletion
+          - conversation_pdf_export
           - conversation_topic_change
           - conversation_topic_creation
           - conversation_topic_deletion
@@ -15127,6 +15129,7 @@ components:
           - macro_creation
           - macro_deletion
           - macro_update
+          - macro_usage_export
           - malicious_domains_setting_change
           - message_deletion
           - message_state_change

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -9210,6 +9210,7 @@ components:
           type: string
           enum:
           - admin_assignment_limit_change
+          - admin_avatar_change
           - admin_away_mode_change
           - admin_deletion
           - admin_deprovisioned
@@ -9250,6 +9251,7 @@ components:
           - campaign_deletion
           - campaign_state_change
           - conversation_part_deletion
+          - conversation_pdf_export
           - conversation_topic_change
           - conversation_topic_creation
           - conversation_topic_deletion

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -9210,6 +9210,7 @@ components:
           type: string
           enum:
           - admin_assignment_limit_change
+          - admin_avatar_change
           - admin_away_mode_change
           - admin_deletion
           - admin_deprovisioned
@@ -9250,6 +9251,7 @@ components:
           - campaign_deletion
           - campaign_state_change
           - conversation_part_deletion
+          - conversation_pdf_export
           - conversation_topic_change
           - conversation_topic_creation
           - conversation_topic_deletion

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -10390,6 +10390,7 @@ components:
           type: string
           enum:
           - admin_assignment_limit_change
+          - admin_avatar_change
           - admin_away_mode_change
           - admin_deletion
           - admin_deprovisioned
@@ -10430,6 +10431,7 @@ components:
           - campaign_deletion
           - campaign_state_change
           - conversation_part_deletion
+          - conversation_pdf_export
           - conversation_topic_change
           - conversation_topic_creation
           - conversation_topic_deletion


### PR DESCRIPTION
### Why?

Three new Teammate Activity Log event types shipped in the intercom monolith and need to appear in the public activity-log types enum:

- `admin_avatar_change` — intercom/intercom#537931 (intercom/intercom#529379)
- `conversation_pdf_export` — intercom/intercom#537908 (intercom/intercom#537132)
- `macro_usage_export` — intercom/intercom#537906 (intercom/intercom#529280)

### How?

Adds the three values to the activity-log event-types enum. `admin_avatar_change` and `conversation_pdf_export` are emitted dynamically with no version `Change` class, so they're live on every API version at runtime — added to all 10 version dirs (`0`/Unstable, `2.7`–`2.15`), matching the existing `admin_away_mode_change` / `conversation_part_deletion` precedent. `macro_usage_export` is scoped to `2.14`+ only, matching the rest of the Macro* enum cluster, which doesn't exist in the spec before 2.14.

<sub>Generated with Claude Code</sub>