### PR TITLE
Fix YAML parse errors in ecommerce catalog schema descriptions

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -33505,7 +33505,10 @@ components:
           nullable: true
         in_stock:
           type: boolean
-          description: Whether the product is available to purchase. If omitted, derived from variant stock — the product is in stock if at least one variant has `in_stock: true`. Products with no in-stock variants are hidden from Fin entirely and will not be recommended to shoppers.
+          description: |
+            Whether the product is available to purchase. If omitted, derived from variant stock — the
+            product is in stock if at least one variant has `in_stock: true`. Products with no in-stock
+            variants are hidden from Fin entirely and will not be recommended to shoppers.
           example: true
           nullable: true
         tags:
@@ -33547,7 +33550,11 @@ components:
           nullable: true
         available_options:
           type: array
-          description: Option types available for this product and their possible values (e.g. {"name": "Size", "values": ["S", "M", "L"]}). Fin uses these to understand what choices a shopper can make and to correctly filter variants when a shopper asks for a specific size, colour, or other attribute.
+          description: |
+            Option types available for this product and their possible values
+            (e.g. `{"name": "Size", "values": ["S", "M", "L"]}`). Fin uses these to understand what
+            choices a shopper can make and to correctly filter variants when a shopper asks for a
+            specific size, colour, or other attribute.
           items:
             type: object
             properties:


### PR DESCRIPTION
### Why?

PR #587 introduced two YAML parse errors in the `ecommerce_catalog_product` schema in `descriptions/0/api.intercom.io.yaml`:

1. `` `in_stock: true` `` in a plain scalar — the `: ` inside backticks was treated as a mapping entry
2. `{"name": "Size", "values": [...]}` in a plain scalar — the `{` was treated as starting a flow mapping

This caused the Fern `fern check` validation and any YAML parser to fail on this file.

### How?

Both descriptions converted to literal block scalars (`|`), which disables YAML indicator parsing inside the value. No content change otherwise.

### Related

- Original schema PR: #587
- Companion fix in developer-docs: https://github.com/intercom/developer-docs/pull/1041

<sub>Generated with Claude Code</sub>