### PR TITLE
Clarify company_id validation on update_ticket_request

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -41292,7 +41292,10 @@ components:
         company_id:
           type: string
           description: The ID of the company that the ticket is associated with. The
-            unique identifier for the company which is given by Intercom. Set to nil to remove company.
+            unique identifier for the company which is given by Intercom. The company
+            must be associated with one of the contacts on the ticket, otherwise the
+            request will fail with a `parameter_invalid` error. Set to nil to remove
+            company.
           example: 5f4d3c1c-7b1b-4d7d-a97e-6095715c6632
         open:
           type: boolean


### PR DESCRIPTION
### Why?

The Update Ticket endpoint rejects a `company_id` with a `parameter_invalid` error unless the company is already associated with one of the contacts on the ticket. The existing description didn't mention this, so callers could hit the error without knowing why.

### How?

Extends the `company_id` field description on the `update_ticket_request` schema (Preview spec) to state this requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)