### PR TITLE
fix(dataEvents): widen event metadata typing beyond string

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -1418,8 +1418,7 @@ components:
             metadata:
               type: object
               description: Optional metadata about the event.
-              additionalProperties:
-                type: string
+              additionalProperties: true
               example:
                 invite_code: ADDAFRIEND
           required:
@@ -1451,8 +1450,7 @@ components:
             metadata:
               type: object
               description: Optional metadata about the event.
-              additionalProperties:
-                type: string
+              additionalProperties: true
               example:
                 invite_code: ADDAFRIEND
           required:
@@ -1486,8 +1484,7 @@ components:
             metadata:
               type: object
               description: Optional metadata about the event.
-              additionalProperties:
-                type: string
+              additionalProperties: true
               example:
                 invite_code: ADDAFRIEND
           required:
@@ -1886,6 +1883,9 @@ components:
             - collection
             - section
     data_event:
+      properties:
+        metadata:
+          additionalProperties: true
       required:
         - type
         - event_name

--- a/fern/preview-openapi-overrides.yml
+++ b/fern/preview-openapi-overrides.yml
@@ -114,6 +114,14 @@ components:
     custom_attributes:
       example:
         monthly_spend: '155.5'
+    create_data_event_request:
+      properties:
+        metadata:
+          additionalProperties: true
+    data_event:
+      properties:
+        metadata:
+          additionalProperties: true
     create_ticket_request:
       x-fern-type-name: CreateTicketRequestBody
       properties:


### PR DESCRIPTION
### Why?

Event `metadata` is typed as a string-only map in the generated SDKs (`Record<string, string>`), but the Events API accepts more value types (number, date, link, rich link, monetary amount) and applies no per-type validation. The strict type forces users to stringify non-string values.

### How?

Widen `create_data_event_request.metadata` and `data_event.metadata` to `additionalProperties: true` in the stable and preview overrides. Override-only; no runtime change.

<sub>Generated with Claude Code</sub>