### PR TITLE
Align Preview fin_replied wording with 2.16

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -36040,7 +36040,7 @@ components:
         Event fired when Fin replies to a user.
         The content of the response will be contained in the message object.
         Intermediate replies have status 'replying'; a separate fin_status_updated
-        event with 'awaiting_user_reply' fires as a done signal.
+        event with 'awaiting_user_reply' fires once Fin's reply is done.
       x-tags:
       - Fin Agent
       properties:
@@ -36093,7 +36093,7 @@ components:
           description: |
             Fin's current status.
             - replying: Intermediate reply part; more parts may follow
-            - awaiting_user_reply: Legacy status; use fin_status_updated event as the done signal instead
+            - awaiting_user_reply: Legacy status; instead use the fin_status_updated event with 'awaiting_user_reply', which fires once Fin's reply is done
           example: replying
         stream_id:
           type: string


### PR DESCRIPTION
### Why?

The `fin_replied` description in the Preview spec described the `awaiting_user_reply` status differently from the 2.16 spec, for behaviour that is identical on both.

### How?

Rewords two description lines in `descriptions/0` to match `descriptions/2.16`. No enum values, fields, or endpoints change.

<sub>Generated with Claude Code</sub>