### PR TITLE
docs: add skip_reopen to assign_conversation_request schema (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -28787,6 +28787,7 @@ components:
           example: Let me pass you over to one of my colleagues.
         skip_reopen:
           type: boolean
+          default: false
           description: When true, assigning a closed conversation leaves it closed
             instead of reopening it. No reopen event is recorded, so the conversation
             keeps its original close timestamp and the assignment does not count as

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -28785,6 +28785,13 @@ components:
           description: Optionally you can send a response in the conversation when
             it is assigned.
           example: Let me pass you over to one of my colleagues.
+        skip_reopen:
+          type: boolean
+          description: When true, assigning a closed conversation leaves it closed
+            instead of reopening it. No reopen event is recorded, so the conversation
+            keeps its original close timestamp and the assignment does not count as
+            a new closure in reporting.
+          example: true
       required:
       - message_type
       - type


### PR DESCRIPTION
### Why?

Assigning a closed conversation reopens it, so closing it again writes a new close timestamp and counts as another closure in reporting. That makes it hard to reassign a batch of closed conversations — after a teammate leaves, or when retiring an inbox — without skewing closure metrics. A new opt-in parameter lets a caller assign a closed conversation and leave it closed, and it needs documenting.

### How?

Adds the parameter to the assignment request schema in the Preview spec.

<details>
<summary>Notes for reviewers</summary>

Documented on the assignment schema rather than the reply schema. The parameter also applies to a reply carrying an assignee, but the reply schema does not document an assignee field, so documenting it there would describe an effect that depends on an undocumented field.

</details>

<sub>Generated with Claude Code</sub>