### PR TITLE
Show priority and admin_id as top-level params in the Preview update-conversation examples

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -12634,7 +12634,7 @@ paths:
                     tags:
                       type: tag.list
                       tags: []
-                    priority: none
+                    priority: high
                     sla_applied:
                     statistics:
                     conversation_rating:
@@ -12642,7 +12642,6 @@ paths:
                     title:
                     custom_attributes:
                       issue_type: Billing
-                      priority: high
                     topics: {}
                     ticket:
                     linked_objects:
@@ -12825,9 +12824,10 @@ paths:
                 value:
                   read: true
                   title: new conversation title
+                  priority: high
+                  admin_id: '394051'
                   custom_attributes:
                     issue_type: Billing
-                    priority: high
               update_a_conversation_with_an_association_to_a_custom_object_instance:
                 summary: update a conversation with an association to a custom object
                   instance
@@ -12840,9 +12840,10 @@ paths:
                 value:
                   read: true
                   title: new conversation title
+                  priority: high
+                  admin_id: '394051'
                   custom_attributes:
                     issue_type: Billing
-                    priority: high
     delete:
       summary: Delete a conversation
       parameters:


### PR DESCRIPTION
### Why?

The Preview update-conversation examples show `priority` nested inside `custom_attributes`, where it means a workspace attribute that happens to share the name rather than the conversation priority the endpoint now accepts. Developers copy the example panel rather than the schema, so a request built from the page silently leaves the priority unchanged.

### How?

Adds the top-level `priority` and `admin_id` params to those examples and drops the same-named custom attribute that made the two ambiguous. Preview only, examples only.

<sub>Generated with Claude Code</sub>