### PR TITLE
Document setting ticket priority on the update endpoint (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -23824,6 +23824,7 @@ paths:
                   open: true
                   snoozed_until: 1673609604
                   ticket_state_id: 8498
+                  priority: high
               admin_not_found:
                 summary: Admin not found
                 value:
@@ -41297,6 +41298,18 @@ components:
           description: The ID of the admin or team to which the ticket is assigned.
             Set this 0 to unassign it.
           example: '123'
+        priority:
+          type: string
+          enum:
+          - none
+          - low
+          - medium
+          - high
+          - urgent
+          description: The priority level to set on the ticket. Accepts one of none,
+            low, medium, high, or urgent. Set none to clear an existing priority. The
+            change is attributed to admin_id, or to Operator when admin_id is omitted.
+          example: high
     update_ticket_type_attribute_request:
       description: You can update a Ticket Type Attribute
       type: object

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -23801,6 +23801,34 @@ paths:
                       message: Access Token Invalid
               schema:
                 "$ref": "#/components/schemas/error"
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              examples:
+                Teammate without Inbox access:
+                  value:
+                    type: error.list
+                    request_id: 8e4a1ee0-2a4c-4a9f-9c3f-1c2b6d7e5f01
+                    errors:
+                    - code: action_forbidden
+                      message: This admin does not have Inbox access permissions
+              schema:
+                "$ref": "#/components/schemas/error"
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              examples:
+                Unrecognised priority level:
+                  value:
+                    type: error.list
+                    request_id: 3f6c9b21-7d58-4e0a-8b44-5a9e2c1d7b03
+                    errors:
+                    - code: parameter_invalid
+                      message: 'priority must be one of: none, low, medium, high, urgent'
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
### Why?

Priority can already be set on a conversation through the API, but not on a ticket, so an integration that triages tickets in its own tooling had nothing to write back to. This documents the other half.

### How?

Adds the priority level to the Preview update-ticket request body and example, and declares the two error responses the field can produce.

<details>
<summary>Notes for reviewers</summary>

- Affected versions: **Preview only**. No dated version changes.
- The spec addition is byte-identical to the developer-docs copy — diffed to confirm the two stay in step.
- Tickets already document a top-level attribution field, so unlike the conversation change this adds one property, not two.
- `403` and `422` were not declared on this operation before. The codes and messages match what the endpoint actually returns.
- The ticket response has no priority field, so this covers the write only.
- Rebased on main after the two schema additions that landed today.

</details>

<sub>Generated with Claude Code</sub>