### PR TITLE
Add inbox_bulk_action to the activity log event type enum

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -26591,6 +26591,7 @@ components:
           - help_center_settings_change
           - inbound_conversations_change
           - inbox_access_change
+          - inbox_bulk_action
           - message_deletion
           - message_state_change
           - messenger_look_and_feel_change

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -465,6 +465,7 @@ paths:
                     - help_center_settings_change
                     - inbound_conversations_change
                     - inbox_access_change
+                    - inbox_bulk_action
                     - message_deletion
                     - message_state_change
                     - messenger_look_and_feel_change

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -15282,6 +15282,7 @@ components:
           - help_center_settings_change
           - inbound_conversations_change
           - inbox_access_change
+          - inbox_bulk_action
           - macro_creation
           - macro_deletion
           - macro_update


### PR DESCRIPTION
### Why?

A new activity log event type records bulk actions taken on conversations from the inbox. The API already returns this value, because the activity type is derived from the event itself rather than read from this list — so the spec fell behind the moment the feature shipped.

### How?

Adds the new value to the activity type enum in the latest stable spec and the Preview spec, leaving already-published versions as they are.

<sub>Generated with Claude Code</sub>