### PR TITLE
Add email_verified to Contacts create/update request (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -30484,6 +30484,11 @@ components:
           type: string
           description: The contacts email
           example: jdoe@example.com
+        email_verified:
+          type: boolean
+          nullable: true
+          description: Whether the contact's email address has been verified. Set to true to indicate you have verified the contact owns this email address, or false to mark it as unverified.
+          example: true
         phone:
           type: string
           nullable: true
@@ -37944,6 +37949,11 @@ components:
           type: string
           description: The contacts email
           example: jdoe@example.com
+        email_verified:
+          type: boolean
+          nullable: true
+          description: Whether the contact's email address has been verified. Set to true to indicate you have verified the contact owns this email address, or false to mark it as unverified.
+          example: true
         phone:
           type: string
           nullable: true

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -30487,7 +30487,7 @@ components:
         email_verified:
           type: boolean
           nullable: true
-          description: Whether the contact's email address has been verified. Set to true to indicate you have verified the contact owns this email address, or false to mark it as unverified.
+          description: Whether the contact's email address has been verified. Set to true to indicate you have verified the contact owns this email address, or false to mark it as unverified. Must be supplied together with an email in the same request; sending it without an email returns a 400.
           example: true
         phone:
           type: string
@@ -37952,7 +37952,7 @@ components:
         email_verified:
           type: boolean
           nullable: true
-          description: Whether the contact's email address has been verified. Set to true to indicate you have verified the contact owns this email address, or false to mark it as unverified.
+          description: Whether the contact's email address has been verified. Set to true to indicate you have verified the contact owns this email address, or false to mark it as unverified. Must be supplied together with an email in the same request; sending it without an email returns a 400.
           example: true
         phone:
           type: string


### PR DESCRIPTION
### Why?

The Contacts API accepts a new field for asserting whether a contact's email address has been verified.

### How?

Adds the `email_verified` boolean to the create and update contact request schemas in the Preview spec (`descriptions/0`).

<sub>Generated with Claude Code</sub>