### PR TITLE
Add Document Contacts bulk create and bulk delete contacts (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9236,6 +9236,45 @@ paths:
                     email: maria@example.com
                     name: "María García"
                     role: lead
+              all_fields:
+                summary: All supported fields
+                value:
+                  contacts:
+                  - external_id: abc123
+                    email: joe@bloggs.com
+                    name: Joe Bloggs
+                    role: user
+                    phone: "+353871234567"
+                    avatar: https://www.example.com/avatar_image.jpg
+                    signed_up_at: 1571672154
+                    last_seen_at: 1571672154
+                    owner_id: "321"
+                    unsubscribed_from_emails: false
+                    language_override: fr
+                    custom_attributes:
+                      plan: pro
+                    companies:
+                    - company_id: '6'
+                      name: Blue Sun
+                    tags:
+                      add:
+                      - id: '123'
+              with_companies:
+                summary: Associate companies
+                value:
+                  contacts:
+                  - external_id: abc123
+                    email: joe@bloggs.com
+                    companies:
+                    - company_id: '6'
+                      name: Blue Sun
+                    - company_id: '7'
+                      name: Weyland-Yutani
+                  - external_id: def456
+                    email: maria@example.com
+                    company:
+                      company_id: '6'
+                      name: Blue Sun
       responses:
         '202':
           description: Accepted
@@ -9334,6 +9373,41 @@ paths:
                   - id: ghi789
                     language_override: es
                     name: "María García"
+              all_fields:
+                summary: All supported fields
+                value:
+                  contacts:
+                  - id: abc123
+                    external_id: ext123
+                    email: joe@bloggs.com
+                    name: Joe Bloggs
+                    phone: "+353871234567"
+                    avatar: https://www.example.com/avatar_image.jpg
+                    owner_id: "321"
+                    unsubscribed_from_emails: false
+                    language_override: fr
+                    custom_attributes:
+                      plan: pro
+                    companies:
+                    - company_id: '6'
+                      name: Blue Sun
+                    tags:
+                      add:
+                      - id: '123'
+              with_companies:
+                summary: Attach and detach companies
+                value:
+                  contacts:
+                  - id: abc123
+                    companies:
+                    - company_id: '6'
+                      name: Blue Sun
+                    - company_id: '7'
+                      remove: true
+                  - id: def456
+                    company:
+                      company_id: '6'
+                      name: Blue Sun
               with_tags:
                 summary: Add and remove tags
                 value:
@@ -27460,6 +27534,41 @@ components:
                 type: boolean
                 description: Whether the contact is unsubscribed from emails.
                 example: true
+              companies:
+                type: array
+                description: A list of companies to associate with the contact.
+                  Each company is identified by the `company_id` you have defined.
+                  A company that does not exist is created, and one that already
+                  exists has the supplied attributes applied to it.
+                items:
+                  type: object
+                  required:
+                  - company_id
+                  properties:
+                    company_id:
+                      type: string
+                      description: The company ID you have defined for the company.
+                      example: '6'
+                    name:
+                      type: string
+                      description: The name of the company.
+                      example: Blue Sun
+              company:
+                type: object
+                description: A single company to associate with the contact, identified
+                  by the `company_id` you have defined. Created if it does not exist.
+                  Ignored when `role` is `lead` — use `companies` instead.
+                required:
+                - company_id
+                properties:
+                  company_id:
+                    type: string
+                    description: The company ID you have defined for the company.
+                    example: '6'
+                  name:
+                    type: string
+                    description: The name of the company.
+                    example: Blue Sun
               tags:
                 type: object
                 description: |
@@ -27572,6 +27681,46 @@ components:
               custom_attributes:
                 type: object
                 description: Custom attributes to update on the contact.
+              companies:
+                type: array
+                description: A list of companies to associate with the contact.
+                  Each company is identified by the `company_id` you have defined.
+                  A company that does not exist is created, and one that already
+                  exists has the supplied attributes applied to it.
+                items:
+                  type: object
+                  required:
+                  - company_id
+                  properties:
+                    company_id:
+                      type: string
+                      description: The company ID you have defined for the company.
+                      example: '6'
+                    name:
+                      type: string
+                      description: The name of the company.
+                      example: Blue Sun
+                    remove:
+                      type: boolean
+                      description: Set to true to detach this company from the contact
+                        instead of attaching it.
+                      example: true
+              company:
+                type: object
+                description: A single company to associate with the contact, identified
+                  by the `company_id` you have defined. Created if it does not exist.
+                  Ignored for a contact whose role is `lead` — use `companies` instead.
+                required:
+                - company_id
+                properties:
+                  company_id:
+                    type: string
+                    description: The company ID you have defined for the company.
+                    example: '6'
+                  name:
+                    type: string
+                    description: The name of the company.
+                    example: Blue Sun
               tags:
                 type: object
                 description: |

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9262,11 +9262,6 @@ paths:
                       name: Blue Sun
                     - company_id: '7'
                       name: Weyland-Yutani
-                  - external_id: def456
-                    email: maria@example.com
-                    company:
-                      company_id: '6'
-                      name: Blue Sun
               with_tags:
                 summary: Add tags
                 value:
@@ -9405,10 +9400,6 @@ paths:
                       name: Blue Sun
                     - company_id: '7'
                       remove: true
-                  - id: def456
-                    company:
-                      company_id: '6'
-                      name: Blue Sun
               with_tags:
                 summary: Add and remove tags
                 value:
@@ -27561,22 +27552,6 @@ components:
                       type: string
                       description: The name of the company.
                       example: Blue Sun
-              company:
-                type: object
-                description: A single company to associate with the contact, identified
-                  by the `company_id` you have defined. Created if it does not exist.
-                  Ignored when `role` is `lead` — use `companies` instead.
-                required:
-                - company_id
-                properties:
-                  company_id:
-                    type: string
-                    description: The company ID you have defined for the company.
-                    example: '6'
-                  name:
-                    type: string
-                    description: The name of the company.
-                    example: Blue Sun
               tags:
                 type: object
                 description: |
@@ -27713,22 +27688,6 @@ components:
                       description: Set to true to detach this company from the contact
                         instead of attaching it.
                       example: true
-              company:
-                type: object
-                description: A single company to associate with the contact, identified
-                  by the `company_id` you have defined. Created if it does not exist.
-                  Ignored for a contact whose role is `lead` — use `companies` instead.
-                required:
-                - company_id
-                properties:
-                  company_id:
-                    type: string
-                    description: The company ID you have defined for the company.
-                    example: '6'
-                  name:
-                    type: string
-                    description: The name of the company.
-                    example: Blue Sun
               tags:
                 type: object
                 description: |

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9209,6 +9209,8 @@ paths:
 
         The endpoint creates an async job that processes the items in the background. Use the returned job ID with `GET /contacts/bulk/{id}` to check the job status.
 
+        Only the fields listed in the request schema below can be set. Any other fields in a contact object are ignored.
+
         {% admonition type="info" name="Handling existing contacts" %}
           If a contact already exists with the given `external_id` or `email` (including an archived contact), that item is rejected and the job's `state` ends as `completed_with_errors`. New contacts in the same request are still created. The job `state` from `GET /contacts/bulk/{id}` is the signal that one or more items were rejected.
 
@@ -9218,6 +9220,7 @@ paths:
         {% admonition type="info" name="Limits" %}
           - Maximum of 100 contacts per request.
           - You can append tasks to an existing job by including `job.id` in the request body.
+          - Tag application is best-effort and processed asynchronously: unknown tag IDs are skipped, and per-tag results are not returned in the job status.
         {% /admonition %}
       requestBody:
         content:
@@ -9249,7 +9252,7 @@ paths:
                       add:
                       - id: '123'
               with_companies:
-                summary: Associate companies
+                summary: Attach companies
                 value:
                   contacts:
                   - external_id: abc123
@@ -9264,6 +9267,15 @@ paths:
                     company:
                       company_id: '6'
                       name: Blue Sun
+              with_tags:
+                summary: Add tags
+                value:
+                  contacts:
+                  - name: Contact Name
+                    external_id: abc123
+                    tags:
+                      add:
+                      - id: '123'
               append_to_existing_job:
                 summary: Append to existing job
                 value:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9212,7 +9212,7 @@ paths:
         {% admonition type="info" name="Handling existing contacts" %}
           If a contact already exists with the given `external_id` or `email` (including an archived contact), that item is rejected and the job's `state` ends as `completed_with_errors`. New contacts in the same request are still created. The job `state` from `GET /contacts/bulk/{id}` is the signal that one or more items were rejected.
 
-          Created contacts aren't returned with IDs in the response. Look them up afterwards with [Get a contact by External ID](/docs/references/preview/rest-api/api.intercom.io/contacts/getcontactbyexternalid) or [Search contacts](/docs/references/preview/rest-api/api.intercom.io/contacts/searchcontacts).
+          Created contacts aren't returned with IDs in the response. Look them up afterwards with [Get a contact by External ID](/docs/references/preview/rest-api/api.intercom.io/contacts/showcontactbyexternalid) or [Search contacts](/docs/references/preview/rest-api/api.intercom.io/contacts/searchcontacts).
         {% /admonition %}
 
         {% admonition type="info" name="Limits" %}
@@ -9227,17 +9227,6 @@ paths:
             examples:
               successful:
                 summary: Successful
-                value:
-                  contacts:
-                  - external_id: abc123
-                    email: joe@bloggs.com
-                    name: Joe Bloggs
-                  - external_id: def456
-                    email: maria@example.com
-                    name: "María García"
-                    role: lead
-              all_fields:
-                summary: All supported fields
                 value:
                   contacts:
                   - external_id: abc123
@@ -9275,6 +9264,15 @@ paths:
                     company:
                       company_id: '6'
                       name: Blue Sun
+              append_to_existing_job:
+                summary: Append to existing job
+                value:
+                  contacts:
+                  - external_id: abc123
+                    email: joe@bloggs.com
+                    language_override: de
+                  job:
+                    id: job_v2_1
       responses:
         '202':
           description: Accepted
@@ -9323,14 +9321,14 @@ paths:
                     type: error.list
                     request_id: 2859da57-c83f-405c-8166-240a312442a3
                     errors:
-                    - code: missing_field
+                    - code: field_not_found
                       message: contacts field must be supplied
                 too_many_contacts:
                   value:
                     type: error.list
                     request_id: 2859da57-c83f-405c-8166-240a312442a3
                     errors:
-                    - code: invalid_parameter
+                    - code: parameter_invalid
                       message: maximum number of contacts per request is 100
               schema:
                 "$ref": "#/components/schemas/error"
@@ -9363,18 +9361,7 @@ paths:
               "$ref": "#/components/schemas/bulk_update_contacts_request"
             examples:
               successful:
-                summary: Successful
-                value:
-                  contacts:
-                  - id: abc123
-                    language_override: fr
-                  - id: def456
-                    name: Updated Name
-                  - id: ghi789
-                    language_override: es
-                    name: "María García"
-              all_fields:
-                summary: All supported fields
+                summary: successful
                 value:
                   contacts:
                   - id: abc123
@@ -9394,6 +9381,8 @@ paths:
                     tags:
                       add:
                       - id: '123'
+                      remove:
+                      - id: '987'
               with_companies:
                 summary: Attach and detach companies
                 value:
@@ -9475,21 +9464,21 @@ paths:
                     type: error.list
                     request_id: 2859da57-c83f-405c-8166-240a312442a3
                     errors:
-                    - code: missing_field
+                    - code: field_not_found
                       message: contacts field must be supplied
                 missing_id:
                   value:
                     type: error.list
                     request_id: 2859da57-c83f-405c-8166-240a312442a3
                     errors:
-                    - code: missing_field
+                    - code: field_not_found
                       message: contacts must be identified by id
                 too_many_contacts:
                   value:
                     type: error.list
                     request_id: 2859da57-c83f-405c-8166-240a312442a3
                     errors:
-                    - code: invalid_parameter
+                    - code: parameter_invalid
                       message: maximum number of contacts per request is 100
               schema:
                 "$ref": "#/components/schemas/error"
@@ -9505,7 +9494,7 @@ paths:
       - Contacts
       operationId: BulkDeleteContacts
       description: |
-        You can permanently delete contacts in bulk by submitting an array of contact `id`s.
+        You can delete contacts in bulk by submitting an array of contact `id`s.
 
         The endpoint creates an async job that processes the deletes in the background. Use the returned job ID with `GET /contacts/bulk/{id}` to check the job status.
 
@@ -9529,6 +9518,13 @@ paths:
                   contacts:
                   - id: abc123
                   - id: def456
+              append_to_existing_job:
+                  summary: Append to existing job
+                  value:
+                    contacts:
+                    - id: abc123
+                    job:
+                      id: job_v2_1
       responses:
         '202':
           description: Accepted
@@ -9577,21 +9573,21 @@ paths:
                     type: error.list
                     request_id: 2859da57-c83f-405c-8166-240a312442a3
                     errors:
-                    - code: missing_field
+                    - code: field_not_found
                       message: contacts field must be supplied
                 missing_id:
                   value:
                     type: error.list
                     request_id: 2859da57-c83f-405c-8166-240a312442a3
                     errors:
-                    - code: missing_field
+                    - code: field_not_found
                       message: contacts must be identified by id
                 too_many_contacts:
                   value:
                     type: error.list
                     request_id: 2859da57-c83f-405c-8166-240a312442a3
                     errors:
-                    - code: invalid_parameter
+                    - code: parameter_invalid
                       message: maximum number of contacts per request is 100
               schema:
                 "$ref": "#/components/schemas/error"

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9194,6 +9194,107 @@ paths:
               schema:
                 "$ref": "#/components/schemas/error"
   "/contacts/bulk":
+    post:
+      summary: Bulk create contacts
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      tags:
+      - Contacts
+      operationId: BulkCreateContacts
+      description: |
+        You can bulk create contacts by submitting an array of contact objects. This is a **strict create** and never updates an existing contact.
+
+        The endpoint creates an async job that processes the items in the background. Use the returned job ID with `GET /contacts/bulk/{id}` to check the job status.
+
+        {% admonition type="info" name="Handling existing contacts" %}
+          If a contact already exists with the given `external_id` or `email` (including an archived contact), that item is rejected and the job's `state` ends as `completed_with_errors`. New contacts in the same request are still created. The job `state` from `GET /contacts/bulk/{id}` is the signal that one or more items were rejected.
+
+          Created contacts aren't returned with IDs in the response. Look them up afterwards with [Get a contact by External ID](/docs/references/preview/rest-api/api.intercom.io/contacts/getcontactbyexternalid) or [Search contacts](/docs/references/preview/rest-api/api.intercom.io/contacts/searchcontacts).
+        {% /admonition %}
+
+        {% admonition type="info" name="Limits" %}
+          - Maximum of 100 contacts per request.
+          - You can append tasks to an existing job by including `job.id` in the request body.
+        {% /admonition %}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/bulk_create_contacts_request"
+            examples:
+              successful:
+                summary: Successful
+                value:
+                  contacts:
+                  - external_id: abc123
+                    email: joe@bloggs.com
+                    name: Joe Bloggs
+                  - external_id: def456
+                    email: maria@example.com
+                    name: "María García"
+                    role: lead
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              examples:
+                successful:
+                  value:
+                    id: job_v2_2
+                    type: contacts.bulk.job
+                    state: running
+                    created_at: 1713360000
+                    updated_at: 1713360060
+                    completed_at:
+                    tasks:
+                    - id: task_v2_2
+                      item_count: 2
+                      state: pending
+                      created_at: 1713360000
+                      started_at:
+                      completed_at:
+                    url: https://api.intercom.io/contacts/bulk/job_v2_2
+              schema:
+                "$ref": "#/components/schemas/contacts_bulk_job"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                Unauthorized:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: unauthorized
+                      message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              examples:
+                missing_contacts:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: missing_field
+                      message: contacts field must be supplied
+                too_many_contacts:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: invalid_parameter
+                      message: maximum number of contacts per request is 100
+              schema:
+                "$ref": "#/components/schemas/error"
     put:
       summary: Bulk update contacts
       parameters:
@@ -9274,6 +9375,108 @@ paths:
                       started_at:
                       completed_at:
                     url: https://api.intercom.io/contacts/bulk/job_v2_1
+              schema:
+                "$ref": "#/components/schemas/contacts_bulk_job"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                Unauthorized:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: unauthorized
+                      message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              examples:
+                missing_contacts:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: missing_field
+                      message: contacts field must be supplied
+                missing_id:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: missing_field
+                      message: contacts must be identified by id
+                too_many_contacts:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: invalid_parameter
+                      message: maximum number of contacts per request is 100
+              schema:
+                "$ref": "#/components/schemas/error"
+  "/contacts/bulk/delete":
+    post:
+      summary: Bulk delete contacts
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      tags:
+      - Contacts
+      operationId: BulkDeleteContacts
+      description: |
+        You can permanently delete contacts in bulk by submitting an array of contact `id`s.
+
+        The endpoint creates an async job that processes the deletes in the background. Use the returned job ID with `GET /contacts/bulk/{id}` to check the job status.
+
+        {% admonition type="warning" name="Permanent deletion" %}
+          A contact that doesn't exist, or can't be deleted, fails that item and the job's `state` ends as `completed_with_errors` (visible via `GET /contacts/bulk/{id}`) without failing the rest of the batch.
+        {% /admonition %}
+
+        {% admonition type="info" name="Limits" %}
+          - Maximum of 100 contacts per request.
+          - You can append tasks to an existing job by including `job.id` in the request body.
+        {% /admonition %}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/bulk_delete_contacts_request"
+            examples:
+              successful:
+                summary: Successful
+                value:
+                  contacts:
+                  - id: abc123
+                  - id: def456
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              examples:
+                successful:
+                  value:
+                    id: job_v2_3
+                    type: contacts.bulk.job
+                    state: running
+                    created_at: 1713360000
+                    updated_at: 1713360060
+                    completed_at:
+                    tasks:
+                    - id: task_v2_3
+                      item_count: 2
+                      state: pending
+                      created_at: 1713360000
+                      started_at:
+                      completed_at:
+                    url: https://api.intercom.io/contacts/bulk/job_v2_3
               schema:
                 "$ref": "#/components/schemas/contacts_bulk_job"
         '401':
@@ -27193,6 +27396,124 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/brand"
+    bulk_create_contacts_request:
+      title: Bulk Create Contacts Request
+      type: object
+      description: Request body for bulk creating contacts.
+      required:
+      - contacts
+      properties:
+        contacts:
+          type: array
+          description: An array of contact objects to create. Maximum 100 contacts
+            per request.
+          maxItems: 100
+          items:
+            type: object
+            properties:
+              external_id:
+                type: string
+                description: A unique identifier for the contact which you have
+                  defined.
+                example: abc123
+              email:
+                type: string
+                description: The contact's email address.
+                example: joe@example.com
+              name:
+                type: string
+                description: The contact's name.
+                example: Joe Bloggs
+              role:
+                type: string
+                description: The contact's role. One of `user` or `lead`. Leads
+                  are exempt from the uniqueness check described above.
+                example: user
+              phone:
+                type: string
+                description: The contact's phone number.
+              avatar:
+                type: string
+                description: An image URL containing the avatar of the contact.
+                example: https://www.example.com/avatar_image.jpg
+              language_override:
+                type: string
+                description: A preferred language setting for the contact, used by
+                  the Intercom Messenger.
+                example: fr
+              custom_attributes:
+                type: object
+                description: Custom attributes to set on the contact.
+              signed_up_at:
+                type: integer
+                description: The time the contact signed up, in Unix timestamp format.
+              last_seen_at:
+                type: integer
+                description: The time the contact was last seen, in Unix timestamp
+                  format.
+              owner_id:
+                type: string
+                description: The ID of an admin that has been assigned account ownership
+                  of the contact.
+                example: "321"
+              unsubscribed_from_emails:
+                type: boolean
+                description: Whether the contact is unsubscribed from emails.
+                example: true
+              tags:
+                type: object
+                description: |
+                  Tags to add to the contact. Each tag is identified by its `id`, which must be a positive integer for a tag that already exists in your workspace. Tag application is best-effort: unknown tag IDs are skipped while the rest of the contact create still applies. Per-tag results are not yet returned in the job status.
+                properties:
+                  add:
+                    type: array
+                    description: Tags to add to the contact.
+                    items:
+                      type: object
+                      required:
+                      - id
+                      properties:
+                        id:
+                          type: string
+                          description: The ID of an existing tag to add to the contact.
+                          example: '123'
+        job:
+          type: object
+          description: Optional. Include to append tasks to an existing job.
+          properties:
+            id:
+              type: string
+              description: The ID of an existing bulk job to append to.
+              example: job_v2_1
+    bulk_delete_contacts_request:
+      title: Bulk Delete Contacts Request
+      type: object
+      description: Request body for permanently bulk deleting contacts.
+      required:
+      - contacts
+      properties:
+        contacts:
+          type: array
+          description: An array of contacts to delete, each identified by `id`.
+            Maximum 100 contacts per request.
+          maxItems: 100
+          items:
+            type: object
+            required:
+            - id
+            properties:
+              id:
+                type: string
+                description: The unique identifier for the contact.
+                example: abc123
+        job:
+          type: object
+          description: Optional. Include to append tasks to an existing job.
+          properties:
+            id:
+              type: string
+              description: The ID of an existing bulk job to append to.
+              example: job_v2_1
     bulk_update_contacts_request:
       title: Bulk Update Contacts Request
       type: object
@@ -27214,6 +27535,11 @@ components:
                 type: string
                 description: The unique identifier for the contact.
                 example: abc123
+              external_id:
+                type: string
+                description: A unique identifier for the contact which you have
+                  defined.
+                example: abc123
               email:
                 type: string
                 description: The contact's email address.
@@ -27222,60 +27548,30 @@ components:
                 type: string
                 description: The contact's name.
                 example: Joe Bloggs
+              phone:
+                type: string
+                description: The contact's phone number.
+              avatar:
+                type: string
+                description: An image URL containing the avatar of the contact.
+                example: https://www.example.com/avatar_image.jpg
+              owner_id:
+                type: string
+                description: The ID of an admin that has been assigned account ownership
+                  of the contact.
+                example: "321"
+              unsubscribed_from_emails:
+                type: boolean
+                description: Whether the contact is unsubscribed from emails.
+                example: true
               language_override:
                 type: string
                 description: A preferred language setting for the contact, used by
                   the Intercom Messenger.
                 example: fr
-              user_id:
-                type: string
-                description: A unique identifier for the contact that you provide. Maps to the contact's external user ID.
-                example: '25'
-              phone:
-                type: string
-                description: The contact's phone number.
-                example: "+353871234567"
-              owner_id:
-                type: integer
-                description: The ID of the teammate who owns the contact.
-                example: 123
-              unsubscribed_from_emails:
-                type: boolean
-                description: Whether the contact is unsubscribed from emails.
-                example: true
-              avatar:
-                type: string
-                description: An image URL for the contact's avatar. You can also pass an object with an `image_url` field.
-                example: https://www.example.com/avatar.png
               custom_attributes:
                 type: object
                 description: Custom attributes to update on the contact.
-              companies:
-                type: array
-                description: A list of companies to associate with the contact. Each company is identified by the `company_id` you have defined. Companies that do not exist are created.
-                items:
-                  type: object
-                  properties:
-                    company_id:
-                      type: string
-                      description: The company ID you have defined for the company.
-                      example: '6'
-                    name:
-                      type: string
-                      description: The name of the company.
-                      example: Blue Sun
-              company:
-                type: object
-                description: A single company to associate with the contact, identified by the `company_id` you have defined. Created if it does not exist.
-                properties:
-                  company_id:
-                    type: string
-                    description: The company ID you have defined for the company.
-                    example: '6'
-                  name:
-                    type: string
-                    description: The name of the company.
-                    example: Blue Sun
               tags:
                 type: object
                 description: |
@@ -27304,7 +27600,7 @@ components:
                         id:
                           type: string
                           description: The ID of an existing tag to remove from the contact.
-                          example: '456'
+                          example: '789'
         job:
           type: object
           description: Optional. Include to append tasks to an existing job.


### PR DESCRIPTION
## Why?
Adds parity bulk create/delete operations for contacts to the Preview API surface, alongside the existing bulk update endpoint, so SDKs generated from this spec include them.

## How?
Added POST /contacts/bulk (strict create) and POST /contacts/bulk/delete (permanent delete) paths, plus two new request schemas (bulk_create_contacts_request, bulk_delete_contacts_request), reusing the existing contacts_bulk_job response schema.

