### PR TITLE
Add the contact reference `email` field to the Preview spec

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -11973,6 +11973,7 @@ paths:
                         contacts:
                         - type: contact
                           id: 6762f0f31bb69f9f2193bb8b
+                          email: joe@example.com
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
@@ -12283,6 +12284,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1261bb69f9f2193bba7
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
@@ -12492,6 +12494,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1261bb69f9f2193bba7
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
@@ -12801,6 +12804,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1301bb69f9f2193bbab
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
@@ -12901,6 +12905,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1341bb69f9f2193bbac
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
@@ -13271,6 +13276,7 @@ paths:
                         contacts:
                         - type: contact
                           id: 6762f14a1bb69f9f2193bbb3
+                          email: joe@example.com
                           external_id: '70'
                       first_contact_reply:
                       admin_assignee_id: 991267715
@@ -13428,6 +13434,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1571bb69f9f2193bbbb
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                       created_at: 1734537561
@@ -13511,6 +13518,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f15b1bb69f9f2193bbbc
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
@@ -13603,6 +13611,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f15e1bb69f9f2193bbbd
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
@@ -13683,6 +13692,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1621bb69f9f2193bbbe
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                       created_at: 1734537572
@@ -13890,6 +13900,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f16e1bb69f9f2193bbc2
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
@@ -13970,6 +13981,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1711bb69f9f2193bbc3
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
@@ -14050,6 +14062,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1781bb69f9f2193bbc8
+                        email: joe@example.com
                         external_id: '74'
                     first_contact_reply:
                     admin_assignee_id: 991267715
@@ -14130,6 +14143,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1831bb69f9f2193bbcc
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                     admin_assignee_id: 991267715
@@ -14847,6 +14861,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1f81bb69f9f2193bc09
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                       created_at: 1734537722
@@ -15009,6 +15024,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1571bb69f9f2193bbbb
+                        email: joe@example.com
                         external_id: '70'
                     first_contact_reply:
                       created_at: 1734537561
@@ -15201,6 +15217,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f2041bb69f9f2193bc0c
+                        email: joe@example.com
                         external_id: '70'
                     admin_assignee_id: 0
                     team_assignee_id: 0
@@ -23079,6 +23096,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1261bb69f9f2193bba7
+                        email: joe@example.com
                         external_id: '70'
                     open: true
                     state: open
@@ -23244,6 +23262,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f1261bb69f9f2193bba7
+                        email: joe@example.com
                         external_id: '70'
                     open: true
                     state: open
@@ -23389,6 +23408,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f2d81bb69f9f2193bc54
+                        email: joe@example.com
                         external_id: '70'
                     admin_assignee_id: 0
                     team_assignee_id: 0
@@ -23631,6 +23651,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f2dd1bb69f9f2193bc55
+                        email: joe@example.com
                         external_id: 8df1fa21-b41d-4621-9229-d6f7a3a590ce
                     admin_assignee_id: 991268013
                     team_assignee_id: 0
@@ -23937,6 +23958,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 6762f2f61bb69f9f2193bc59
+                        email: joe@example.com
                         external_id: b16afa36-2637-4880-adee-a46d145bc27f
                     admin_assignee_id: 0
                     team_assignee_id: 0
@@ -24122,6 +24144,7 @@ paths:
                       contacts:
                       - type: contact
                         id: 667d61c88a68186f43bafe93
+                        email: joe@example.com
                         external_id: '71'
                     admin_assignee_id: 0
                     team_assignee_id: 0
@@ -24402,6 +24425,7 @@ paths:
                         contacts:
                         - type: contact
                           id: 6762f3061bb69f9f2193bc5b
+                          email: joe@example.com
                           external_id: 9b913927-c084-4391-b1db-098341b5ffe3
                       admin_assignee_id: 0
                       team_assignee_id: 0
@@ -30688,6 +30712,11 @@ components:
           description: The unique identifier for the contact which is provided by
             the Client.
           example: "70"
+        email:
+          type: string
+          nullable: true
+          description: The contact's email.
+          example: joe@example.com
     contact_reply_base_request:
       title: Contact Reply Base Object
       type: object


### PR DESCRIPTION
### Why?

The Preview API returns a contact's email address in the contact references listed on a conversation or a ticket, but the spec did not describe it, so generated SDKs and the reference docs both dropped the field.

### How?

Adds the property to the shared contact reference schema and to the response examples that show one, mirroring the change made in the docs repo.

Closes gap tracked in:
- https://github.com/intercom/intercom/issues/559299

<sub>Generated with Claude Code</sub>
