### PR TITLE
Document reading a ticket's priority back from the API (Preview)

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -39966,6 +39966,17 @@ components:
             change. Returns null if no state change history exists. Useful for tracking
             state transitions for reporting and compliance.
           example: '7493'
+        priority:
+          type: string
+          enum:
+          - none
+          - low
+          - medium
+          - high
+          - urgent
+          description: The priority level of the ticket. Returns one of none, low,
+            medium, high, or urgent.
+          example: high
     ticket_deleted:
       title: Ticket Deleted
       type: object


### PR DESCRIPTION
### Why?

Setting a ticket's priority is already documented, but nothing describes reading it back, so an integration that writes a level has no documented way to confirm it stuck short of fetching the underlying conversation. The ticket schema omits the field entirely, which stops being accurate once the read side ships.

### How?

Adds the priority level to the Preview ticket response schema, copying the shape the conversation object already uses.

<details>
<summary>Notes for reviewers</summary>

- Affected versions: **Preview only**. No dated version changes.
- Draft on purpose. This should only merge once the API change has shipped, or the spec will describe a field that isn't being returned yet.
- The spec addition is byte-identical to the developer-docs copy, diffed to confirm the two stay in step.
- The five levels and the description are lifted from the conversation object's existing priority field.

Spec mirror, merge alongside this one:
- https://github.com/intercom/developer-docs/pull/1128

Follows on from:
- #647

</details>

<sub>Generated with Claude Code</sub>