### PR TITLE
Correct part assigned_to: it returns a reference, and can name a team or bot

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -32323,8 +32323,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         admin_assignee_id:
           type: integer
           nullable: true
@@ -40035,8 +40037,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the ticket by this ticket_part
-            (null if there has been no change in assignment.)
+          description: The assignee this ticket_part assigned the ticket to, as a reference
+            whose `type` is `admin`, `team` or `bot`. When the part unassigned the ticket,
+            `type` is `nobody_admin` and `id` is `null`. Null when the part did not change
+            the assignment, or when the assignee has since been deleted.
         admin_assignee_id:
           type: integer
           nullable: true

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -12331,8 +12331,6 @@ paths:
                         updated_at: 1663597260
                         notified_at: 1663597260
                         assigned_to:
-                          type: contact
-                          id: '1a2b3c'
                         author:
                           type: admin
                           id: '274'
@@ -12540,8 +12538,6 @@ paths:
                         updated_at: 1663597260
                         notified_at: 1663597260
                         assigned_to:
-                          type: contact
-                          id: '1a2b3c'
                         author:
                           type: admin
                           id: '274'

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -13299,8 +13299,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -16445,8 +16447,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the ticket by this ticket_part
-            (null if there has been no change in assignment.)
+          description: The assignee this ticket_part assigned the ticket to, as a reference
+            whose `type` is `admin`, `team` or `bot`. When the part unassigned the ticket,
+            `type` is `nobody_admin` and `id` is `null`. Null when the part did not change
+            the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -14074,8 +14074,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -18226,8 +18228,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the ticket by this ticket_part
-            (null if there has been no change in assignment.)
+          description: The assignee this ticket_part assigned the ticket to, as a reference
+            whose `type` is `admin`, `team` or `bot`. When the part unassigned the ticket,
+            `type` is `nobody_admin` and `id` is `null`. Null when the part did not change
+            the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -14363,8 +14363,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -17833,8 +17835,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the ticket by this ticket_part
-            (null if there has been no change in assignment.)
+          description: The assignee this ticket_part assigned the ticket to, as a reference
+            whose `type` is `admin`, `team` or `bot`. When the part unassigned the ticket,
+            `type` is `nobody_admin` and `id` is `null`. Null when the part did not change
+            the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -5901,8 +5901,6 @@ paths:
                         updated_at: 1663597260
                         notified_at: 1663597260
                         assigned_to:
-                          type: contact
-                          id: '1a2b3c'
                         author:
                           type: admin
                           id: '274'

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -15801,8 +15801,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -19516,8 +19518,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the ticket by this ticket_part
-            (null if there has been no change in assignment.)
+          description: The assignee this ticket_part assigned the ticket to, as a reference
+            whose `type` is `admin`, `team` or `bot`. When the part unassigned the ticket,
+            `type` is `nobody_admin` and `id` is `null`. Null when the part did not change
+            the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -17529,8 +17529,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -22177,8 +22179,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the ticket by this ticket_part
-            (null if there has been no change in assignment.)
+          description: The assignee this ticket_part assigned the ticket to, as a reference
+            whose `type` is `admin`, `team` or `bot`. When the part unassigned the ticket,
+            `type` is `nobody_admin` and `id` is `null`. Null when the part did not change
+            the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -6870,8 +6870,6 @@ paths:
                         updated_at: 1663597260
                         notified_at: 1663597260
                         assigned_to:
-                          type: contact
-                          id: '1a2b3c'
                         author:
                           type: admin
                           id: '274'

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -6793,8 +6793,6 @@ paths:
                         updated_at: 1663597260
                         notified_at: 1663597260
                         assigned_to:
-                          type: contact
-                          id: '1a2b3c'
                         author:
                           type: admin
                           id: '274'

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -18329,8 +18329,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -23186,8 +23188,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the ticket by this ticket_part
-            (null if there has been no change in assignment.)
+          description: The assignee this ticket_part assigned the ticket to, as a reference
+            whose `type` is `admin`, `team` or `bot`. When the part unassigned the ticket,
+            `type` is `nobody_admin` and `id` is `null`. Null when the part did not change
+            the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -27264,8 +27264,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -33973,8 +33975,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the ticket by this ticket_part
-            (null if there has been no change in assignment.)
+          description: The assignee this ticket_part assigned the ticket to, as a reference
+            whose `type` is `admin`, `team` or `bot`. When the part unassigned the ticket,
+            `type` is `nobody_admin` and `id` is `null`. Null when the part did not change
+            the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -11073,8 +11073,6 @@ paths:
                         updated_at: 1663597260
                         notified_at: 1663597260
                         assigned_to:
-                          type: contact
-                          id: '1a2b3c'
                         author:
                           type: admin
                           id: '274'

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -11400,8 +11400,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -11424,8 +11424,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -12604,8 +12604,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the conversation by this
-            conversation_part (null if there has been no change in assignment.)
+          description: The assignee this conversation_part assigned the conversation to, as
+            a reference whose `type` is `admin`, `team` or `bot`. When the part unassigned
+            the conversation, `type` is `nobody_admin` and `id` is `null`. Null when the
+            part did not change the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/conversation_part_author"
         attachments:
@@ -15826,8 +15828,10 @@ components:
         assigned_to:
           "$ref": "#/components/schemas/reference"
           nullable: true
-          description: The id of the admin that was assigned the ticket by this ticket_part
-            (null if there has been no change in assignment.)
+          description: The assignee this ticket_part assigned the ticket to, as a reference
+            whose `type` is `admin`, `team` or `bot`. When the part unassigned the ticket,
+            `type` is `nobody_admin` and `id` is `null`. Null when the part did not change
+            the assignment, or when the assignee has since been deleted.
         author:
           "$ref": "#/components/schemas/ticket_part_author"
         attachments:


### PR DESCRIPTION
### Why?

The spec described a conversation or ticket part's `assigned_to` as the id of the admin the part assigned. It is really an object whose type can be a team or a bot as well as an admin, so a part that routed a conversation to a team looked like it reported nothing, and the value returned when a part unassigns was documented nowhere.

### How?

Rewrites the description on both part schemas so it names the object, the three kinds of assignee it can hold, and what an unassignment returns, and clears the comment-part examples that showed a contact as the assignee. Every published version returns the same shape here, so the correction covers all of them rather than the Preview version alone.

<sub>Generated with Claude Code</sub>