### PR TITLE
Document the Admin occupancy activity log events

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -427,6 +427,7 @@ paths:
                     - admin_login_failure
                     - admin_login_success
                     - admin_logout
+                    - admin_occupancy_setting_change
                     - admin_occupancy_state_change
                     - admin_password_reset_request
                     - admin_password_reset_success
@@ -26258,6 +26259,7 @@ components:
           - admin_login_failure
           - admin_login_success
           - admin_logout
+          - admin_occupancy_setting_change
           - admin_occupancy_state_change
           - admin_password_reset_request
           - admin_password_reset_success
@@ -26442,6 +26444,29 @@ components:
           description: Indicates the state was derived automatically rather than set
             by an Admin.
           example: true
+        setting_type:
+          type: string
+          nullable: true
+          description: The group of workspace settings the change belongs to, for
+            example `teammate_occupancy` or `automatic_away_mode`.
+          example: teammate_occupancy
+        changes:
+          type: object
+          nullable: true
+          description: The settings altered by the change, keyed by setting name.
+            Only settings whose value actually moved are included, so an unchanged
+            setting is absent rather than present with equal values.
+          additionalProperties:
+            type: object
+            properties:
+              before:
+                description: The value before the change.
+              after:
+                description: The value after the change.
+          example:
+            occupancy_window_minutes:
+              before: 15
+              after: 30
         conversation_assignment_limit:
           type: integer
           nullable: true

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -427,6 +427,7 @@ paths:
                     - admin_login_failure
                     - admin_login_success
                     - admin_logout
+                    - admin_occupancy_state_change
                     - admin_password_reset_request
                     - admin_password_reset_success
                     - admin_permission_change
@@ -26257,6 +26258,7 @@ components:
           - admin_login_failure
           - admin_login_success
           - admin_logout
+          - admin_occupancy_state_change
           - admin_password_reset_request
           - admin_password_reset_success
           - admin_permission_change
@@ -26412,6 +26414,34 @@ components:
           nullable: true
           description: The name of the Admin who initiated the activity.
           example: Joe Example
+        previous_state:
+          type: string
+          nullable: true
+          description: The state before the change. `idle` or `occupied`, and null
+            when the Admin had not been classified yet.
+          example: idle
+        new_state:
+          type: string
+          nullable: true
+          description: The state after the change. `idle` or `occupied`.
+          example: occupied
+        threshold_minutes:
+          type: integer
+          nullable: true
+          description: The inactivity window, in minutes, used to classify the Admin.
+          example: 15
+        last_activity_at:
+          type: integer
+          format: date-time
+          nullable: true
+          description: The time of the Admin's last recorded activity.
+          example: 1671028894
+        auto:
+          type: boolean
+          nullable: true
+          description: Indicates the state was derived automatically rather than set
+            by an Admin.
+          example: true
         conversation_assignment_limit:
           type: integer
           nullable: true

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -13099,6 +13099,7 @@ components:
           - admin_login_failure
           - admin_login_success
           - admin_logout
+          - admin_occupancy_state_change
           - admin_password_reset_request
           - admin_password_reset_success
           - admin_permission_change
@@ -13231,6 +13232,34 @@ components:
           nullable: true
           description: The name of the Admin who initiated the activity.
           example: Joe Example
+        previous_state:
+          type: string
+          nullable: true
+          description: The state before the change. `idle` or `occupied`, and null
+            when the Admin had not been classified yet.
+          example: idle
+        new_state:
+          type: string
+          nullable: true
+          description: The state after the change. `idle` or `occupied`.
+          example: occupied
+        threshold_minutes:
+          type: integer
+          nullable: true
+          description: The inactivity window, in minutes, used to classify the Admin.
+          example: 15
+        last_activity_at:
+          type: integer
+          format: date-time
+          nullable: true
+          description: The time of the Admin's last recorded activity.
+          example: 1671028894
+        auto:
+          type: boolean
+          nullable: true
+          description: Indicates the state was derived automatically rather than set
+            by an Admin.
+          example: true
     addressable_list:
       title: Addressable List
       type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -13099,6 +13099,7 @@ components:
           - admin_login_failure
           - admin_login_success
           - admin_logout
+          - admin_occupancy_setting_change
           - admin_occupancy_state_change
           - admin_password_reset_request
           - admin_password_reset_success
@@ -13260,6 +13261,29 @@ components:
           description: Indicates the state was derived automatically rather than set
             by an Admin.
           example: true
+        setting_type:
+          type: string
+          nullable: true
+          description: The group of workspace settings the change belongs to, for
+            example `teammate_occupancy` or `automatic_away_mode`.
+          example: teammate_occupancy
+        changes:
+          type: object
+          nullable: true
+          description: The settings altered by the change, keyed by setting name.
+            Only settings whose value actually moved are included, so an unchanged
+            setting is absent rather than present with equal values.
+          additionalProperties:
+            type: object
+            properties:
+              before:
+                description: The value before the change.
+              after:
+                description: The value after the change.
+          example:
+            occupancy_window_minutes:
+              before: 15
+              after: 30
     addressable_list:
       title: Addressable List
       type: object

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -14619,6 +14619,7 @@ components:
           - admin_login_failure
           - admin_login_success
           - admin_logout
+          - admin_occupancy_state_change
           - admin_password_reset_request
           - admin_password_reset_success
           - admin_permission_change
@@ -14782,6 +14783,34 @@ components:
           nullable: true
           description: The name of the Admin who initiated the activity.
           example: Joe Example
+        previous_state:
+          type: string
+          nullable: true
+          description: The state before the change. `idle` or `occupied`, and null
+            when the Admin had not been classified yet.
+          example: idle
+        new_state:
+          type: string
+          nullable: true
+          description: The state after the change. `idle` or `occupied`.
+          example: occupied
+        threshold_minutes:
+          type: integer
+          nullable: true
+          description: The inactivity window, in minutes, used to classify the Admin.
+          example: 15
+        last_activity_at:
+          type: integer
+          format: date-time
+          nullable: true
+          description: The time of the Admin's last recorded activity.
+          example: 1671028894
+        auto:
+          type: boolean
+          nullable: true
+          description: Indicates the state was derived automatically rather than set
+            by an Admin.
+          example: true
         conversation_assignment_limit:
           type: integer
           nullable: true

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -14619,6 +14619,7 @@ components:
           - admin_login_failure
           - admin_login_success
           - admin_logout
+          - admin_occupancy_setting_change
           - admin_occupancy_state_change
           - admin_password_reset_request
           - admin_password_reset_success
@@ -14811,6 +14812,29 @@ components:
           description: Indicates the state was derived automatically rather than set
             by an Admin.
           example: true
+        setting_type:
+          type: string
+          nullable: true
+          description: The group of workspace settings the change belongs to, for
+            example `teammate_occupancy` or `automatic_away_mode`.
+          example: teammate_occupancy
+        changes:
+          type: object
+          nullable: true
+          description: The settings altered by the change, keyed by setting name.
+            Only settings whose value actually moved are included, so an unchanged
+            setting is absent rather than present with equal values.
+          additionalProperties:
+            type: object
+            properties:
+              before:
+                description: The value before the change.
+              after:
+                description: The value after the change.
+          example:
+            occupancy_window_minutes:
+              before: 15
+              after: 30
         conversation_assignment_limit:
           type: integer
           nullable: true

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -15233,6 +15233,7 @@ components:
           - admin_login_failure
           - admin_login_success
           - admin_logout
+          - admin_occupancy_state_change
           - admin_password_reset_request
           - admin_password_reset_success
           - admin_permission_change
@@ -15405,6 +15406,34 @@ components:
           nullable: true
           description: The name of the Admin who initiated the activity.
           example: Joe Example
+        previous_state:
+          type: string
+          nullable: true
+          description: The state before the change. `idle` or `occupied`, and null
+            when the Admin had not been classified yet.
+          example: idle
+        new_state:
+          type: string
+          nullable: true
+          description: The state after the change. `idle` or `occupied`.
+          example: occupied
+        threshold_minutes:
+          type: integer
+          nullable: true
+          description: The inactivity window, in minutes, used to classify the Admin.
+          example: 15
+        last_activity_at:
+          type: integer
+          format: date-time
+          nullable: true
+          description: The time of the Admin's last recorded activity.
+          example: 1671028894
+        auto:
+          type: boolean
+          nullable: true
+          description: Indicates the state was derived automatically rather than set
+            by an Admin.
+          example: true
         conversation_assignment_limit:
           type: integer
           nullable: true

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -15233,6 +15233,7 @@ components:
           - admin_login_failure
           - admin_login_success
           - admin_logout
+          - admin_occupancy_setting_change
           - admin_occupancy_state_change
           - admin_password_reset_request
           - admin_password_reset_success
@@ -15434,6 +15435,29 @@ components:
           description: Indicates the state was derived automatically rather than set
             by an Admin.
           example: true
+        setting_type:
+          type: string
+          nullable: true
+          description: The group of workspace settings the change belongs to, for
+            example `teammate_occupancy` or `automatic_away_mode`.
+          example: teammate_occupancy
+        changes:
+          type: object
+          nullable: true
+          description: The settings altered by the change, keyed by setting name.
+            Only settings whose value actually moved are included, so an unchanged
+            setting is absent rather than present with equal values.
+          additionalProperties:
+            type: object
+            properties:
+              before:
+                description: The value before the change.
+              after:
+                description: The value after the change.
+          example:
+            occupancy_window_minutes:
+              before: 15
+              after: 30
         conversation_assignment_limit:
           type: integer
           nullable: true

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -792,6 +792,7 @@ paths:
                     - admin_login_failure
                     - admin_login_success
                     - admin_logout
+                    - admin_occupancy_state_change
                     - admin_password_reset_request
                     - admin_password_reset_success
                     - admin_permission_change
@@ -22442,6 +22443,7 @@ components:
           - admin_login_failure
           - admin_login_success
           - admin_logout
+          - admin_occupancy_state_change
           - admin_password_reset_request
           - admin_password_reset_success
           - admin_permission_change
@@ -22635,6 +22637,34 @@ components:
           nullable: true
           description: The name of the Admin who initiated the activity.
           example: Joe Example
+        previous_state:
+          type: string
+          nullable: true
+          description: The state before the change. `idle` or `occupied`, and null
+            when the Admin had not been classified yet.
+          example: idle
+        new_state:
+          type: string
+          nullable: true
+          description: The state after the change. `idle` or `occupied`.
+          example: occupied
+        threshold_minutes:
+          type: integer
+          nullable: true
+          description: The inactivity window, in minutes, used to classify the Admin.
+          example: 15
+        last_activity_at:
+          type: integer
+          format: date-time
+          nullable: true
+          description: The time of the Admin's last recorded activity.
+          example: 1671028894
+        auto:
+          type: boolean
+          nullable: true
+          description: Indicates the state was derived automatically rather than set
+            by an Admin.
+          example: true
         conversation_assignment_limit:
           type: integer
           nullable: true

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -792,6 +792,7 @@ paths:
                     - admin_login_failure
                     - admin_login_success
                     - admin_logout
+                    - admin_occupancy_setting_change
                     - admin_occupancy_state_change
                     - admin_password_reset_request
                     - admin_password_reset_success
@@ -22443,6 +22444,7 @@ components:
           - admin_login_failure
           - admin_login_success
           - admin_logout
+          - admin_occupancy_setting_change
           - admin_occupancy_state_change
           - admin_password_reset_request
           - admin_password_reset_success
@@ -22665,6 +22667,29 @@ components:
           description: Indicates the state was derived automatically rather than set
             by an Admin.
           example: true
+        setting_type:
+          type: string
+          nullable: true
+          description: The group of workspace settings the change belongs to, for
+            example `teammate_occupancy` or `automatic_away_mode`.
+          example: teammate_occupancy
+        changes:
+          type: object
+          nullable: true
+          description: The settings altered by the change, keyed by setting name.
+            Only settings whose value actually moved are included, so an unchanged
+            setting is absent rather than present with equal values.
+          additionalProperties:
+            type: object
+            properties:
+              before:
+                description: The value before the change.
+              after:
+                description: The value after the change.
+          example:
+            occupancy_window_minutes:
+              before: 15
+              after: 30
         conversation_assignment_limit:
           type: integer
           nullable: true


### PR DESCRIPTION
### Why?

The activity logs endpoint now returns two new Admin activity types and their accompanying metadata, but the published spec doesn't describe either. Without it, SDK consumers get no types for the new fields and the reference docs omit the events entirely.

### How?

Adds both activity types to the activity log type enum, and their nullable metadata properties to the shared activity log metadata schema.

<details>
<summary>Notes for reviewers</summary>

Applied to `0`, `2.13`, `2.14`, `2.15` and `2.16`. `2.15` and `2.13` are the versions this endpoint is actually requested on today, so those two carry the most weight; `2.16` is current stable, `0` is Preview, and `2.14` is what SDK generation currently reads from. `2.7`-`2.12` are untouched - the events are returned independently of API version, so happy to widen to full coverage if you'd prefer.

The setting-change event's `changes` map is keyed by setting name with untyped `before`/`after` values, since a setting's value may be a boolean or an integer.

</details>

<sub>Generated with Claude Code</sub>