### PR TITLE
Add 2.16 to the Intercom-Version enum in the Preview description

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -37598,6 +37598,7 @@ components:
       - '2.13'
       - '2.14'
       - '2.15'
+      - '2.16'
       - Preview
     linked_object:
       title: Linked Object


### PR DESCRIPTION
### Why?

The `Intercom-Version` enum in the Preview description stops at 2.15, so the released 2.16 version is missing.

### How?

Adds 2.16 to the version list in the Preview description.

<sub>Generated with Claude Code</sub>