### PR TITLE
Document skip_notifications on the Preview conversation reply schema

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -27022,6 +27022,10 @@ components:
           items:
             "$ref": "#/components/schemas/conversation_attachment_files"
           maxItems: 10
+        skip_notifications:
+          type: boolean
+          description: Option to disable notifications when replying to a conversation.
+          example: true
         skip_unsnooze:
           type: boolean
           description: When true, prevents the reply from waking a snoozed conversation.


### PR DESCRIPTION
### Why?

`skip_notifications` is documented for the conversation reply endpoint on 2.15 and 2.16 but is missing from the Preview description, so Preview looks like it does not accept the field when it does.

### How?

Adds the field to the Preview admin reply schema with the same wording and position as 2.16.

<sub>Generated with Claude Code</sub>