### PR TITLE
Enable consolidateTypeFiles for the TypeScript SDK

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -48,6 +48,7 @@ groups:
           noSerdeLayer: true
           enableInlineTypes: true
           inlinePathParameters: true
+          consolidateTypeFiles: true
           timeoutInSeconds: 20
           packageJson:
             license: Apache-2.0


### PR DESCRIPTION
Addresses intercom/intercom-node#527 — `intercom-client` ships hundreds of byte-identical empty compiled modules (one per erased type file, doubled across the CJS + ESM builds).

### Root cause
With `noSerdeLayer: true`, every type file is a pure `interface`/`type` that `tsc` erases to an empty `.js`/`.mjs` (just the `"use strict"; __esModule` boilerplate). The TypeScript SDK generator emits one source file per declared type, so these empty runtime modules pile up.

### Fix
Set `consolidateTypeFiles: true` on the `ts-sdk` generator. This collapses all types in a namespace into a single `types.ts`, cutting the number of files that erase to empty modules.

### Verification (same-spec, flag OFF vs ON)
Regenerated the `ts-sdk` group from the current spec both ways and built each (CJS + ESM compile clean):

| | flag OFF | flag ON |
|---|---|---|
| total published `.js` | 573 | 375 (−35%) |
| empty compiled modules | 331 | 166 (−50%) |

### Non-breaking
Verified the public API surface is unchanged by the flag (same spec):
- Runtime exports (root `require`): 6 → 6, identical.
- Type exports (recursive, incl. all `Intercom.*` namespaces): 826 → 826, **0 added, 0 removed**.

It is purely an internal `dist/**` file-layout change. The package's `exports` map only exposes `.` and `./package.json`, so no deep-import path into `dist/**` is affected.