### PR TITLE
fix(data-events): metadata accepts non-string values in Unstable base spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -30736,8 +30736,7 @@ components:
         metadata:
           type: object
           description: Optional metadata about the event.
-          additionalProperties:
-            type: string
+          additionalProperties: true
           example:
             invite_code: ADDAFRIEND
       anyOf:
@@ -33036,8 +33035,7 @@ components:
         metadata:
           type: object
           description: Optional metadata about the event.
-          additionalProperties:
-            type: string
+          additionalProperties: true
           example:
             invite_code: ADDAFRIEND
       required:


### PR DESCRIPTION
### Why?

The data-event `metadata` schema in the Unstable base spec documents values as strings only (`additionalProperties: {type: string}`), which does not match the API's behaviour — the Events API accepts strings, numbers, dates, links, rich links, and monetary amounts. This over-narrow schema is what drives the SDKs to generate a `Record<string, string>` type.

### How?

Widen `metadata` `additionalProperties` to `true` on both data-event schemas in the Unstable (`descriptions/0`) base spec, matching the fix already applied in the Fern overrides.

Related:
- #586

<sub>Generated with Claude Code</sub>