### PR TITLE
Correct translated-reply webhook topic descriptions in Preview spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -32214,7 +32214,10 @@ components:
             text translated into that locale, as HTML in the same format as `body`.
             The `body` field is unchanged and always
             stays in the original source language. Available in the Preview API version
-            only (set `Intercom-Version: Preview`).
+            only (set `Intercom-Version: Preview`). This webhook topic is not sent for
+            every translated reply: it is suppressed when the reply's `body` contains
+            any text outside an HTML block element, which includes plain-text replies
+            created through the REST API.
           required:
             - original
           additionalProperties:
@@ -39880,7 +39883,10 @@ components:
             text translated into that locale, as HTML in the same format as `body`.
             The `body` field is unchanged and always
             stays in the original source language. Available in the Preview API version
-            only (set `Intercom-Version: Preview`).
+            only (set `Intercom-Version: Preview`). This webhook topic is not sent for
+            every translated reply: it is suppressed when the reply's `body` contains
+            any text outside an HTML block element, which includes plain-text replies
+            created through the REST API.
           required:
             - original
           additionalProperties:
@@ -40069,7 +40075,10 @@ components:
             text translated into that locale, as HTML in the same format as `body`.
             The `body` field is unchanged and always
             stays in the original source language. Available in the Preview API version
-            only (set `Intercom-Version: Preview`).
+            only (set `Intercom-Version: Preview`). This webhook topic is not sent for
+            every translated reply: it is suppressed when the reply's `body` contains
+            any text outside an HTML block element, which includes plain-text replies
+            created through the REST API.
           required:
             - original
           additionalProperties:


### PR DESCRIPTION
### Why?

The Preview spec's `translations` field description says it backs the `conversation.admin.replied.translated` and `ticket.admin.replied.translated` webhook topics, implying they fire for every translated admin reply. Since a gate that shipped 2026-08-24, that's no longer true: the topic is suppressed whenever the reply's body has text outside an HTML block element, which includes every plain-text reply sent through the REST API (which only accepts `body`, never `blocks`). A developer who subscribes to either topic and sends a plain-text reply gets nothing back, with no way to tell why from the current docs, even though both topics went GA on 2026-08-26.

### How?

Add a short caveat to the three affected `translations` description blocks explaining when the event is suppressed.

<sub>Generated with Claude Code</sub>