### PR TITLE
Correct contact search date filtering and operator docs

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9063,11 +9063,11 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. On Preview/Unstable, the day boundary is always UTC, regardless of your workspace's timezone.
-        Because the value is truncated to a day, `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day (not from the instant you submitted), and `<` matches everything before the start of that UTC day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st.
-        If you'd like to get contacts created on January 1st, 2020 (UTC) you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Standard timestamp fields (created_at, updated_at, last_seen_at etc.) are filtered on the exact second, in UTC. `=` matches only Contacts whose value is that exact second, and `>`, `<`, `>=` and `<=` compare against the exact instant you pass - the value is not rounded or truncated. These fields report a type of `datetime` on the Data Attributes endpoint.
+        Date custom attributes behave differently: they are still truncated to a whole calendar day, and the day boundary is always UTC regardless of your workspace's timezone. On a Date custom attribute, `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day (not from the instant you submitted), and `<` matches everything before the start of that UTC day. The `!=`, `>=`, and `<=` operators are not supported on Date custom attributes and return an error.
+        For example, searching for a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC) returns Contacts created after that exact instant. Passing the same value for a Date custom attribute truncates it to 1577836800 (January 1st, 2020 12:00 AM UTC), so the results include Contacts from January 2nd, 2020 12:00 AM UTC onwards.
+        Note that `!=` on a standard timestamp also matches Contacts that have no value set for that field.
+        Search results always contain the full UNIX timestamp and are sorted on the full value.
 
         ### Accepted Fields
 
@@ -9121,22 +9121,22 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
+        {% admonition type="warning" name="Operators not supported on Date custom attributes" %}
+          Date custom attributes do not support the `!=`, `>=`, or `<=` operators. Using them returns an error. Standard timestamp fields (`created_at`, `updated_at` etc.) do support these operators, and are filtered on the exact second.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
         | Operator | Valid Types                        | Description                                                            |
         | :------- | :---------------------------------- | :----------------------------------------------------------------------|
         | =        | All                                  | Equals                                                                  |
-        | !=       | All except Date                      | Doesn't Equal                                                           |
-        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
-        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
-        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | !=       | All except Date                      | Doesn't Equal<br>Also matches Contacts with no value set                |
+        | IN       | All except Date, Datetime and tag_id | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date, Datetime and tag_id | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Datetime<br>Date | Greater than<br>On Date custom attributes, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Datetime<br>Date | Lower than<br>On Date custom attributes, matches before the start of the day |
+        | >=       | Integer<br>Float<br>Datetime         | Greater than or equal to<br>Not supported on Date custom attributes    |
+        | <=       | Integer<br>Float<br>Datetime         | Lower than or equal to<br>Not supported on Date custom attributes      |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -38979,7 +38979,8 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `datetime` fields (standard contact timestamps such as `created_at` and `last_seen_at`): `=`, `!=`, `<`, `>`, `<=`, `>=`. Filtering is on the exact second, in UTC.
+            - `date` fields (Date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error. Values are truncated to a whole UTC day.
           example: ">"
         value:
           oneOf:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -38980,7 +38980,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `datetime` fields (standard contact timestamps such as `created_at` and `last_seen_at`): `=`, `!=`, `<`, `>`, `<=`, `>=`. Filtering is on the exact second, in UTC.

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9063,11 +9063,15 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        Standard timestamp fields (created_at, updated_at, last_seen_at etc.) are filtered on the exact second, in UTC. `=` matches only Contacts whose value is that exact second, and `>`, `<`, `>=` and `<=` compare against the exact instant you pass - the value is not rounded or truncated. These fields report a type of `datetime` on the Data Attributes endpoint.
-        Date custom attributes behave differently: they are still truncated to a whole calendar day, and the day boundary is always UTC regardless of your workspace's timezone. On a Date custom attribute, `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day (not from the instant you submitted), and `<` matches everything before the start of that UTC day. The `!=`, `>=`, and `<=` operators are not supported on Date custom attributes and return an error.
-        For example, searching for a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC) returns Contacts created after that exact instant. Passing the same value for a Date custom attribute truncates it to 1577836800 (January 1st, 2020 12:00 AM UTC), so the results include Contacts from January 2nd, 2020 12:00 AM UTC onwards.
-        Note that `!=` on a standard timestamp also matches Contacts that have no value set for that field.
-        Search results always contain the full UNIX timestamp and are sorted on the full value.
+        Standard timestamp fields and Date custom attributes behave differently.
+
+        **Standard timestamp fields** (`created_at`, `updated_at`, `last_seen_at` etc.) are filtered on the exact second, in UTC. `=` matches only Contacts whose value is that exact second, and `>`, `<`, `>=` and `<=` compare against the exact instant you pass - the value is not rounded or truncated. These fields report a type of `datetime` on the Data Attributes endpoint. Note that `!=` also matches Contacts with no value set for the field.
+
+        **Date custom attributes** are matched by calendar day, and the day boundary is always UTC regardless of your workspace's timezone. `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day, and `<` matches everything before the start of that day. The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on these fields and return an error.
+
+        **Example.** Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) returns Contacts created after that exact instant. Passing the same value for a Date custom attribute truncates it to `1577836800` (January 1st, 2020 12:00 AM UTC), so those results begin from January 2nd, 2020 12:00 AM UTC.
+
+        Only search queries behave this way. Responses always carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9063,8 +9063,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are filtered by UTC calendar day in Contact Search. An equality (=) query on a timestamp matches any contact whose value falls on the same UTC day, so filtering by a value the API returned reliably matches that contact regardless of your workspace's timezone. Comparisons (>, <) are evaluated at UTC day granularity.
-        For example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. On Preview/Unstable, the day boundary is always UTC, regardless of your workspace's timezone.
+        Because the value is truncated to a day, `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day (not from the instant you submitted), and `<` matches everything before the start of that UTC day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st.
         If you'd like to get contacts created on January 1st, 2020 (UTC) you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -9120,24 +9121,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -38964,13 +38967,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9064,7 +9064,7 @@ paths:
         ### Searching for Timestamp Fields
 
         All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. On Preview/Unstable, the day boundary is always UTC, regardless of your workspace's timezone.
-        Because the value is truncated to a day, `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day (not from the instant you submitted), and `<` matches everything before the start of that UTC day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        Because the value is truncated to a day, `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day (not from the instant you submitted), and `<` matches everything before the start of that UTC day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st.
         If you'd like to get contacts created on January 1st, 2020 (UTC) you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
@@ -9122,7 +9122,7 @@ paths:
         ### Accepted Operators
 
         {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
         The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
@@ -38979,7 +38979,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9063,15 +9063,10 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        Standard timestamp fields and Date custom attributes behave differently.
-
-        **Standard timestamp fields** (`created_at`, `updated_at`, `last_seen_at` etc.) are filtered on the exact second, in UTC. `=` matches only Contacts whose value is that exact second, and `>`, `<`, `>=` and `<=` compare against the exact instant you pass - the value is not rounded or truncated. These fields report a type of `datetime` on the Data Attributes endpoint. Note that `!=` also matches Contacts with no value set for the field.
-
-        **Date custom attributes** are matched by calendar day, and the day boundary is always UTC regardless of your workspace's timezone. `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day, and `<` matches everything before the start of that day. The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on these fields and return an error.
-
-        **Example.** Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) returns Contacts created after that exact instant. Passing the same value for a Date custom attribute truncates it to `1577836800` (January 1st, 2020 12:00 AM UTC), so those results begin from January 2nd, 2020 12:00 AM UTC.
-
-        Only search queries behave this way. Responses always carry the full UNIX timestamp, and sorting uses the full value.
+        All timestamp fields (created_at, updated_at etc.) are filtered by UTC calendar day in Contact Search. An equality (=) query on a timestamp matches any contact whose value falls on the same UTC day, so filtering by a value the API returned reliably matches that contact regardless of your workspace's timezone. Comparisons (>, <) are evaluated at UTC day granularity.
+        For example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards.
+        If you'd like to get contacts created on January 1st, 2020 (UTC) you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
+        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
         ### Accepted Fields
 
@@ -9125,26 +9120,24 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Operators not supported on Date custom attributes" %}
-          Date custom attributes do not support the `!=`, `>=`, or `<=` operators. Using them returns an error. Standard timestamp fields (`created_at`, `updated_at` etc.) do support these operators, and are filtered on the exact second.
+        {% admonition type="warning" name="Searching based on `created_at`" %}
+          You cannot use the `<=` or `>=` operators to search by `created_at`.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
+        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
 
-        | Operator | Valid Types                        | Description                                                            |
-        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
-        | =        | All                                  | Equals                                                                  |
-        | !=       | All except Date                      | Doesn't Equal<br>Also matches Contacts with no value set                |
-        | IN       | All except Date, Datetime and tag_id | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All except Date, Datetime and tag_id | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Datetime<br>Date | Greater than<br>On Date custom attributes, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Datetime<br>Date | Lower than<br>On Date custom attributes, matches before the start of the day |
-        | >=       | Integer<br>Float<br>Datetime         | Greater than or equal to<br>Not supported on Date custom attributes    |
-        | <=       | Integer<br>Float<br>Datetime         | Lower than or equal to<br>Not supported on Date custom attributes      |
-        | ~        | String                               | Contains                                                                |
-        | !~       | String                               | Doesn't Contain                                                         |
-        | ^        | String                               | Starts With                                                             |
-        | $        | String                               | Ends With                                                               |
+        | Operator | Valid Types                      | Description                                                      |
+        | :------- | :------------------------------- | :--------------------------------------------------------------- |
+        | =        | All                              | Equals                                                           |
+        | !=       | All                              | Doesn't Equal                                                    |
+        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
+        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
+        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
+        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
+        | ~        | String                           | Contains                                                         |
+        | !~       | String                           | Doesn't Contain                                                  |
+        | ^        | String                           | Starts With                                                      |
+        | $        | String                           | Ends With                                                        |
       responses:
         '200':
           description: successful
@@ -38971,21 +38964,13 @@ components:
           - IN
           - NIN
           - "<"
-          - "<="
           - ">"
-          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
-            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
-            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `datetime` fields (standard contact timestamps such as `created_at` and `last_seen_at`): `=`, `!=`, `<`, `>`, `<=`, `>=`. Filtering is on the exact second, in UTC.
-            - `date` fields (Date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error. Values are truncated to a whole UTC day.
+          description: The accepted operators you can use to define how you want to
+            search for the value.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -3676,11 +3676,23 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
-        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Timestamp fields (`created_at`, `updated_at` etc.) and Date custom attributes are matched by calendar day. Sub-day precision (hour, minute, second) is not supported.
+
+        The day boundary uses **your workspace's timezone**, so the same query can return different results on two workspaces in different timezones.
+
+        Because the value is truncated to a day:
+
+        * `=` matches the whole day.
+        * `>` matches from the start of the *next* day, not from the instant you passed.
+        * `<` matches everything before the start of that day.
+
+        The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on Date fields and return an error.
+
+        **Example**, on a workspace set to UTC. Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) truncates that value to `1577836800` (January 1st, 2020 12:00 AM UTC). Because `>` starts at the next day, the results begin from January 2nd, 2020 12:00 AM UTC - not from 9:00 AM on January 1st. On a workspace in another timezone, the boundaries fall on that timezone's midnight instead.
+
+        To get contacts created on January 1st, 2020, search for `created_at` equal to `1577836800`.
+
+        Only search queries behave this way. Responses still carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -3757,10 +3757,10 @@ paths:
         | !=       | All except Date                      | Doesn't Equal                                                           |
         | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
         | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
-        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
-        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | >        | Integer<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer                     | Lower than or equal to<br>Not supported on Date fields                 |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -15875,7 +15875,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -15872,7 +15872,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -15871,7 +15871,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -3677,7 +3677,7 @@ paths:
         ### Searching for Timestamp Fields
 
         All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
@@ -3734,7 +3734,7 @@ paths:
         ### Accepted Operators
 
         {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
         The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
@@ -15863,7 +15863,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -3737,14 +3737,14 @@ paths:
           Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
         | Operator | Valid Types                        | Description                                                            |
         | :------- | :---------------------------------- | :----------------------------------------------------------------------|
         | =        | All                                  | Equals                                                                  |
         | !=       | All except Date                      | Doesn't Equal                                                           |
-        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
         | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
         | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
         | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
@@ -15863,7 +15863,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -3676,8 +3676,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second. The day a timestamp falls on is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones. Because timestamps are stored in UTC, filtering by a value the API returned may not match the originating contact when your workspace is not set to UTC.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -3732,24 +3733,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -15848,13 +15851,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -3756,7 +3756,7 @@ paths:
         ### Searching for Timestamp Fields
 
         All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
@@ -3813,7 +3813,7 @@ paths:
         ### Accepted Operators
 
         {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
         The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
@@ -17323,7 +17323,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -17331,7 +17331,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -3816,14 +3816,14 @@ paths:
           Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
         | Operator | Valid Types                        | Description                                                            |
         | :------- | :---------------------------------- | :----------------------------------------------------------------------|
         | =        | All                                  | Equals                                                                  |
         | !=       | All except Date                      | Doesn't Equal                                                           |
-        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
         | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
         | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
         | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
@@ -17323,7 +17323,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -17332,7 +17332,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -3755,8 +3755,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second. The day a timestamp falls on is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones. Because timestamps are stored in UTC, filtering by a value the API returned may not match the originating contact when your workspace is not set to UTC.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -3811,24 +3812,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -17308,13 +17311,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -3755,11 +3755,23 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
-        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Timestamp fields (`created_at`, `updated_at` etc.) and Date custom attributes are matched by calendar day. Sub-day precision (hour, minute, second) is not supported.
+
+        The day boundary uses **your workspace's timezone**, so the same query can return different results on two workspaces in different timezones.
+
+        Because the value is truncated to a day:
+
+        * `=` matches the whole day.
+        * `>` matches from the start of the *next* day, not from the instant you passed.
+        * `<` matches everything before the start of that day.
+
+        The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on Date fields and return an error.
+
+        **Example**, on a workspace set to UTC. Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) truncates that value to `1577836800` (January 1st, 2020 12:00 AM UTC). Because `>` starts at the next day, the results begin from January 2nd, 2020 12:00 AM UTC - not from 9:00 AM on January 1st. On a workspace in another timezone, the boundaries fall on that timezone's midnight instead.
+
+        To get contacts created on January 1st, 2020, search for `created_at` equal to `1577836800`.
+
+        Only search queries behave this way. Responses still carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -3836,10 +3836,10 @@ paths:
         | !=       | All except Date                      | Doesn't Equal                                                           |
         | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
         | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
-        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
-        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | >        | Integer<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer                     | Lower than or equal to<br>Not supported on Date fields                 |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -17335,7 +17335,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -4289,8 +4289,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second. The day a timestamp falls on is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones. Because timestamps are stored in UTC, filtering by a value the API returned may not match the originating contact when your workspace is not set to UTC.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -4345,24 +4346,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -17251,13 +17254,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -4290,7 +4290,7 @@ paths:
         ### Searching for Timestamp Fields
 
         All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
@@ -4347,7 +4347,7 @@ paths:
         ### Accepted Operators
 
         {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
         The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
@@ -17266,7 +17266,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -4289,11 +4289,23 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
-        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Timestamp fields (`created_at`, `updated_at` etc.) and Date custom attributes are matched by calendar day. Sub-day precision (hour, minute, second) is not supported.
+
+        The day boundary uses **your workspace's timezone**, so the same query can return different results on two workspaces in different timezones.
+
+        Because the value is truncated to a day:
+
+        * `=` matches the whole day.
+        * `>` matches from the start of the *next* day, not from the instant you passed.
+        * `<` matches everything before the start of that day.
+
+        The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on Date fields and return an error.
+
+        **Example**, on a workspace set to UTC. Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) truncates that value to `1577836800` (January 1st, 2020 12:00 AM UTC). Because `>` starts at the next day, the results begin from January 2nd, 2020 12:00 AM UTC - not from 9:00 AM on January 1st. On a workspace in another timezone, the boundaries fall on that timezone's midnight instead.
+
+        To get contacts created on January 1st, 2020, search for `created_at` equal to `1577836800`.
+
+        Only search queries behave this way. Responses still carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -17275,7 +17275,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -4370,10 +4370,10 @@ paths:
         | !=       | All except Date                      | Doesn't Equal                                                           |
         | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
         | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
-        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
-        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | >        | Integer<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer                     | Lower than or equal to<br>Not supported on Date fields                 |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -17278,7 +17278,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -17274,7 +17274,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -4350,14 +4350,14 @@ paths:
           Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
         | Operator | Valid Types                        | Description                                                            |
         | :------- | :---------------------------------- | :----------------------------------------------------------------------|
         | =        | All                                  | Equals                                                                  |
         | !=       | All except Date                      | Doesn't Equal                                                           |
-        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
         | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
         | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
         | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
@@ -17266,7 +17266,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -18940,7 +18940,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -4871,14 +4871,14 @@ paths:
           Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
         | Operator | Valid Types                        | Description                                                            |
         | :------- | :---------------------------------- | :----------------------------------------------------------------------|
         | =        | All                                  | Equals                                                                  |
         | !=       | All except Date                      | Doesn't Equal                                                           |
-        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
         | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
         | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
         | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
@@ -18931,7 +18931,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -4810,11 +4810,23 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
-        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Timestamp fields (`created_at`, `updated_at` etc.) and Date custom attributes are matched by calendar day. Sub-day precision (hour, minute, second) is not supported.
+
+        The day boundary uses **your workspace's timezone**, so the same query can return different results on two workspaces in different timezones.
+
+        Because the value is truncated to a day:
+
+        * `=` matches the whole day.
+        * `>` matches from the start of the *next* day, not from the instant you passed.
+        * `<` matches everything before the start of that day.
+
+        The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on Date fields and return an error.
+
+        **Example**, on a workspace set to UTC. Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) truncates that value to `1577836800` (January 1st, 2020 12:00 AM UTC). Because `>` starts at the next day, the results begin from January 2nd, 2020 12:00 AM UTC - not from 9:00 AM on January 1st. On a workspace in another timezone, the boundaries fall on that timezone's midnight instead.
+
+        To get contacts created on January 1st, 2020, search for `created_at` equal to `1577836800`.
+
+        Only search queries behave this way. Responses still carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -18939,7 +18939,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -4810,8 +4810,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second. The day a timestamp falls on is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones. Because timestamps are stored in UTC, filtering by a value the API returned may not match the originating contact when your workspace is not set to UTC.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -4866,24 +4867,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -18916,13 +18919,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -4891,10 +4891,10 @@ paths:
         | !=       | All except Date                      | Doesn't Equal                                                           |
         | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
         | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
-        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
-        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | >        | Integer<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer                     | Lower than or equal to<br>Not supported on Date fields                 |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -18943,7 +18943,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -4811,7 +4811,7 @@ paths:
         ### Searching for Timestamp Fields
 
         All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
@@ -4868,7 +4868,7 @@ paths:
         ### Accepted Operators
 
         {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
         The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
@@ -18931,7 +18931,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -5853,10 +5853,10 @@ paths:
         | !=       | All except Date                      | Doesn't Equal                                                           |
         | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
         | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
-        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
-        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | >        | Integer<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer                     | Lower than or equal to<br>Not supported on Date fields                 |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -21594,7 +21594,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -5773,7 +5773,7 @@ paths:
         ### Searching for Timestamp Fields
 
         All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
@@ -5830,7 +5830,7 @@ paths:
         ### Accepted Operators
 
         {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
         The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
@@ -21582,7 +21582,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -5772,11 +5772,23 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
-        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Timestamp fields (`created_at`, `updated_at` etc.) and Date custom attributes are matched by calendar day. Sub-day precision (hour, minute, second) is not supported.
+
+        The day boundary uses **your workspace's timezone**, so the same query can return different results on two workspaces in different timezones.
+
+        Because the value is truncated to a day:
+
+        * `=` matches the whole day.
+        * `>` matches from the start of the *next* day, not from the instant you passed.
+        * `<` matches everything before the start of that day.
+
+        The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on Date fields and return an error.
+
+        **Example**, on a workspace set to UTC. Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) truncates that value to `1577836800` (January 1st, 2020 12:00 AM UTC). Because `>` starts at the next day, the results begin from January 2nd, 2020 12:00 AM UTC - not from 9:00 AM on January 1st. On a workspace in another timezone, the boundaries fall on that timezone's midnight instead.
+
+        To get contacts created on January 1st, 2020, search for `created_at` equal to `1577836800`.
+
+        Only search queries behave this way. Responses still carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -21590,7 +21590,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -21591,7 +21591,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -5772,8 +5772,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second. The day a timestamp falls on is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones. Because timestamps are stored in UTC, filtering by a value the API returned may not match the originating contact when your workspace is not set to UTC.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -5828,24 +5829,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -21567,13 +21570,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -5833,14 +5833,14 @@ paths:
           Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
         | Operator | Valid Types                        | Description                                                            |
         | :------- | :---------------------------------- | :----------------------------------------------------------------------|
         | =        | All                                  | Equals                                                                  |
         | !=       | All except Date                      | Doesn't Equal                                                           |
-        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
         | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
         | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
         | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
@@ -21582,7 +21582,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -5776,10 +5776,10 @@ paths:
         | !=       | All except Date                      | Doesn't Equal                                                           |
         | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
         | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
-        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
-        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | >        | Integer<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer                     | Lower than or equal to<br>Not supported on Date fields                 |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -22575,7 +22575,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -5756,14 +5756,14 @@ paths:
           Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
         | Operator | Valid Types                        | Description                                                            |
         | :------- | :---------------------------------- | :----------------------------------------------------------------------|
         | =        | All                                  | Equals                                                                  |
         | !=       | All except Date                      | Doesn't Equal                                                           |
-        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
         | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
         | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
         | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
@@ -22563,7 +22563,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -5696,7 +5696,7 @@ paths:
         ### Searching for Timestamp Fields
 
         All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
@@ -5753,7 +5753,7 @@ paths:
         ### Accepted Operators
 
         {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
         The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
@@ -22563,7 +22563,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -5695,8 +5695,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second. The day a timestamp falls on is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones. Because timestamps are stored in UTC, filtering by a value the API returned may not match the originating contact when your workspace is not set to UTC.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -5751,24 +5752,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -22548,13 +22551,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -22572,7 +22572,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -22571,7 +22571,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -5695,11 +5695,23 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
-        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Timestamp fields (`created_at`, `updated_at` etc.) and Date custom attributes are matched by calendar day. Sub-day precision (hour, minute, second) is not supported.
+
+        The day boundary uses **your workspace's timezone**, so the same query can return different results on two workspaces in different timezones.
+
+        Because the value is truncated to a day:
+
+        * `=` matches the whole day.
+        * `>` matches from the start of the *next* day, not from the instant you passed.
+        * `<` matches everything before the start of that day.
+
+        The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on Date fields and return an error.
+
+        **Example**, on a workspace set to UTC. Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) truncates that value to `1577836800` (January 1st, 2020 12:00 AM UTC). Because `>` starts at the next day, the results begin from January 2nd, 2020 12:00 AM UTC - not from 9:00 AM on January 1st. On a workspace in another timezone, the boundaries fall on that timezone's midnight instead.
+
+        To get contacts created on January 1st, 2020, search for `created_at` equal to `1577836800`.
+
+        Only search queries behave this way. Responses still carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -33313,7 +33313,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -8812,24 +8812,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -33309,7 +33311,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -33310,7 +33310,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -8742,8 +8742,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are filtered by UTC calendar day in Contact Search. An equality (=) query on a timestamp matches any contact whose value falls on the same UTC day, so filtering by a value the API returned reliably matches that contact regardless of your workspace's timezone. Comparisons (>, <) are evaluated at UTC day granularity.
-        For example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is always UTC, regardless of your workspace's timezone, so the same query returns the same results across workspaces in every timezone.
+        Because the value is truncated to a day, `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day (not from the instant you submitted), and `<` matches everything before the start of that UTC day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st.
         If you'd like to get contacts created on January 1st, 2020 (UTC) you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -33288,13 +33289,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -8742,10 +8742,10 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is always UTC, regardless of your workspace's timezone, so the same query returns the same results across workspaces in every timezone.
-        Because the value is truncated to a day, `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day (not from the instant you submitted), and `<` matches everything before the start of that UTC day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. A contact's value is placed in a day using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st.
-        If you'd like to get contacts created on January 1st, 2020 (UTC) you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
+        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
         ### Accepted Fields
@@ -33301,7 +33301,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -8742,11 +8742,23 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. A contact's value is placed in a day using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st.
-        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Timestamp fields (`created_at`, `updated_at` etc.) and Date custom attributes are matched by calendar day. Sub-day precision (hour, minute, second) is not supported.
+
+        The day boundary uses **your workspace's timezone**, so the same query can return different results on two workspaces in different timezones.
+
+        Because the value is truncated to a day:
+
+        * `=` matches the whole day.
+        * `>` matches from the start of the *next* day, not from the instant you passed.
+        * `<` matches everything before the start of that day.
+
+        The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on Date fields and return an error.
+
+        **Example**, on a workspace set to UTC. Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) truncates that value to `1577836800` (January 1st, 2020 12:00 AM UTC). Because `>` starts at the next day, the results begin from January 2nd, 2020 12:00 AM UTC - not from 9:00 AM on January 1st. On a workspace in another timezone, the boundaries fall on that timezone's midnight instead.
+
+        To get contacts created on January 1st, 2020, search for `created_at` equal to `1577836800`.
+
+        Only search queries behave this way. Responses still carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -33301,7 +33301,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -3975,10 +3975,10 @@ paths:
         | !=       | All except Date                      | Doesn't Equal                                                           |
         | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
         | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
-        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
-        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | >        | Integer<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer                     | Lower than or equal to<br>Not supported on Date fields                 |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -13874,7 +13874,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -3894,11 +3894,23 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
-        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Timestamp fields (`created_at`, `updated_at` etc.) and Date custom attributes are matched by calendar day. Sub-day precision (hour, minute, second) is not supported.
+
+        The day boundary uses **your workspace's timezone**, so the same query can return different results on two workspaces in different timezones.
+
+        Because the value is truncated to a day:
+
+        * `=` matches the whole day.
+        * `>` matches from the start of the *next* day, not from the instant you passed.
+        * `<` matches everything before the start of that day.
+
+        The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on Date fields and return an error.
+
+        **Example**, on a workspace set to UTC. Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) truncates that value to `1577836800` (January 1st, 2020 12:00 AM UTC). Because `>` starts at the next day, the results begin from January 2nd, 2020 12:00 AM UTC - not from 9:00 AM on January 1st. On a workspace in another timezone, the boundaries fall on that timezone's midnight instead.
+
+        To get contacts created on January 1st, 2020, search for `created_at` equal to `1577836800`.
+
+        Only search queries behave this way. Responses still carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -3895,7 +3895,7 @@ paths:
         ### Searching for Timestamp Fields
 
         All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
@@ -3952,7 +3952,7 @@ paths:
         ### Accepted Operators
 
         {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
         The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
@@ -13862,7 +13862,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -13871,7 +13871,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -3894,8 +3894,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second. The day a timestamp falls on is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones. Because timestamps are stored in UTC, filtering by a value the API returned may not match the originating contact when your workspace is not set to UTC.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -3950,24 +3951,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -13847,13 +13850,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -13870,7 +13870,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -3955,14 +3955,14 @@ paths:
           Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
         | Operator | Valid Types                        | Description                                                            |
         | :------- | :---------------------------------- | :----------------------------------------------------------------------|
         | =        | All                                  | Equals                                                                  |
         | !=       | All except Date                      | Doesn't Equal                                                           |
-        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
         | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
         | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
         | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
@@ -13862,7 +13862,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -13894,7 +13894,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -13895,7 +13895,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -3975,10 +3975,10 @@ paths:
         | !=       | All except Date                      | Doesn't Equal                                                           |
         | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
         | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
-        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
-        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | >        | Integer<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer                     | Lower than or equal to<br>Not supported on Date fields                 |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -13898,7 +13898,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -3894,11 +3894,23 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
-        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Timestamp fields (`created_at`, `updated_at` etc.) and Date custom attributes are matched by calendar day. Sub-day precision (hour, minute, second) is not supported.
+
+        The day boundary uses **your workspace's timezone**, so the same query can return different results on two workspaces in different timezones.
+
+        Because the value is truncated to a day:
+
+        * `=` matches the whole day.
+        * `>` matches from the start of the *next* day, not from the instant you passed.
+        * `<` matches everything before the start of that day.
+
+        The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on Date fields and return an error.
+
+        **Example**, on a workspace set to UTC. Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) truncates that value to `1577836800` (January 1st, 2020 12:00 AM UTC). Because `>` starts at the next day, the results begin from January 2nd, 2020 12:00 AM UTC - not from 9:00 AM on January 1st. On a workspace in another timezone, the boundaries fall on that timezone's midnight instead.
+
+        To get contacts created on January 1st, 2020, search for `created_at` equal to `1577836800`.
+
+        Only search queries behave this way. Responses still carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -3895,7 +3895,7 @@ paths:
         ### Searching for Timestamp Fields
 
         All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
@@ -3952,7 +3952,7 @@ paths:
         ### Accepted Operators
 
         {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
         The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
@@ -13886,7 +13886,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -3894,8 +3894,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second. The day a timestamp falls on is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones. Because timestamps are stored in UTC, filtering by a value the API returned may not match the originating contact when your workspace is not set to UTC.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -3950,24 +3951,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -13871,13 +13874,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -3955,14 +3955,14 @@ paths:
           Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
         | Operator | Valid Types                        | Description                                                            |
         | :------- | :---------------------------------- | :----------------------------------------------------------------------|
         | =        | All                                  | Equals                                                                  |
         | !=       | All except Date                      | Doesn't Equal                                                           |
-        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
         | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
         | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
         | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
@@ -13886,7 +13886,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -15247,7 +15247,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -3955,14 +3955,14 @@ paths:
           Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
         | Operator | Valid Types                        | Description                                                            |
         | :------- | :---------------------------------- | :----------------------------------------------------------------------|
         | =        | All                                  | Equals                                                                  |
         | !=       | All except Date                      | Doesn't Equal                                                           |
-        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
-        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
         | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
         | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
         | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
@@ -15239,7 +15239,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -3895,7 +3895,7 @@ paths:
         ### Searching for Timestamp Fields
 
         All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
         For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
@@ -3952,7 +3952,7 @@ paths:
         ### Accepted Operators
 
         {% admonition type="warning" name="Operators not supported on Date fields" %}
-          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns an error.
         {% /admonition %}
 
         The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
@@ -15239,7 +15239,7 @@ components:
             - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
-            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -3975,10 +3975,10 @@ paths:
         | !=       | All except Date                      | Doesn't Equal                                                           |
         | IN       | All except Date and tag_id           | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
         | NIN      | All except Date and tag_id           | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
-        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
-        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | >        | Integer<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer                     | Lower than or equal to<br>Not supported on Date fields                 |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -15251,7 +15251,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.
           example: ">"
         value:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -3894,11 +3894,23 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
-        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return an error.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
-        If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Timestamp fields (`created_at`, `updated_at` etc.) and Date custom attributes are matched by calendar day. Sub-day precision (hour, minute, second) is not supported.
+
+        The day boundary uses **your workspace's timezone**, so the same query can return different results on two workspaces in different timezones.
+
+        Because the value is truncated to a day:
+
+        * `=` matches the whole day.
+        * `>` matches from the start of the *next* day, not from the instant you passed.
+        * `<` matches everything before the start of that day.
+
+        The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on Date fields and return an error.
+
+        **Example**, on a workspace set to UTC. Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) truncates that value to `1577836800` (January 1st, 2020 12:00 AM UTC). Because `>` starts at the next day, the results begin from January 2nd, 2020 12:00 AM UTC - not from 9:00 AM on January 1st. On a workspace in another timezone, the boundaries fall on that timezone's midnight instead.
+
+        To get contacts created on January 1st, 2020, search for `created_at` equal to `1577836800`.
+
+        Only search queries behave this way. Responses still carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -3894,8 +3894,9 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second. The day a timestamp falls on is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones. Because timestamps are stored in UTC, filtering by a value the API returned may not match the originating contact when your workspace is not set to UTC.
-        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
+        All timestamp fields (created_at, updated_at etc.) and Date custom attributes are truncated to a calendar day for Contact Search queries; sub-day precision (hour, minute, second) is not supported. The day boundary is determined using your workspace's timezone, so the same query can return different results across workspaces in different timezones.
+        Because the value is truncated to a day, `=` matches the whole day, `>` matches from the start of the *next* day (not from the instant you submitted), and `<` matches everything before the start of that day. The `!=`, `>=`, and `<=` operators are not supported on Date fields and return a 400 error.
+        For example, on a workspace set to UTC, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that timestamp is truncated to 1577836800 (January 1st, 2020 12:00 AM UTC), and because `>` matches from the start of the next day, the search results include Contacts created from January 2nd, 2020 12:00 AM UTC onwards - not from 9:00 AM on January 1st. On a workspace in another timezone, the day boundaries fall on that timezone's midnight instead.
         If you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
         This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
 
@@ -3950,24 +3951,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date fields" %}
+          Date fields (`created_at`, `updated_at`, and any Date custom attribute) do not support the `!=`, `>=`, or `<=` operators. Using them returns a 400 error.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal                                                           |
+        | IN       | All                                  | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All                                  | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Date             | Greater than<br>On Date fields, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Date             | Lower than<br>On Date fields, matches before the start of the day      |
+        | >=       | Integer<br>Float                     | Greater than or equal to<br>Not supported on Date fields               |
+        | <=       | Integer<br>Float                     | Lower than or equal to<br>Not supported on Date fields                 |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -15224,13 +15227,19 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `IN`, `NIN`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return a 400 error.
           example: ">"
         value:
           oneOf:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -15248,7 +15248,8 @@ components:
           - "$"
           description: |-
             The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
-            - `string` fields (including tags): `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
             - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `date` fields (all standard timestamp attributes and date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, `>=`, `IN`, and `NIN` are not supported and return an error.


### PR DESCRIPTION
### Why?

The contact search docs describe date filtering incorrectly. They list operators that actually return a 400 error, leave out two that work, and never mention that a date value is cut down to a whole day, which makes `>` look like it skips a day.

### How?

Rewrites the timestamp section and the operator table in every version to say which operators each field type accepts, and what day truncation does to the comparison results.

<sub>Generated with Claude Code</sub>