### PR TITLE
Add admin_assignee_id and team_assignee_id to conversation part and ticket part schemas

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -32089,16 +32089,16 @@ components:
           type: integer
           nullable: true
           description: The id of the teammate that this conversation_part assigned the
-            conversation to (null if the part did not assign a teammate, 0 if the part
-            removed the teammate).
+            conversation to. Null or absent when the part did not assign a teammate, and
+            0 when the part removed the teammate.
         team_assignee_id:
           type: integer
           nullable: true
           description: The id of the team that this conversation_part assigned the
-            conversation to (null if the part did not assign a team, 0 if the part
-            removed the team). A part can assign a team and a teammate at the same
-            time, for example when the team uses Round Robin distribution and the
-            teammate is resolved inline. In that case assigned_to reports only the
+            conversation to. Null or absent when the part did not assign a team, and 0
+            when the part removed the team. A part can assign a team and a teammate at
+            the same time, for example when the team uses Round Robin distribution and
+            the teammate is resolved inline. In that case assigned_to reports only the
             teammate, and these two fields report each assignee separately.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
@@ -39773,17 +39773,17 @@ components:
           type: integer
           nullable: true
           description: The id of the teammate that this ticket_part assigned the ticket
-            to (null if the part did not assign a teammate, 0 if the part removed the
-            teammate).
+            to. Null or absent when the part did not assign a teammate, and 0 when the
+            part removed the teammate.
         team_assignee_id:
           type: integer
           nullable: true
-          description: The id of the team that this ticket_part assigned the ticket to
-            (null if the part did not assign a team, 0 if the part removed the team).
-            A part can assign a team and a teammate at the same time, for example when
-            the team uses Round Robin distribution and the teammate is resolved inline.
-            In that case assigned_to reports only the teammate, and these two fields
-            report each assignee separately.
+          description: The id of the team that this ticket_part assigned the ticket to.
+            Null or absent when the part did not assign a team, and 0 when the part
+            removed the team. A part can assign a team and a teammate at the same time,
+            for example when the team uses Round Robin distribution and the teammate is
+            resolved inline. In that case assigned_to reports only the teammate, and
+            these two fields report each assignee separately.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -32094,7 +32094,7 @@ components:
             example when the team uses Round Robin distribution and the teammate is
             resolved inline. In that case assigned_to reports the teammate and this
             field reports the team. When the part removed the team, type is
-            nobody_team and id is null.
+            unassigned and id is null.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -39772,7 +39772,7 @@ components:
             can assign a team and a teammate at the same time, for example when the
             team uses Round Robin distribution and the teammate is resolved inline.
             In that case assigned_to reports the teammate and this field reports the
-            team. When the part removed the team, type is nobody_team and id is null.
+            team. When the part removed the team, type is unassigned and id is null.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -32089,16 +32089,19 @@ components:
           type: integer
           nullable: true
           description: The id of the teammate that this conversation_part assigned the
-            conversation to. Null or absent when the part did not assign a teammate, and
-            0 when the part removed the teammate.
+            conversation to, or 0 if the part removed the teammate. Null or absent when
+            the part did not change the teammate, including an unassignment that did not
+            name which assignee it cleared. A bot is reported here, because assignment
+            treats anything that is not a team as a teammate.
         team_assignee_id:
           type: integer
           nullable: true
           description: The id of the team that this conversation_part assigned the
-            conversation to. Null or absent when the part did not assign a team, and 0
-            when the part removed the team. A part can assign a team and a teammate at
-            the same time, for example when the team uses Round Robin distribution and
-            the teammate is resolved inline. In that case assigned_to reports only the
+            conversation to, or 0 if the part removed the team. Null or absent when the
+            part did not change the team, including an unassignment that did not name
+            which assignee it cleared. A part can assign a team and a teammate at the
+            same time, for example when the team uses Round Robin distribution and the
+            teammate is resolved inline. In that case assigned_to reports only the
             teammate, and these two fields report each assignee separately.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
@@ -39773,15 +39776,18 @@ components:
           type: integer
           nullable: true
           description: The id of the teammate that this ticket_part assigned the ticket
-            to. Null or absent when the part did not assign a teammate, and 0 when the
-            part removed the teammate.
+            to, or 0 if the part removed the teammate. Null or absent when the part did
+            not change the teammate, including an unassignment that did not name which
+            assignee it cleared. A bot is reported here, because assignment treats
+            anything that is not a team as a teammate.
         team_assignee_id:
           type: integer
           nullable: true
-          description: The id of the team that this ticket_part assigned the ticket to.
-            Null or absent when the part did not assign a team, and 0 when the part
-            removed the team. A part can assign a team and a teammate at the same time,
-            for example when the team uses Round Robin distribution and the teammate is
+          description: The id of the team that this ticket_part assigned the ticket to,
+            or 0 if the part removed the team. Null or absent when the part did not
+            change the team, including an unassignment that did not name which assignee
+            it cleared. A part can assign a team and a teammate at the same time, for
+            example when the team uses Round Robin distribution and the teammate is
             resolved inline. In that case assigned_to reports only the teammate, and
             these two fields report each assignee separately.
         author:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -14012,6 +14012,8 @@ paths:
                         assigned_to:
                           type: admin
                           id: '991267715'
+                        admin_assignee_id: 991267715
+                        team_assignee_id: 5017691
                         author:
                           id: '991267715'
                           type: admin
@@ -23483,6 +23485,8 @@ paths:
                         assigned_to:
                           type: admin
                           id: '991268013'
+                        admin_assignee_id: 991268013
+                        team_assignee_id: null
                         author:
                           id: '991268011'
                           type: admin
@@ -32093,6 +32097,7 @@ components:
             the part did not change the teammate, including an unassignment that did not
             name which assignee it cleared. A bot is reported here, because assignment
             treats anything that is not a team as a teammate.
+          example: 991267715
         team_assignee_id:
           type: integer
           nullable: true
@@ -32103,6 +32108,7 @@ components:
             same time, for example when the team uses Round Robin distribution and the
             teammate is resolved inline. In that case assigned_to reports only the
             teammate, and these two fields report each assignee separately.
+          example: 5017691
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -39780,6 +39786,7 @@ components:
             not change the teammate, including an unassignment that did not name which
             assignee it cleared. A bot is reported here, because assignment treats
             anything that is not a team as a teammate.
+          example: 991268013
         team_assignee_id:
           type: integer
           nullable: true
@@ -39790,6 +39797,7 @@ components:
             example when the team uses Round Robin distribution and the teammate is
             resolved inline. In that case assigned_to reports only the teammate, and
             these two fields report each assignee separately.
+          example: 5017691
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -32085,6 +32085,16 @@ components:
           nullable: true
           description: The id of the admin that was assigned the conversation by this
             conversation_part (null if there has been no change in assignment.)
+        team_assigned_to:
+          "$ref": "#/components/schemas/reference"
+          nullable: true
+          description: The team that this conversation_part assigned the conversation
+            to, when the part changed the team (null if the part did not change the
+            team). A part can assign a team and a teammate at the same time, for
+            example when the team uses Round Robin distribution and the teammate is
+            resolved inline. In that case assigned_to reports the teammate and this
+            field reports the team. When the part removed the team, type is
+            nobody_team and id is null.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -39754,6 +39764,15 @@ components:
           nullable: true
           description: The id of the admin that was assigned the ticket by this ticket_part
             (null if there has been no change in assignment.)
+        team_assigned_to:
+          "$ref": "#/components/schemas/reference"
+          nullable: true
+          description: The team that this ticket_part assigned the ticket to, when the
+            part changed the team (null if the part did not change the team). A part
+            can assign a team and a teammate at the same time, for example when the
+            team uses Round Robin distribution and the teammate is resolved inline.
+            In that case assigned_to reports the teammate and this field reports the
+            team. When the part removed the team, type is nobody_team and id is null.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -32085,16 +32085,21 @@ components:
           nullable: true
           description: The id of the admin that was assigned the conversation by this
             conversation_part (null if there has been no change in assignment.)
-        team_assigned_to:
-          "$ref": "#/components/schemas/reference"
+        admin_assignee_id:
+          type: integer
           nullable: true
-          description: The team that this conversation_part assigned the conversation
-            to, when the part changed the team (null if the part did not change the
-            team). A part can assign a team and a teammate at the same time, for
-            example when the team uses Round Robin distribution and the teammate is
-            resolved inline. In that case assigned_to reports the teammate and this
-            field reports the team. When the part removed the team, type is
-            unassigned and id is null.
+          description: The id of the teammate that this conversation_part assigned the
+            conversation to (null if the part did not assign a teammate, 0 if the part
+            removed the teammate).
+        team_assignee_id:
+          type: integer
+          nullable: true
+          description: The id of the team that this conversation_part assigned the
+            conversation to (null if the part did not assign a team, 0 if the part
+            removed the team). A part can assign a team and a teammate at the same
+            time, for example when the team uses Round Robin distribution and the
+            teammate is resolved inline. In that case assigned_to reports only the
+            teammate, and these two fields report each assignee separately.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -39764,15 +39769,21 @@ components:
           nullable: true
           description: The id of the admin that was assigned the ticket by this ticket_part
             (null if there has been no change in assignment.)
-        team_assigned_to:
-          "$ref": "#/components/schemas/reference"
+        admin_assignee_id:
+          type: integer
           nullable: true
-          description: The team that this ticket_part assigned the ticket to, when the
-            part changed the team (null if the part did not change the team). A part
-            can assign a team and a teammate at the same time, for example when the
-            team uses Round Robin distribution and the teammate is resolved inline.
-            In that case assigned_to reports the teammate and this field reports the
-            team. When the part removed the team, type is unassigned and id is null.
+          description: The id of the teammate that this ticket_part assigned the ticket
+            to (null if the part did not assign a teammate, 0 if the part removed the
+            teammate).
+        team_assignee_id:
+          type: integer
+          nullable: true
+          description: The id of the team that this ticket_part assigned the ticket to
+            (null if the part did not assign a team, 0 if the part removed the team).
+            A part can assign a team and a teammate at the same time, for example when
+            the team uses Round Robin distribution and the teammate is resolved inline.
+            In that case assigned_to reports only the teammate, and these two fields
+            report each assignee separately.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:


### PR DESCRIPTION
### Why?

A conversation part records a single assignee, so when a part assigns a conversation to both a team and a teammate at once, only the teammate was reported and the team the conversation went to was not visible on the API. Two new Preview fields report each assignee separately; this documents them.

### How?

Adds `admin_assignee_id` and `team_assignee_id` to the Preview `conversation_part` and `ticket_part` response schemas, describing when each is set, cleared, or absent.