### PR TITLE
Document setting conversation priority on the update endpoint (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -40389,6 +40389,22 @@ components:
           type: string
           description: The title given to the conversation
           example: Conversation Title
+        priority:
+          type: string
+          enum:
+          - none
+          - low
+          - medium
+          - high
+          - urgent
+          description: The priority level to set on the conversation. Accepts one of
+            none, low, medium, high, or urgent. Set none to clear an existing priority.
+          example: high
+        admin_id:
+          type: string
+          description: The ID of the teammate to attribute the priority change to.
+            Defaults to Operator when omitted, and is only used alongside priority.
+          example: '394051'
         custom_attributes:
           "$ref": "#/components/schemas/custom_attributes"
         company_id:


### PR DESCRIPTION
### Why?

Conversation priority can be read through the API but there was no documented way to set it, so integrations that triage conversations in their own tooling had nothing to write back to.

### How?

Documents the priority level and an optional attribution field on the Preview update-conversation request body.

<details>
<summary>Notes for reviewers</summary>

- Affected versions: **Preview only**. No dated version (2.15 or earlier) changes.
- `fern check` reports the same 3 errors as clean `main` (pre-existing duplicate declarations in the preview articles and conversation-attributes files); this change introduces none.
- Local Redocly preview was **not** run — CI is the render signal here.
- Companions:
  - intercom/intercom#556305
  - intercom/developer-docs#1093

</details>

<sub>Generated with Claude Code</sub>