### PR TITLE
security: bump brace-expansion for GHSA-mh99-v99m-4gvg

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,11 +366,11 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2491,12 +2491,12 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -3560,11 +3560,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Bumps the transitive `brace-expansion` dependency out of the range flagged by
GHSA-mh99-v99m-4gvg (CVE-2026-14257, High).

`expand()` caps how many results it produces but not how long they get, so a
few KB of chained brace groups is enough to exhaust memory and kill the Node
process. The OOM is fatal, so wrapping the call in `try/catch` does not help.
Anything that feeds attacker-influenced strings into brace patterns through
`minimatch` or `glob` can be crashed this way.

Lockfile only. `brace-expansion` is not a direct dependency here, and
`minimatch` (the only consumer) declares a caret range that the new version
already satisfies, so no manifest needed changing.

The versions here are 1.1.18 / 2.1.4 / 5.0.9, not the 1.1.17 / 2.1.3 / 5.0.8
this advisory names. The higher set clears the other brace-expansion advisories
that are open at the same time, and the dependency set is unchanged within each
major line either way.

Worth knowing if you are still on Node 18: brace-expansion raised its engines
floor to `20 || >=22` in 5.0.8, so any fix in the 5.x line brings that with it.
It warns rather than fails unless you run engine-strict.

To check nothing else moved, I stripped every brace-expansion entry out of the
old and new lockfiles and confirmed the remainder was byte-identical, then ran a
frozen-lockfile install to verify the integrity hashes against the registry.
