### PR TITLE
Correct the 200 response schema for attaching and detaching a contact

### DIFF
--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -14556,7 +14556,7 @@ paths:
                     - type: user
                       id: 6762f19b1bb69f9f2193bbd4
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -14661,7 +14661,7 @@ paths:
                     - type: user
                       id: 6762f1b41bb69f9f2193bbe0
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -28972,25 +28972,25 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type
@@ -29714,7 +29714,7 @@ components:
             properties:
               id:
                 type: string
-                description: The unique identifier for the contact.
+                description: The unique identifier for the participant.
                 example: abc123
         job:
           type: object
@@ -29743,7 +29743,7 @@ components:
             properties:
               id:
                 type: string
-                description: The unique identifier for the contact.
+                description: The unique identifier for the participant.
                 example: abc123
               external_id:
                 type: string

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -29714,7 +29714,7 @@ components:
             properties:
               id:
                 type: string
-                description: The unique identifier for the participant.
+                description: The unique identifier for the contact.
                 example: abc123
         job:
           type: object
@@ -29743,7 +29743,7 @@ components:
             properties:
               id:
                 type: string
-                description: The unique identifier for the participant.
+                description: The unique identifier for the contact.
                 example: abc123
               external_id:
                 type: string

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -28986,7 +28986,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -28995,6 +28995,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     team_metric:

--- a/descriptions/0/api.intercom.io.yaml
+++ b/descriptions/0/api.intercom.io.yaml
@@ -14556,7 +14556,7 @@ paths:
                     - type: user
                       id: 6762f19b1bb69f9f2193bbd4
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -14661,7 +14661,7 @@ paths:
                     - type: user
                       id: 6762f1b41bb69f9f2193bbe0
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -28972,6 +28972,31 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     team_metric:
       type: object
       description: Per-admin activity metrics within a team.

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -5971,7 +5971,7 @@ paths:
                     - type: user
                       id: 6657accd6abd0166b52ae296
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -6076,7 +6076,7 @@ paths:
                     - type: user
                       id: 6657acdb6abd0166b52ae2a2
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -11937,6 +11937,31 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     close_conversation_request:
       title: Close Conversation Request
       type: object

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -11951,7 +11951,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -11960,6 +11960,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     close_conversation_request:

--- a/descriptions/2.10/api.intercom.io.yaml
+++ b/descriptions/2.10/api.intercom.io.yaml
@@ -5971,7 +5971,7 @@ paths:
                     - type: user
                       id: 6657accd6abd0166b52ae296
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -6076,7 +6076,7 @@ paths:
                     - type: user
                       id: 6657acdb6abd0166b52ae2a2
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -11937,25 +11937,25 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -12193,7 +12193,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -12202,6 +12202,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     button_component:

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -6081,7 +6081,7 @@ paths:
                     - type: user
                       id: 667d61168a68186f43bafe0d
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -6186,7 +6186,7 @@ paths:
                     - type: user
                       id: 667d61228a68186f43bafe19
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -12179,6 +12179,31 @@ components:
                 nullable: true
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     button_component:
       title: Button Component
       type: object

--- a/descriptions/2.11/api.intercom.io.yaml
+++ b/descriptions/2.11/api.intercom.io.yaml
@@ -6081,7 +6081,7 @@ paths:
                     - type: user
                       id: 667d61168a68186f43bafe0d
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -6186,7 +6186,7 @@ paths:
                     - type: user
                       id: 667d61228a68186f43bafe19
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -12179,25 +12179,25 @@ components:
                 nullable: true
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -12857,7 +12857,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -12866,6 +12866,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     close_conversation_request:

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -6491,7 +6491,7 @@ paths:
                     - type: user
                       id: 677c55ef6abd011ad17ff541
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -6596,7 +6596,7 @@ paths:
                     - type: user
                       id: 677c56016abd011ad17ff54d
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -12843,6 +12843,31 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     close_conversation_request:
       title: Close Conversation Request
       type: object

--- a/descriptions/2.12/api.intercom.io.yaml
+++ b/descriptions/2.12/api.intercom.io.yaml
@@ -6491,7 +6491,7 @@ paths:
                     - type: user
                       id: 677c55ef6abd011ad17ff541
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -6596,7 +6596,7 @@ paths:
                     - type: user
                       id: 677c56016abd011ad17ff54d
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -12843,25 +12843,25 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -14308,7 +14308,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -14317,6 +14317,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     close_conversation_request:

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -7476,7 +7476,7 @@ paths:
                     - type: user
                       id: 677c55ef6abd011ad17ff541
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -7581,7 +7581,7 @@ paths:
                     - type: user
                       id: 677c56016abd011ad17ff54d
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -14294,6 +14294,31 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     close_conversation_request:
       title: Close Conversation Request
       type: object

--- a/descriptions/2.13/api.intercom.io.yaml
+++ b/descriptions/2.13/api.intercom.io.yaml
@@ -7476,7 +7476,7 @@ paths:
                     - type: user
                       id: 677c55ef6abd011ad17ff541
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -7581,7 +7581,7 @@ paths:
                     - type: user
                       id: 677c56016abd011ad17ff54d
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -14294,25 +14294,25 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -15965,7 +15965,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -15974,6 +15974,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     away_status_reason:

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -8459,7 +8459,7 @@ paths:
                     - type: user
                       id: 6762f19b1bb69f9f2193bbd4
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -8564,7 +8564,7 @@ paths:
                     - type: user
                       id: 6762f1b41bb69f9f2193bbe0
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -15951,25 +15951,25 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type

--- a/descriptions/2.14/api.intercom.io.yaml
+++ b/descriptions/2.14/api.intercom.io.yaml
@@ -8459,7 +8459,7 @@ paths:
                     - type: user
                       id: 6762f19b1bb69f9f2193bbd4
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -8564,7 +8564,7 @@ paths:
                     - type: user
                       id: 6762f1b41bb69f9f2193bbe0
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -15951,6 +15951,31 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     away_status_reason:
       type: object
       properties:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -8382,7 +8382,7 @@ paths:
                     - type: user
                       id: 6762f19b1bb69f9f2193bbd4
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -8487,7 +8487,7 @@ paths:
                     - type: user
                       id: 6762f1b41bb69f9f2193bbe0
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -16636,6 +16636,31 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     brand:
       type: object
       title: Brand

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -16650,7 +16650,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -16659,6 +16659,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     brand:

--- a/descriptions/2.15/api.intercom.io.yaml
+++ b/descriptions/2.15/api.intercom.io.yaml
@@ -8382,7 +8382,7 @@ paths:
                     - type: user
                       id: 6762f19b1bb69f9f2193bbd4
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -8487,7 +8487,7 @@ paths:
                     - type: user
                       id: 6762f1b41bb69f9f2193bbe0
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -16636,25 +16636,25 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -24394,7 +24394,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -24403,6 +24403,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     brand:

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -12697,7 +12697,7 @@ paths:
                     - type: user
                       id: 6762f19b1bb69f9f2193bbd4
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -12802,7 +12802,7 @@ paths:
                     - type: user
                       id: 6762f1b41bb69f9f2193bbe0
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -24380,6 +24380,31 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     brand:
       type: object
       title: Brand

--- a/descriptions/2.16/api.intercom.io.yaml
+++ b/descriptions/2.16/api.intercom.io.yaml
@@ -12697,7 +12697,7 @@ paths:
                     - type: user
                       id: 6762f19b1bb69f9f2193bbd4
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -12802,7 +12802,7 @@ paths:
                     - type: user
                       id: 6762f1b41bb69f9f2193bbe0
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -24380,25 +24380,25 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -10061,7 +10061,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -10070,6 +10070,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     close_conversation_request:

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -6103,7 +6103,7 @@ paths:
                     - type: user
                       id: 6657a89e6abd0160d35d1ef2
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -6208,7 +6208,7 @@ paths:
                     - type: user
                       id: 6657a8ab6abd0160d35d1efe
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -10047,6 +10047,31 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     close_conversation_request:
       title: Close Conversation Request
       type: object

--- a/descriptions/2.7/api.intercom.io.yaml
+++ b/descriptions/2.7/api.intercom.io.yaml
@@ -6103,7 +6103,7 @@ paths:
                     - type: user
                       id: 6657a89e6abd0160d35d1ef2
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -6208,7 +6208,7 @@ paths:
                     - type: user
                       id: 6657a8ab6abd0160d35d1efe
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -10047,25 +10047,25 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -10085,7 +10085,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -10094,6 +10094,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     close_conversation_request:

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -6103,7 +6103,7 @@ paths:
                     - type: user
                       id: 6657a9f76abd01639cc9e9f3
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -6208,7 +6208,7 @@ paths:
                     - type: user
                       id: 6657aa036abd01639cc9e9ff
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -10071,6 +10071,31 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     close_conversation_request:
       title: Close Conversation Request
       type: object

--- a/descriptions/2.8/api.intercom.io.yaml
+++ b/descriptions/2.8/api.intercom.io.yaml
@@ -6103,7 +6103,7 @@ paths:
                     - type: user
                       id: 6657a9f76abd01639cc9e9f3
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -6208,7 +6208,7 @@ paths:
                     - type: user
                       id: 6657aa036abd01639cc9e9ff
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -10071,25 +10071,25 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -11265,7 +11265,7 @@ components:
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user", "lead", or "visitor"
+                description: The role of the contact. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
@@ -11274,6 +11274,9 @@ components:
             required:
             - type
             - id
+          example:
+          - type: user
+            id: '6762f1a61bb69f9f2193bbd8'
       required:
       - customers
     close_conversation_request:

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -6115,7 +6115,7 @@ paths:
                     - type: user
                       id: 6657ab566abd0164c24b0d7d
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Not found
           content:
@@ -6220,7 +6220,7 @@ paths:
                     - type: user
                       id: 6657ab636abd0164c24b0d89
               schema:
-                "$ref": "#/components/schemas/conversation"
+                "$ref": "#/components/schemas/conversation_customers_response"
         '404':
           description: Contact not found
           content:
@@ -11251,6 +11251,31 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
+    conversation_customers_response:
+      title: Conversation Customers Response
+      type: object
+      description: The contacts participating in the conversation, returned after
+        attaching or detaching a contact
+      properties:
+        customers:
+          type: array
+          description: The contacts participating in the conversation after the change
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The role of the contact. Can be "user", "lead", or "visitor"
+                example: 'user'
+              id:
+                type: string
+                description: The unique identifier for the contact
+                example: '6762f1a61bb69f9f2193bbd8'
+            required:
+            - type
+            - id
+      required:
+      - customers
     close_conversation_request:
       title: Close Conversation Request
       type: object

--- a/descriptions/2.9/api.intercom.io.yaml
+++ b/descriptions/2.9/api.intercom.io.yaml
@@ -6115,7 +6115,7 @@ paths:
                     - type: user
                       id: 6657ab566abd0164c24b0d7d
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Not found
           content:
@@ -6220,7 +6220,7 @@ paths:
                     - type: user
                       id: 6657ab636abd0164c24b0d89
               schema:
-                "$ref": "#/components/schemas/conversation_customers_response"
+                "$ref": "#/components/schemas/conversation_participants_response"
         '404':
           description: Contact not found
           content:
@@ -11251,25 +11251,25 @@ components:
                 "$ref": "#/components/schemas/customer_request"
             required:
             - email
-    conversation_customers_response:
-      title: Conversation Customers Response
+    conversation_participants_response:
+      title: Conversation Participants Response
       type: object
-      description: The contacts participating in the conversation, returned after
-        attaching or detaching a contact
+      description: The participants of the conversation, returned after attaching
+        or detaching a contact
       properties:
         customers:
           type: array
-          description: The contacts participating in the conversation after the change
+          description: The conversation participants after the change
           items:
             type: object
             properties:
               type:
                 type: string
-                description: The role of the contact. Can be "user" or "lead"
+                description: The role of the participant. Can be "user" or "lead"
                 example: 'user'
               id:
                 type: string
-                description: The unique identifier for the contact
+                description: The unique identifier for the participant
                 example: '6762f1a61bb69f9f2193bbd8'
             required:
             - type


### PR DESCRIPTION
### Why?

Both the attach-contact and detach-contact endpoints declare that they return a conversation, but each returns only the conversation's remaining contacts. The inline examples already showed the real shape, so the examples were right and the declared response was wrong. Anything that maps a response against the declared shape finds nothing to match, so a successful call can look as though it did nothing.

### How?

Adds one shared response definition describing the real body and points both endpoints' success response at it, across Preview and v2.7–v2.16.

<details>
<summary>Notes for reviewers</summary>

Both endpoints are in scope because they return the same body and had the identical mismatch, so they now share one definition rather than repeating it.

This changes the generated SDK return type for both operations. The previous type was never correct, so no working integration depended on it, but the change is visible to SDK consumers and may warrant release-note coverage.

The contact role is described in prose rather than as a fixed set of values, so adding a role in future does not become a breaking SDK change.

</details>

<sub>Generated with Claude Code</sub>