### PR TITLE
Document `event_details` on standalone platform handoff parts (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -12447,7 +12447,31 @@ paths:
                         event_details:
                           call_id: '3822007689'
                         app_package_code: null
-                      total_count: 5
+                      - type: conversation_part
+                        id: 6
+                        part_type: standalone_platform_handoff
+                        body:
+                        created_at: 1740141910
+                        updated_at: 1740141910
+                        notified_at: 1740141910
+                        assigned_to:
+                        author:
+                          type: bot
+                          id: '278'
+                          name: Fin
+                          email: operator+abcd1234@intercom.io
+                        attachments: []
+                        external_id:
+                        redacted: false
+                        email_message_metadata: null
+                        state: closed
+                        tags: []
+                        event_details:
+                          handoff:
+                            type: zendesk_ticket
+                            success: true
+                        app_package_code: null
+                      total_count: 6
                 email conversation with history found:
                   value:
                     type: conversation
@@ -36662,6 +36686,26 @@ components:
           type: string
           description: The id of the call the summary describes
           example: "3822007689"
+    standalone_platform_handoff:
+      title: Part type - standalone_platform_handoff
+      type: object
+      description: Contains the escalation target Fin handed the conversation off to, for conversation part type <code>standalone_platform_handoff</code>.
+      properties:
+        handoff:
+          type: object
+          description: The escalation Fin attempted.
+          properties:
+            type:
+              type: string
+              description: Where Fin handed the conversation off to. <code>zendesk_ticket</code> means a Zendesk ticket was created, and <code>zendesk_agent</code> means the conversation was handed over to a Zendesk agent for live chat.
+              enum:
+              - zendesk_ticket
+              - zendesk_agent
+              example: zendesk_ticket
+            success:
+              type: boolean
+              description: Whether the handoff completed. A handoff that did not complete falls back to a live agent, which is reported in a separate successful part.
+              example: true
     event_details:
       title: Event details of Workflow & actions
       type: object
@@ -36682,6 +36726,7 @@ components:
         - "$ref": "#/components/schemas/conversation_sla_unpaused"
         - "$ref": "#/components/schemas/conversation_sla_removed"
         - "$ref": "#/components/schemas/call_summary"
+        - "$ref": "#/components/schemas/standalone_platform_handoff"
     email_setting:
       type: object
       title: Email Setting


### PR DESCRIPTION
### Why?

A conversation part recording a Fin handoff to Zendesk returns details of where the conversation went, but the spec did not describe them, so generated SDKs and the reference docs both dropped the field.

### How?

Adds a handoff detail schema, references it from the shared event details, and shows it in a conversation example, mirroring the change made in the docs repo.

Closes gap tracked in:
- https://github.com/intercom/intercom/issues/559299

<sub>Generated with Claude Code</sub>
