### PR TITLE
Clarify note deletion description: contact and company notes only

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -20167,7 +20167,8 @@ paths:
       tags:
       - Notes
       operationId: deleteNote
-      description: You can delete a single note.
+      description: You can delete a single contact or company note. Notes of other
+        kinds cannot be deleted through the API.
       responses:
         '200':
           description: successful


### PR DESCRIPTION
### Why?

Follow-up to #636: the note deletion description says you can delete a single note, but the endpoint only deletes contact and company notes — other kinds return 404. The docs should say so.

### How?

Updates the operation description to state the restriction.

<sub>Generated with Claude Code</sub>