### PR TITLE
Clarify that <div> still suppresses the translated-reply webhook topic

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -32648,6 +32648,9 @@ components:
             every translated reply: it is suppressed when the reply's `body` contains
             any text outside an HTML block element, which includes plain-text replies
             created through the REST API.
+            Wrap the body in `<p>` or another supported block element to avoid this;
+            `<div>` is removed when the reply is saved, which leaves its text bare and
+            still suppresses the topic.
           required:
             - original
           additionalProperties:
@@ -40361,6 +40364,9 @@ components:
             every translated reply: it is suppressed when the reply's `body` contains
             any text outside an HTML block element, which includes plain-text replies
             created through the REST API.
+            Wrap the body in `<p>` or another supported block element to avoid this;
+            `<div>` is removed when the reply is saved, which leaves its text bare and
+            still suppresses the topic.
           required:
             - original
           additionalProperties:
@@ -40553,6 +40559,9 @@ components:
             every translated reply: it is suppressed when the reply's `body` contains
             any text outside an HTML block element, which includes plain-text replies
             created through the REST API.
+            Wrap the body in `<p>` or another supported block element to avoid this;
+            `<div>` is removed when the reply is saved, which leaves its text bare and
+            still suppresses the topic.
           required:
             - original
           additionalProperties:


### PR DESCRIPTION
### Why?

A caveat added in #638 says this webhook topic is suppressed when the reply's `body` has text outside an HTML block element. An automated review on the companion developer-docs pull request flagged that this reads as an invitation to wrap that text in a `<div>` — but `<div>` isn't one of the HTML elements the admin reply content sanitizer allows, so it's stripped when the reply saves, leaving the text bare and the topic still suppressed. This sentence closes that trap before a developer hits it.

### How?

Appends the same clarifying sentence to the three admin-reply `translations` field descriptions in the Preview spec; prose only, no schema or behavior change. A matching update is going into intercom/developer-docs#1133.

<sub>Generated with Claude Code</sub>