### PR TITLE
Add transform_code_block field to Data Connector (Detail) schema

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -17246,7 +17246,12 @@ paths:
                     - leads
                     execution_type: server_side
                     configuration_response_type: test_response_type
-                    data_transformation_type:
+                    data_transformation_type: code_block_transformation
+                    transform_code_block:
+                      code: |
+                        def transform(response):
+                            return {"status": response["order_status"]}
+                      language: python
                     client_function_name:
                     client_function_timeout_ms:
                     data_inputs:
@@ -17461,6 +17466,7 @@ paths:
                     execution_type: server_side
                     configuration_response_type: test_response_type
                     data_transformation_type:
+                    transform_code_block:
                     client_function_name:
                     client_function_timeout_ms:
                     data_inputs:
@@ -35295,6 +35301,25 @@ components:
           - full_access
           - redacted_access
           - code_block_transformation
+        transform_code_block:
+          type: object
+          nullable: true
+          description: |
+            The code block used to transform the connector's response when `data_transformation_type` is
+            `code_block_transformation`. Omitted if the connector has no transform code block configured.
+          properties:
+            code:
+              type: string
+              description: The source code of the transform code block.
+              example: |
+                def transform(response):
+                    return {"status": response["order_status"]}
+            language:
+              type: string
+              description: The programming language of the transform code block.
+              enum:
+              - python
+              example: python
         client_function_name:
           type: string
           nullable: true

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -35316,9 +35316,7 @@ components:
                     return {"status": response["order_status"]}
             language:
               type: string
-              description: The programming language of the transform code block.
-              enum:
-              - python
+              description: The programming language of the transform code block. Currently always `python`.
               example: python
         client_function_name:
           type: string

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -17466,7 +17466,6 @@ paths:
                     execution_type: server_side
                     configuration_response_type: test_response_type
                     data_transformation_type:
-                    transform_code_block:
                     client_function_name:
                     client_function_timeout_ms:
                     data_inputs:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -35306,6 +35306,11 @@ components:
           description: |
             The code block used to transform the connector's response when `data_transformation_type` is
             `code_block_transformation`. Omitted if the connector has no transform code block configured.
+          example:
+            code: |
+              def transform(response):
+                  return {"status": response["order_status"]}
+            language: python
           properties:
             code:
               type: string


### PR DESCRIPTION
### Why?

Data connectors that transform their response with a code block didn't expose that code anywhere in the API, so consumers had no way to see how the response was being transformed. This adds visibility into that step wherever a connector's full detail is returned.

### How?

Adds a new optional field to the data connector detail schema containing the code block's source and language when one is configured, with matching example updates.

<sub>Generated with Claude Code</sub>