### PR TITLE
docs: add skip_unsnooze to admin_reply_conversation_request schema (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -25230,7 +25230,8 @@ components:
         skip_unsnooze:
           type: boolean
           description: When true, prevents the reply from waking a snoozed conversation.
-            The part is still created and visible in the conversation thread.
+            Applies to 'comment' and 'note' message types. The part is still created
+            and visible in the conversation thread.
           example: true
       required:
       - message_type

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -25227,6 +25227,11 @@ components:
           items:
             "$ref": "#/components/schemas/conversation_attachment_files"
           maxItems: 10
+        skip_unsnooze:
+          type: boolean
+          description: When true, prevents the reply from waking a snoozed conversation.
+            The part is still created and visible in the conversation thread.
+          example: true
       required:
       - message_type
       - type


### PR DESCRIPTION
### Why?

Adds documentation for the new `skip_unsnooze` boolean parameter accepted by the conversation reply endpoint. When set to `true`, the reply is threaded into the conversation without waking an active snooze.

### How?

Adds `skip_unsnooze` to the `admin_reply_conversation_request` schema in the Preview spec.

<sub>Generated with Claude Code</sub>