### PR TITLE
Correct the documented default page size for List contacts

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -9337,7 +9337,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -3831,7 +3831,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -3930,7 +3930,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -4444,7 +4444,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -4965,7 +4965,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -5927,7 +5927,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -5850,7 +5850,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -8923,7 +8923,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -4049,7 +4049,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -4049,7 +4049,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -4049,7 +4049,7 @@ paths:
           Contacts that have been merged (via POST /contacts/merge) will not appear in list results. Only the target contact from the merge remains accessible.
         {% /admonition %}
         {% admonition type="warning" name="Pagination" %}
-          You can use pagination to limit the number of results returned. The default is `50` results per page.
+          You can use pagination to limit the number of results returned. The default is `10` results per page, with a maximum of `150`.
           See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.
         {% /admonition %}
       responses:


### PR DESCRIPTION
### Why?

The `GET /contacts` pagination note says the default is 50 results per page, but the endpoint returns 10. The same operation's own example response already showed 10, so the description contradicted itself.

### How?

Corrects the note for List contacts across every description and documents the 150 maximum. Search contacts is unchanged — 50 really is its default.

<sub>Generated with Claude Code</sub>