### PR TITLE
Document exact-second timestamp filtering for contacts search on Preview

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9089,14 +9089,14 @@ paths:
         | phone                              | String                         |
         | formatted_phone                    | String                         |
         | external_id                        | String                         |
-        | created_at                         | Date (UNIX Timestamp)          |
-        | signed_up_at                       | Date (UNIX Timestamp)          |
-        | updated_at                         | Date (UNIX Timestamp)          |
-        | last_seen_at                       | Date (UNIX Timestamp)          |
-        | last_contacted_at                  | Date (UNIX Timestamp)          |
-        | last_replied_at                    | Date (UNIX Timestamp)          |
-        | last_email_opened_at               | Date (UNIX Timestamp)          |
-        | last_email_clicked_at              | Date (UNIX Timestamp)          |
+        | created_at                         | Datetime (Unix timestamp in seconds) |
+        | signed_up_at                       | Datetime (Unix timestamp in seconds) |
+        | updated_at                         | Datetime (Unix timestamp in seconds) |
+        | last_seen_at                       | Datetime (Unix timestamp in seconds) |
+        | last_contacted_at                  | Datetime (Unix timestamp in seconds) |
+        | last_replied_at                    | Datetime (Unix timestamp in seconds) |
+        | last_email_opened_at               | Datetime (Unix timestamp in seconds) |
+        | last_email_clicked_at              | Datetime (Unix timestamp in seconds) |
         | language_override                  | String                         |
         | browser                            | String                         |
         | browser_language                   | String                         |
@@ -9107,21 +9107,21 @@ paths:
         | unsubscribed_from_emails           | Boolean                        |
         | marked_email_as_spam               | Boolean                        |
         | has_hard_bounced                   | Boolean                        |
-        | ios_last_seen_at                   | Date (UNIX Timestamp)          |
+        | ios_last_seen_at                   | Datetime (Unix timestamp in seconds) |
         | ios_app_version                    | String                         |
         | ios_device                         | String                         |
         | ios_app_device                     | String                         |
         | ios_os_version                     | String                         |
         | ios_app_name                       | String                         |
         | ios_sdk_version                    | String                         |
-        | android_last_seen_at               | Date (UNIX Timestamp)          |
+        | android_last_seen_at               | Datetime (Unix timestamp in seconds) |
         | android_app_version                | String                         |
         | android_device                     | String                         |
         | android_app_name                   | String                         |
         | andoid_sdk_version                 | String                         |
         | segment_id                         | String                         |
         | tag_id                             | String                         |
-        | custom_attributes.{attribute_name} | String                         |
+        | custom_attributes.{attribute_name} | Matches the attribute's own type<br>(String, Integer, Float, Boolean or Date) |
 
         ### Accepted Operators
 
@@ -33987,6 +33987,7 @@ components:
           - float
           - boolean
           - date
+          - datetime
           example: boolean
         options:
           type: array
@@ -38979,7 +38980,7 @@ components:
           - "^"
           - "$"
           description: |-
-            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type. The breakdown below is for Contacts search; the other search endpoints that share this schema accept a different set per field:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9137,10 +9137,10 @@ paths:
         | !=       | All except Date                      | Doesn't Equal<br>Also matches Contacts with no value set                |
         | IN       | All except Date, Datetime and tag_id | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
         | NIN      | All except Date, Datetime and tag_id | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
-        | >        | Integer<br>Float<br>Datetime<br>Date | Greater than<br>On Date custom attributes, matches from the start of the next day |
-        | <        | Integer<br>Float<br>Datetime<br>Date | Lower than<br>On Date custom attributes, matches before the start of the day |
-        | >=       | Integer<br>Float<br>Datetime         | Greater than or equal to<br>Not supported on Date custom attributes    |
-        | <=       | Integer<br>Float<br>Datetime         | Lower than or equal to<br>Not supported on Date custom attributes      |
+        | >        | Integer<br>Datetime<br>Date | Greater than<br>On Date custom attributes, matches from the start of the next day |
+        | <        | Integer<br>Datetime<br>Date | Lower than<br>On Date custom attributes, matches before the start of the day |
+        | >=       | Integer<br>Datetime         | Greater than or equal to<br>Not supported on Date custom attributes    |
+        | <=       | Integer<br>Datetime         | Lower than or equal to<br>Not supported on Date custom attributes      |
         | ~        | String                               | Contains                                                                |
         | !~       | String                               | Doesn't Contain                                                         |
         | ^        | String                               | Starts With                                                             |
@@ -38983,7 +38983,7 @@ components:
             - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
             - `tag_id`: `=` and `!=` only. Every other operator returns an error.
             - `boolean` fields: `=`, `!=`, `IN`, `NIN`
-            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `integer` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
             - `datetime` fields (standard contact timestamps such as `created_at` and `last_seen_at`): `=`, `!=`, `<`, `>`, `<=`, `>=`. Filtering is on the exact second, in UTC.
             - `date` fields (Date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error. Values are truncated to a whole UTC day.
           example: ">"

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9063,10 +9063,15 @@ paths:
 
         ### Searching for Timestamp Fields
 
-        All timestamp fields (created_at, updated_at etc.) are filtered by UTC calendar day in Contact Search. An equality (=) query on a timestamp matches any contact whose value falls on the same UTC day, so filtering by a value the API returned reliably matches that contact regardless of your workspace's timezone. Comparisons (>, <) are evaluated at UTC day granularity.
-        For example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM UTC), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM UTC). The search results will then include Contacts created from January 2nd, 2020 12:00 AM UTC onwards.
-        If you'd like to get contacts created on January 1st, 2020 (UTC) you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM UTC).
-        This behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.
+        Standard timestamp fields and Date custom attributes behave differently.
+
+        **Standard timestamp fields** (`created_at`, `updated_at`, `last_seen_at` etc.) are filtered on the exact second, in UTC. `=` matches only Contacts whose value is that exact second, and `>`, `<`, `>=` and `<=` compare against the exact instant you pass - the value is not rounded or truncated. These fields report a type of `datetime` on the Data Attributes endpoint. Note that `!=` also matches Contacts with no value set for the field.
+
+        **Date custom attributes** are matched by calendar day, and the day boundary is always UTC regardless of your workspace's timezone. `=` matches the whole UTC day, `>` matches from the start of the *next* UTC day, and `<` matches everything before the start of that day. The `!=`, `>=`, `<=`, `IN` and `NIN` operators are not supported on these fields and return an error.
+
+        **Example.** Searching for `created_at` greater than `1577869200` (January 1st, 2020 9:00 AM UTC) returns Contacts created after that exact instant. Passing the same value for a Date custom attribute truncates it to `1577836800` (January 1st, 2020 12:00 AM UTC), so those results begin from January 2nd, 2020 12:00 AM UTC.
+
+        Only search queries behave this way. Responses always carry the full UNIX timestamp, and sorting uses the full value.
 
         ### Accepted Fields
 
@@ -9120,24 +9125,26 @@ paths:
 
         ### Accepted Operators
 
-        {% admonition type="warning" name="Searching based on `created_at`" %}
-          You cannot use the `<=` or `>=` operators to search by `created_at`.
+        {% admonition type="warning" name="Operators not supported on Date custom attributes" %}
+          Date custom attributes do not support the `!=`, `>=`, or `<=` operators. Using them returns an error. Standard timestamp fields (`created_at`, `updated_at` etc.) do support these operators, and are filtered on the exact second.
         {% /admonition %}
 
-        The table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`"="`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).
+        The table below shows the operators you can use to define how you want to search for the value. The operator should be put in as a string (`"="`). Which operators are valid depends on the field's type - see the "Valid Types" column below. Searching by `tag_id` supports only the `=` and `!=` operators.
 
-        | Operator | Valid Types                      | Description                                                      |
-        | :------- | :------------------------------- | :--------------------------------------------------------------- |
-        | =        | All                              | Equals                                                           |
-        | !=       | All                              | Doesn't Equal                                                    |
-        | IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |
-        | NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |
-        | >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |
-        | <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |
-        | ~        | String                           | Contains                                                         |
-        | !~       | String                           | Doesn't Contain                                                  |
-        | ^        | String                           | Starts With                                                      |
-        | $        | String                           | Ends With                                                        |
+        | Operator | Valid Types                        | Description                                                            |
+        | :------- | :---------------------------------- | :----------------------------------------------------------------------|
+        | =        | All                                  | Equals                                                                  |
+        | !=       | All except Date                      | Doesn't Equal<br>Also matches Contacts with no value set                |
+        | IN       | All except Date, Datetime and tag_id | In<br>Shortcut for `OR` queries<br>Values must be in Array              |
+        | NIN      | All except Date, Datetime and tag_id | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array        |
+        | >        | Integer<br>Float<br>Datetime<br>Date | Greater than<br>On Date custom attributes, matches from the start of the next day |
+        | <        | Integer<br>Float<br>Datetime<br>Date | Lower than<br>On Date custom attributes, matches before the start of the day |
+        | >=       | Integer<br>Float<br>Datetime         | Greater than or equal to<br>Not supported on Date custom attributes    |
+        | <=       | Integer<br>Float<br>Datetime         | Lower than or equal to<br>Not supported on Date custom attributes      |
+        | ~        | String                               | Contains                                                                |
+        | !~       | String                               | Doesn't Contain                                                         |
+        | ^        | String                               | Starts With                                                             |
+        | $        | String                               | Ends With                                                               |
       responses:
         '200':
           description: successful
@@ -38964,13 +38971,21 @@ components:
           - IN
           - NIN
           - "<"
+          - "<="
           - ">"
+          - ">="
           - "~"
           - "!~"
           - "^"
           - "$"
-          description: The accepted operators you can use to define how you want to
-            search for the value.
+          description: |-
+            The accepted operators you can use to define how you want to search for the value. Operator support depends on the field's data type:
+            - `string` fields: `=`, `!=`, `IN`, `NIN`, `~`, `!~`, `^`, `$`
+            - `tag_id`: `=` and `!=` only. Every other operator returns an error.
+            - `boolean` fields: `=`, `!=`, `IN`, `NIN`
+            - `integer` and `float` fields: `=`, `!=`, `IN`, `NIN`, `<`, `>`, `<=`, `>=`
+            - `datetime` fields (standard contact timestamps such as `created_at` and `last_seen_at`): `=`, `!=`, `<`, `>`, `<=`, `>=`. Filtering is on the exact second, in UTC.
+            - `date` fields (Date custom attributes): `=`, `<`, `>` only. `!=`, `<=`, and `>=` are not supported and return an error. Values are truncated to a whole UTC day.
           example: ">"
         value:
           oneOf:


### PR DESCRIPTION
### Why?

On the Preview version, contact search filters standard timestamps on the exact second in UTC, but the reference still described the old behaviour of matching a whole calendar day. Readers got results the docs did not explain, and two comparison operators were missing from the operator list entirely.

### How?

Rewrote the timestamp guidance so standard timestamps and date custom attributes are described separately, and corrected the operator table and the accepted field types to match what the API actually accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)