### PR TITLE
Document reply_to on conversation source (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -11090,6 +11090,9 @@ paths:
                       recipients:
                       - type: to
                         email: testing-workspace@email.com
+                      reply_to:
+                      - email: replies@example.com
+                        name: Support Team
                       author:
                         type: lead
                         id: '991267645'
@@ -29939,6 +29942,25 @@ components:
                 nullable: true
                 description: The reason this recipient was dropped, if applicable.
                 example:
+        reply_to:
+          type: array
+          nullable: true
+          description: The Reply-To header addresses of the source message, where
+            a reply will be routed. Can differ from the sender's From address. Only
+            present for email conversations.
+          items:
+            type: object
+            properties:
+              email:
+                type: string
+                format: email
+                description: The Reply-To email address.
+                example: replies@example.com
+              name:
+                type: string
+                nullable: true
+                description: The display name associated with the Reply-To address.
+                example: Support Team
         subject:
           type: string
           nullable: true


### PR DESCRIPTION
### Why

Companion documentation for [intercom/intercom#521116](https://github.com/intercom/intercom/pull/521116) (merged), which exposed the email `Reply-To` header on the Conversations API message `source` object. The field shipped on **Preview** but was never documented, so it was held out of the API 2.16 cut. This adds the OpenAPI spec entry so it can be included.

### What

- Adds a `reply_to` array (`{ email, name }`) to the `conversation_source` schema in the Preview spec (`descriptions/0/api.intercom.io.yaml`), beside the existing `recipients`.
- Adds `reply_to` to the email-source response example.

Purely additive (22 insertions, 0 deletions). Preview only — the field is copied into `2.16` during the version cut, so no other version specs are touched here.

### Companion PRs

- Monolith (merged): intercom/intercom#521116
- Developer docs + changelog: intercom/developer-docs#1046

<sub>Generated with Claude Code</sub>