### PR TITLE
Correct the state description on the update article request

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -40087,8 +40087,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -40087,9 +40087,12 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft or a scheduled publish time is
+            set in the same request. The `PUT /articles/{id}/draft` endpoint ignores
+            this field and always stages a draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -16812,8 +16812,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -16812,9 +16812,10 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -18661,8 +18661,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -18661,9 +18661,10 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -18323,8 +18323,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -18323,9 +18323,10 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -20011,9 +20011,10 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -20011,8 +20011,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -22738,8 +22738,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -22738,9 +22738,10 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -23746,9 +23746,10 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -23746,8 +23746,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -34590,9 +34590,12 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft or a scheduled publish time is
+            set in the same request. The `PUT /articles/{id}/draft` endpoint ignores
+            this field and always stages a draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -34590,8 +34590,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -14273,9 +14273,10 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -14273,8 +14273,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -14320,9 +14320,10 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -14320,8 +14320,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -16131,9 +16131,10 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Omitting this field leaves the current publish state unchanged. For
-            multilingual articles, this will be the state of the default language's
-            content.
+            Omitting this field leaves the publish state unchanged, so a draft stays
+            a draft and an edit to a published article goes live immediately unless
+            that article already has a pending draft. For multilingual articles, this
+            will be the state of the default language's content.
           enum:
           - published
           - draft

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -16131,8 +16131,9 @@ components:
         state:
           type: string
           description: Whether the article will be `published` or will be a `draft`.
-            Defaults to draft. For multilingual articles, this will be the state of
-            the default language's content.
+            Omitting this field leaves the current publish state unchanged. For
+            multilingual articles, this will be the state of the default language's
+            content.
           enum:
           - published
           - draft


### PR DESCRIPTION
### Why?

The `state` field on the update article request says it defaults to draft. It doesn't. Leaving it out keeps the article's current publish state, and an edit to a published article goes live immediately unless that article already has a pending draft, so anyone following the docs could expect their edit to be staged when it isn't.

### How?

Reworded that description across all API versions, and on the versions that have scheduled publishing or a draft endpoint, said how those interact with an omitted `state`. The create request still says it defaults to draft, which is accurate there.