### PR TITLE
Document 404 job_not_found and 422 type_mismatch on bulk contacts (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9466,6 +9466,34 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              examples:
+                job_closed:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: forbidden
+                      message: job job_v2_1 is closed for new task updates
+              schema:
+                "$ref": "#/components/schemas/error"
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              examples:
+                job_not_found:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: job_not_found
+                      message: job job_v2_1 not found
+              schema:
+                "$ref": "#/components/schemas/error"
         '422':
           description: Unprocessable Entity
           content:
@@ -9485,6 +9513,20 @@ paths:
                     errors:
                     - code: parameter_invalid
                       message: maximum number of contacts per request is 100
+                contacts_not_an_array:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: type_mismatch
+                      message: contacts must be an array
+                contact_not_an_object:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: type_mismatch
+                      message: each contact must be an object
               schema:
                 "$ref": "#/components/schemas/error"
     put:
@@ -9605,6 +9647,34 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              examples:
+                job_closed:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: forbidden
+                      message: job job_v2_1 is closed for new task updates
+              schema:
+                "$ref": "#/components/schemas/error"
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              examples:
+                job_not_found:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: job_not_found
+                      message: job job_v2_1 not found
+              schema:
+                "$ref": "#/components/schemas/error"
         '422':
           description: Unprocessable Entity
           content:
@@ -9631,6 +9701,20 @@ paths:
                     errors:
                     - code: parameter_invalid
                       message: maximum number of contacts per request is 100
+                contacts_not_an_array:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: type_mismatch
+                      message: contacts must be an array
+                contact_not_an_object:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: type_mismatch
+                      message: each contact must be an object
               schema:
                 "$ref": "#/components/schemas/error"
   "/contacts/bulk/delete":
@@ -9714,6 +9798,34 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              examples:
+                job_closed:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: forbidden
+                      message: job job_v2_1 is closed for new task updates
+              schema:
+                "$ref": "#/components/schemas/error"
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              examples:
+                job_not_found:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: job_not_found
+                      message: job job_v2_1 not found
+              schema:
+                "$ref": "#/components/schemas/error"
         '422':
           description: Unprocessable Entity
           content:
@@ -9740,6 +9852,20 @@ paths:
                     errors:
                     - code: parameter_invalid
                       message: maximum number of contacts per request is 100
+                contacts_not_an_array:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: type_mismatch
+                      message: contacts must be an array
+                contact_not_an_object:
+                  value:
+                    type: error.list
+                    request_id: 2859da57-c83f-405c-8166-240a312442a3
+                    errors:
+                    - code: type_mismatch
+                      message: each contact must be an object
               schema:
                 "$ref": "#/components/schemas/error"
   "/contacts/bulk/{id}":


### PR DESCRIPTION
### Why?

The bulk contacts endpoints can return two error responses this spec did not document, so integrators had no way to know to handle them and would only discover them in production:

- a `404` / `job_not_found` when the request body's `job.id` names a job that does not exist
- a `422` / `type_mismatch` when `contacts` is not an array, or an element of it is not an object

Found while auditing the bulk companies error responses for parity with bulk contacts.

### How?

Added the missing `404` response and two extra `422` examples to the three bulk contacts write endpoints, matching the codes and messages the API actually returns. The `404` sits between `401` and `422` to keep responses in numeric order.

Affects the Preview version only, where these endpoints are defined.

<sub>Generated with Claude Code</sub>

---

## Update: added `403` / `forbidden`

A third undocumented error response, confirmed against a live response body: appending to a job that has already closed returns **`403`** with code `forbidden` and message `job <job_id> is closed for new task updates`.

Added to the same three write endpoints, ordered before `404`. Each now documents `202`, `401`, `403`, `404`, `422`.

The example uses the `job_v2_1` placeholder that the other job examples in this spec already use, rather than a real job id.
