### PR TITLE
Remove stray customer object from detach-contact request examples

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -14631,26 +14631,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991267739
-                  customer:
-                    intercom_user_id: 6762f1a61bb69f9f2193bbd8
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991267742
-                  customer:
-                    intercom_user_id: 6762f1b61bb69f9f2193bbe1
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991267745
-                  customer:
-                    intercom_user_id: 6762f1c41bb69f9f2193bbe9
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991267748
-                  customer:
-                    intercom_user_id: 6762f1d11bb69f9f2193bbf1
   "/conversations/{id}/handling_events":
     get:
       summary: List handling events

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -6150,26 +6150,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991268034
-                  customer:
-                    intercom_user_id: 6657acd36abd0166b52ae29a
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991268037
-                  customer:
-                    intercom_user_id: 6657acdc6abd0166b52ae2a3
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991268040
-                  customer:
-                    intercom_user_id: 6657ace46abd0166b52ae2ab
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991268043
-                  customer:
-                    intercom_user_id: 6657acec6abd0166b52ae2b3
   "/conversations/redact":
     post:
       summary: Redact a conversation part

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -6260,26 +6260,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991267639
-                  customer:
-                    intercom_user_id: 667d611c8a68186f43bafe11
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991267642
-                  customer:
-                    intercom_user_id: 667d61248a68186f43bafe1a
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991267645
-                  customer:
-                    intercom_user_id: 667d612b8a68186f43bafe22
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991267648
-                  customer:
-                    intercom_user_id: 667d61338a68186f43bafe2a
   "/conversations/redact":
     post:
       summary: Redact a conversation part

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -6670,26 +6670,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991266492
-                  customer:
-                    intercom_user_id: 677c55f76abd011ad17ff545
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991266495
-                  customer:
-                    intercom_user_id: 677c56026abd011ad17ff54e
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991266498
-                  customer:
-                    intercom_user_id: 677c560c6abd011ad17ff556
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991266501
-                  customer:
-                    intercom_user_id: 677c56176abd011ad17ff55e
   "/conversations/redact":
     post:
       summary: Redact a conversation part

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -7655,26 +7655,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991266492
-                  customer:
-                    intercom_user_id: 677c55f76abd011ad17ff545
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991266495
-                  customer:
-                    intercom_user_id: 677c56026abd011ad17ff54e
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991266498
-                  customer:
-                    intercom_user_id: 677c560c6abd011ad17ff556
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991266501
-                  customer:
-                    intercom_user_id: 677c56176abd011ad17ff55e
   "/conversations/redact":
     post:
       summary: Redact a conversation part

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -8638,26 +8638,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991267739
-                  customer:
-                    intercom_user_id: 6762f1a61bb69f9f2193bbd8
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991267742
-                  customer:
-                    intercom_user_id: 6762f1b61bb69f9f2193bbe1
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991267745
-                  customer:
-                    intercom_user_id: 6762f1c41bb69f9f2193bbe9
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991267748
-                  customer:
-                    intercom_user_id: 6762f1d11bb69f9f2193bbf1
   "/conversations/redact":
     post:
       summary: Redact a conversation part

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -8561,26 +8561,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991267739
-                  customer:
-                    intercom_user_id: 6762f1a61bb69f9f2193bbd8
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991267742
-                  customer:
-                    intercom_user_id: 6762f1b61bb69f9f2193bbe1
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991267745
-                  customer:
-                    intercom_user_id: 6762f1c41bb69f9f2193bbe9
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991267748
-                  customer:
-                    intercom_user_id: 6762f1d11bb69f9f2193bbf1
   "/conversations/{id}/handling_events":
     get:
       summary: List handling events

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -12876,26 +12876,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991267739
-                  customer:
-                    intercom_user_id: 6762f1a61bb69f9f2193bbd8
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991267742
-                  customer:
-                    intercom_user_id: 6762f1b61bb69f9f2193bbe1
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991267745
-                  customer:
-                    intercom_user_id: 6762f1c41bb69f9f2193bbe9
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991267748
-                  customer:
-                    intercom_user_id: 6762f1d11bb69f9f2193bbf1
   "/conversations/{id}/handling_events":
     get:
       summary: List handling events

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -6282,26 +6282,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991266472
-                  customer:
-                    intercom_user_id: 6657a8a46abd0160d35d1ef6
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991266475
-                  customer:
-                    intercom_user_id: 6657a8ac6abd0160d35d1eff
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991266478
-                  customer:
-                    intercom_user_id: 6657a8b56abd0160d35d1f07
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991266481
-                  customer:
-                    intercom_user_id: 6657a8bd6abd0160d35d1f0f
   "/conversations/redact":
     post:
       summary: Redact a conversation part

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -6282,26 +6282,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991266986
-                  customer:
-                    intercom_user_id: 6657a9fc6abd01639cc9e9f7
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991266989
-                  customer:
-                    intercom_user_id: 6657aa046abd01639cc9ea00
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991266992
-                  customer:
-                    intercom_user_id: 6657aa0b6abd01639cc9ea08
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991266995
-                  customer:
-                    intercom_user_id: 6657aa136abd01639cc9ea10
   "/conversations/redact":
     post:
       summary: Redact a conversation part

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -6294,26 +6294,18 @@ paths:
                 summary: Detach a contact from a group conversation
                 value:
                   admin_id: 991267500
-                  customer:
-                    intercom_user_id: 6657ab5c6abd0164c24b0d81
               conversation_not_found:
                 summary: Conversation not found
                 value:
                   admin_id: 991267503
-                  customer:
-                    intercom_user_id: 6657ab656abd0164c24b0d8a
               contact_not_found:
                 summary: Contact not found
                 value:
                   admin_id: 991267506
-                  customer:
-                    intercom_user_id: 6657ab6c6abd0164c24b0d92
               last_customer:
                 summary: Last customer
                 value:
                   admin_id: 991267509
-                  customer:
-                    intercom_user_id: 6657ab736abd0164c24b0d9a
   "/conversations/redact":
     post:
       summary: Redact a conversation part


### PR DESCRIPTION
### Why?

The request-body examples for detaching a contact from a group conversation included a `customer` object. That field isn't part of the request schema and the endpoint ignores it — the contact to detach comes from the URL — so the examples told readers to send something that does nothing, and named a different contact in the body than in the path.

### How?

Removes that object from all four request examples on the operation, across Preview and v2.7–v2.16, leaving only the admin id the endpoint actually reads.

<sub>Generated with Claude Code</sub>