### PR TITLE
Add DELETE /notes/{id} endpoint to the Preview spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -20167,7 +20167,8 @@ paths:
       tags:
       - Notes
       operationId: deleteNote
-      description: You can delete a single note.
+      description: You can delete a single contact or company note. Notes of other
+        kinds cannot be deleted through the API.
       responses:
         '200':
           description: successful

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -20177,7 +20177,7 @@ paths:
                 successful:
                   value:
                     id: '34'
-                    object: note
+                    type: note
                     deleted: true
               schema:
                 "$ref": "#/components/schemas/deleted_note_object"
@@ -35838,7 +35838,7 @@ components:
           description: The unique identifier for the note which you provided in
             the URL.
           example: '34'
-        object:
+        type:
           type: string
           description: The type of object which was deleted. - `note`
           enum:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -20156,7 +20156,7 @@ paths:
       - name: Intercom-Version
         in: header
         schema:
-          "$ref": "#/components/schemas/intercom_version"
+          "$ref": "#/components/schemas/intercom_version_preview"
       - name: id
         in: path
         required: true

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -20150,6 +20150,79 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+    delete:
+      summary: Delete a note
+      parameters:
+      - name: Intercom-Version
+        in: header
+        schema:
+          "$ref": "#/components/schemas/intercom_version"
+      - name: id
+        in: path
+        required: true
+        description: The unique identifier of a given note
+        example: 1
+        schema:
+          type: integer
+      tags:
+      - Notes
+      operationId: deleteNote
+      description: You can delete a single note.
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              examples:
+                successful:
+                  value:
+                    id: '34'
+                    object: note
+                    deleted: true
+              schema:
+                "$ref": "#/components/schemas/deleted_note_object"
+        '404':
+          description: Note not found
+          content:
+            application/json:
+              examples:
+                Note not found:
+                  value:
+                    type: error.list
+                    request_id: 5c1ca6c7-6f5e-4d4b-9f52-3a2e1c9d7b64
+                    errors:
+                    - code: not_found
+                      message: Resource Not Found
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                Unauthorized:
+                  value:
+                    type: error.list
+                    request_id: e3f0a9c1-2b4d-4e6a-8c7f-1d5b9a3e6f02
+                    errors:
+                    - code: unauthorized
+                      message: Access Token Invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+        '400':
+          description: Resource not available
+          content:
+            application/json:
+              examples:
+                Resource not available:
+                  value:
+                    type: error.list
+                    request_id: 9a2d6e4b-7c1f-4a83-b6d0-2f8e5c1a9b37
+                    errors:
+                    - code: intercom_version_invalid
+                      message: Requested resource is not available in current API version.
+              schema:
+                "$ref": "#/components/schemas/error"
   "/secure_mode_secrets":
     get:
       summary: List all identity verification secrets
@@ -35754,6 +35827,26 @@ components:
         deleted:
           type: boolean
           description: Whether the news item was deleted successfully or not.
+          example: true
+    deleted_note_object:
+      title: Deleted Note Object
+      type: object
+      description: Response returned when an object is deleted
+      properties:
+        id:
+          type: string
+          description: The unique identifier for the note which you provided in
+            the URL.
+          example: '34'
+        object:
+          type: string
+          description: The type of object which was deleted. - `note`
+          enum:
+          - note
+          example: note
+        deleted:
+          type: boolean
+          description: Whether the note was deleted successfully or not.
           example: true
     detach_contact_from_conversation_request:
       properties:


### PR DESCRIPTION
### Why?

The API now supports deleting a note in the Preview version, and the spec needs to document the new endpoint.

### How?

Adds the delete operation to the existing notes path with a deleted-note response schema, mirroring the other delete operations in the spec.

<sub>Generated with Claude Code</sub>