### PR TITLE
Add visible_when_unassigned to conversation attribute descriptors

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -14021,6 +14021,7 @@ paths:
                       data_type: string
                       required: false
                       visible_to_team_ids: []
+                      visible_when_unassigned: false
                       archived: false
                       created_at: 1777473061
                       updated_at: 1777473061
@@ -14033,6 +14034,7 @@ paths:
                       data_type: list
                       required: false
                       visible_to_team_ids: []
+                      visible_when_unassigned: false
                       archived: false
                       created_at: 1777472538
                       updated_at: 1777537799
@@ -14054,6 +14056,7 @@ paths:
                       data_type: relationship
                       required: false
                       visible_to_team_ids: []
+                      visible_when_unassigned: false
                       archived: false
                       created_at: 1777547482
                       updated_at: 1777547482
@@ -14103,6 +14106,7 @@ paths:
                     data_type: string
                     required: false
                     visible_to_team_ids: []
+                    visible_when_unassigned: false
                     archived: false
                     created_at: 1778239701
                     updated_at: 1778239701
@@ -14185,6 +14189,7 @@ paths:
                     data_type: string
                     required: false
                     visible_to_team_ids: []
+                    visible_when_unassigned: false
                     archived: false
                     created_at: 1777473061
                     updated_at: 1777473061
@@ -14253,6 +14258,7 @@ paths:
                     data_type: string
                     required: false
                     visible_to_team_ids: []
+                    visible_when_unassigned: false
                     archived: false
                     created_at: 1778239701
                     updated_at: 1778239718
@@ -14333,6 +14339,7 @@ paths:
                     data_type: string
                     required: false
                     visible_to_team_ids: []
+                    visible_when_unassigned: false
                     archived: true
                     created_at: 1778239701
                     updated_at: 1778239721
@@ -14402,6 +14409,7 @@ paths:
                     data_type: list
                     required: false
                     visible_to_team_ids: []
+                    visible_when_unassigned: false
                     archived: false
                     created_at: 1777472538
                     updated_at: 1778240000
@@ -14536,6 +14544,7 @@ paths:
                     data_type: list
                     required: false
                     visible_to_team_ids: []
+                    visible_when_unassigned: false
                     archived: false
                     created_at: 1777472538
                     updated_at: 1778240001
@@ -14673,6 +14682,7 @@ paths:
                     data_type: list
                     required: false
                     visible_to_team_ids: []
+                    visible_when_unassigned: false
                     archived: false
                     created_at: 1777472538
                     updated_at: 1778240002
@@ -31863,6 +31873,10 @@ components:
           items:
             type: string
           example: []
+        visible_when_unassigned:
+          type: boolean
+          description: Whether this attribute stays visible on unassigned conversations when visible_to_team_ids restricts visibility to specific teams. Defaults to false.
+          example: false
         archived:
           type: boolean
           description: Whether this attribute is archived.
@@ -32103,6 +32117,10 @@ components:
           items:
             type: string
           example: []
+        visible_when_unassigned:
+          type: boolean
+          description: Whether this attribute stays visible on unassigned conversations when visible_to_team_ids restricts visibility to specific teams. Defaults to false.
+          example: false
     create_conversation_attribute_string_request:
       title: Create Conversation Attribute Request (String)
       allOf:
@@ -32257,6 +32275,10 @@ components:
           items:
             type: string
           example: []
+        visible_when_unassigned:
+          type: boolean
+          description: Whether this attribute stays visible on unassigned conversations when visible_to_team_ids restricts visibility to specific teams. Defaults to false.
+          example: false
         reference:
           type: object
           description: "(Relationship data type only) Reference configuration for related objects."

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -31875,7 +31875,7 @@ components:
           example: []
         visible_when_unassigned:
           type: boolean
-          description: Whether this attribute stays visible on unassigned conversations when visible_to_team_ids restricts visibility to specific teams. Defaults to false.
+          description: Whether this attribute is visible on unassigned conversations. Combined with visible_to_team_ids this restricts visibility; with no teams set it makes the attribute visible only on unassigned conversations. Defaults to false.
           example: false
         archived:
           type: boolean
@@ -32119,7 +32119,7 @@ components:
           example: []
         visible_when_unassigned:
           type: boolean
-          description: Whether this attribute stays visible on unassigned conversations when visible_to_team_ids restricts visibility to specific teams. Defaults to false.
+          description: Whether this attribute is visible on unassigned conversations. Combined with visible_to_team_ids this restricts visibility; with no teams set it makes the attribute visible only on unassigned conversations. Defaults to false.
           example: false
     create_conversation_attribute_string_request:
       title: Create Conversation Attribute Request (String)
@@ -32277,7 +32277,7 @@ components:
           example: []
         visible_when_unassigned:
           type: boolean
-          description: Whether this attribute stays visible on unassigned conversations when visible_to_team_ids restricts visibility to specific teams. Defaults to false.
+          description: Whether this attribute is visible on unassigned conversations. Combined with visible_to_team_ids this restricts visibility; with no teams set it makes the attribute visible only on unassigned conversations. Defaults to false.
           example: false
         reference:
           type: object


### PR DESCRIPTION
### Why?

Conversation attributes that are restricted to specific teams (`visible_to_team_ids`) can now stay visible in the Inbox on conversations that have no team assigned. This adds the corresponding `visible_when_unassigned` field to the OpenAPI description for the `/conversations/attributes` endpoints.

### How?

Added `visible_when_unassigned` (boolean, defaults to `false`) to the conversation attribute response schema and both request schemas (create/update) in `descriptions/0/api.intercom.io.yaml`, and updated the existing response examples to include it.

<sub>Generated with Claude Code</sub>