### PR TITLE
Add sku property to ecommerce_catalog_variant schema

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -33522,6 +33522,11 @@ components:
                 type: string
                 description: Selected option value.
                 example: 'Large'
+        sku:
+          type: string
+          description: Stock-keeping unit for this specific variant. Fin uses this to resolve shopper requests like "do you have this in size M?" to the exact variant, and can quote it back when a shopper asks for it directly.
+          example: 'TSHIRT-BLU-L'
+          nullable: true
     ecommerce_catalog_product:
       title: Ecommerce Catalog Product
       type: object


### PR DESCRIPTION
### Why?

Adds an optional `sku` (stock-keeping unit) string property to the `ecommerce_catalog_variant` schema, matching the corresponding property already documented on the public API reference.

### How?

Keeps this repo's OpenAPI description in sync with the public API reference schema.

<sub>Generated with Claude Code</sub>