### PR TITLE
Add translations field to conversation_part and ticket_part (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -12182,8 +12182,8 @@ paths:
                         app_package_code: null
                         translations:
                           original: en
-                          en: 'Okay!'
-                          fr: "D'accord!"
+                          en: <p>Okay!</p>
+                          fr: "<p>D'accord!</p>"
                       - type: conversation_part
                         id: 2
                         part_type: custom_action_started
@@ -12391,8 +12391,8 @@ paths:
                         app_package_code: null
                         translations:
                           original: en
-                          en: 'Okay!'
-                          fr: "D'accord!"
+                          en: <p>Okay!</p>
+                          fr: "<p>D'accord!</p>"
                       - type: conversation_part
                         id: 2
                         part_type: custom_action_started
@@ -14158,8 +14158,8 @@ paths:
                     external_reply_send_state: sent
                     translations:
                       original: en
-                      en: 'Hello there!'
-                      fr: 'Bonjour!'
+                      en: "<p>Hello there!</p>"
+                      fr: "<p>Bonjour!</p>"
                 Mark part as seen:
                   value:
                     type: conversation_part
@@ -14181,8 +14181,8 @@ paths:
                       admin_seen: true
                     translations:
                       original: en
-                      en: 'Hello there!'
-                      fr: 'Bonjour!'
+                      en: "<p>Hello there!</p>"
+                      fr: "<p>Bonjour!</p>"
               schema:
                 "$ref": "#/components/schemas/conversation_part"
         '401':
@@ -22245,8 +22245,8 @@ paths:
                     app_package_code: test-integration
                     translations:
                       original: en
-                      en: "Thanks for reaching out, we're looking into it!"
-                      fr: "Merci de nous avoir contactés, nous nous en occupons !"
+                      en: "<p>Thanks for reaching out, we're looking into it!</p>"
+                      fr: "<p>Merci de nous avoir contactés, nous nous en occupons !</p>"
                 Admin note reply:
                   value:
                     type: ticket_part
@@ -31909,7 +31909,8 @@ components:
             Preview API version and backs the `conversation.admin.replied.translated`
             webhook topic. The special `original` key holds the source locale code
             of the reply; every other key is a locale code whose value is the reply
-            text translated into that locale. The `body` field is unchanged and always
+            text translated into that locale, as HTML in the same format as `body`.
+            The `body` field is unchanged and always
             stays in the original source language. Available in the Preview API version
             only (set `Intercom-Version: Preview`).
           required:
@@ -31918,8 +31919,8 @@ components:
             type: string
           example:
             original: en
-            en: 'Hello'
-            fr: 'Bonjour'
+            en: <p>Hello</p>
+            fr: <p>Bonjour</p>
     conversation_part_author:
       title: Conversation part author
       type: object
@@ -39534,7 +39535,8 @@ components:
             Preview API version and backs the `ticket.admin.replied.translated`
             webhook topic. The special `original` key holds the source locale code
             of the reply; every other key is a locale code whose value is the reply
-            text translated into that locale. The `body` field is unchanged and always
+            text translated into that locale, as HTML in the same format as `body`.
+            The `body` field is unchanged and always
             stays in the original source language. Available in the Preview API version
             only (set `Intercom-Version: Preview`).
           required:
@@ -39543,8 +39545,8 @@ components:
             type: string
           example:
             original: en
-            en: 'Hello'
-            fr: 'Bonjour'
+            en: <p>Hello</p>
+            fr: <p>Bonjour</p>
         updated_attribute_data:
           title: Updated Attribute
           type: object

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -12180,6 +12180,10 @@ paths:
                             name: Test tag
                         event_details:
                         app_package_code: null
+                        translations:
+                          original: en
+                          en: 'Okay!'
+                          fr: "D'accord!"
                       - type: conversation_part
                         id: 2
                         part_type: custom_action_started
@@ -12385,6 +12389,10 @@ paths:
                             name: Test tag
                         event_details:
                         app_package_code: null
+                        translations:
+                          original: en
+                          en: 'Okay!'
+                          fr: "D'accord!"
                       - type: conversation_part
                         id: 2
                         part_type: custom_action_started
@@ -14148,6 +14156,10 @@ paths:
                     attachments: []
                     external_id:
                     external_reply_send_state: sent
+                    translations:
+                      original: en
+                      en: 'Hello there!'
+                      fr: 'Bonjour!'
                 Mark part as seen:
                   value:
                     type: conversation_part
@@ -14167,6 +14179,10 @@ paths:
                     external_id:
                     seen_state:
                       admin_seen: true
+                    translations:
+                      original: en
+                      en: 'Hello there!'
+                      fr: 'Bonjour!'
               schema:
                 "$ref": "#/components/schemas/conversation_part"
         '401':
@@ -31876,6 +31892,8 @@ components:
             text translated into that locale. The `body` field is unchanged and always
             stays in the original source language. Available in the Preview API version
             only (set `Intercom-Version: Preview`).
+          required:
+            - original
           additionalProperties:
             type: string
           example:
@@ -39499,6 +39517,8 @@ components:
             text translated into that locale. The `body` field is unchanged and always
             stays in the original source language. Available in the Preview API version
             only (set `Intercom-Version: Preview`).
+          required:
+            - original
           additionalProperties:
             type: string
           example:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -31865,6 +31865,23 @@ components:
           nullable: true
           example: "test-integration"
           description: The app package code if this part was created via API. null if the part was not created via API.
+        translations:
+          type: object
+          nullable: true
+          description: >-
+            A map of the reply text keyed by locale code. Only present on the
+            Preview API version and backs the `conversation.admin.replied.translated`
+            webhook topic. The special `original` key holds the source locale code
+            of the reply; every other key is a locale code whose value is the reply
+            text translated into that locale. The `body` field is unchanged and always
+            stays in the original source language. Available in the Preview API version
+            only (set `Intercom-Version: Preview`).
+          additionalProperties:
+            type: string
+          example:
+            original: en
+            en: 'Hello'
+            fr: 'Bonjour'
     conversation_part_author:
       title: Conversation part author
       type: object
@@ -39471,6 +39488,23 @@ components:
           nullable: false
           example: text-integration
           description: The app package code if this part was created via API. Note this field won't show if the part was not created via API.
+        translations:
+          type: object
+          nullable: true
+          description: >-
+            A map of the reply text keyed by locale code. Only present on the
+            Preview API version and backs the `ticket.admin.replied.translated`
+            webhook topic. The special `original` key holds the source locale code
+            of the reply; every other key is a locale code whose value is the reply
+            text translated into that locale. The `body` field is unchanged and always
+            stays in the original source language. Available in the Preview API version
+            only (set `Intercom-Version: Preview`).
+          additionalProperties:
+            type: string
+          example:
+            original: en
+            en: 'Hello'
+            fr: 'Bonjour'
         updated_attribute_data:
           title: Updated Attribute
           type: object

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -39716,6 +39716,26 @@ components:
           type: boolean
           description: Whether or not the ticket part has been redacted.
           example: false
+        translations:
+          type: object
+          nullable: true
+          description: >-
+            A map of the reply text keyed by locale code. Only present on the
+            Preview API version and backs the `ticket.admin.replied.translated`
+            webhook topic. The special `original` key holds the source locale code
+            of the reply; every other key is a locale code whose value is the reply
+            text translated into that locale, as HTML in the same format as `body`.
+            The `body` field is unchanged and always
+            stays in the original source language. Available in the Preview API version
+            only (set `Intercom-Version: Preview`).
+          required:
+            - original
+          additionalProperties:
+            type: string
+          example:
+            original: en
+            en: <p>Hello</p>
+            fr: <p>Bonjour</p>
     ticket_request_custom_attributes:
       title: Ticket Attributes
       type: object

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -22227,6 +22227,26 @@ paths:
           content:
             application/json:
               examples:
+                Admin reply:
+                  value:
+                    type: ticket_part
+                    id: '155'
+                    part_type: comment
+                    body: "<p>Thanks for reaching out, we're looking into it!</p>"
+                    created_at: 1734537880
+                    updated_at: 1734537880
+                    author:
+                      id: '991267940'
+                      type: admin
+                      name: Ciaran418 Lee
+                      email: admin418@email.com
+                    attachments: []
+                    redacted: false
+                    app_package_code: test-integration
+                    translations:
+                      original: en
+                      en: "Thanks for reaching out, we're looking into it!"
+                      fr: "Merci de nous avoir contactés, nous nous en occupons !"
                 Admin note reply:
                   value:
                     type: ticket_part


### PR DESCRIPTION
### Why?

Admin reply parts can now be delivered in multiple locales, and the new `conversation.admin.replied.translated` and `ticket.admin.replied.translated` webhook topics carry those translations. The Preview spec did not model that data, so integrators had no schema for it.

### How?

Adds a nullable `translations` map (keyed by locale code, with an `original` key naming the source locale) to the Preview conversation part and ticket part schemas, leaving the existing reply text untouched.

<details>
<summary>Notes for reviewers</summary>

The field is Preview-only, so it is added to `descriptions/0` alone and not to any stable `2.x` version. Example value: `{ "original": "en", "en": "Hello", "fr": "Bonjour" }`. A companion PR in `intercom/developer-docs` syncs the same schema addition into the developer-docs Preview mirror and adds a changelog entry.

</details>

<sub>Generated with Claude Code</sub>