### PR TITLE
Add GitHub Sync activity log event types to the enum

### DIFF
--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -15049,6 +15049,8 @@ components:
           - csv_import_completion
           - csv_import_creation
           - custom_authentication_token_creation
+          - github_sync_cleanup_deleted_folder
+          - github_sync_disconnected
           - help_center_settings_change
           - inbound_conversations_change
           - inbox_access_change


### PR DESCRIPTION
### Why?

The GitHub Sync integration emits two new Teammate Activity Log event types (`github_sync_disconnected`, `github_sync_cleanup_deleted_folder`). The activity-log event-type enum must list them so they are documented in the public API.

### How?

Adds both event types to the 2.15 activity-log event-type enum, in alphabetical order.

<sub>Generated with Claude Code</sub>